### PR TITLE
Update README.md to include additional whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ However, make sure to whitelist the following paths, or users will not be able t
 - /join
 - /j/*
 - /setup*
+- /static/*
 
 ## Installation
 


### PR DESCRIPTION
With the addition of the /static directory, with current recommended whitelist settings, accept.png results in a 401 error when using external authorization providers. Added this to the recommended whitelist in docs