### PR TITLE
Optimize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,10 +3,18 @@ app/__pycache__/
 .env
 .DS_Store
 .gitignore
-README.md
-.buildHelper.txt
-screenshots/*
-docs/*
 .git
-.idea
 .github
+.idea
+.buildHelper.txt
+
+# All hidden files
+.*
+
+Dockerfile
+README.md
+babel.cfg
+unraid.xml
+
+screenshots/
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3.11.2-alpine
-RUN apk add --no-cache tzdata
-RUN mkdir /data
+
 WORKDIR /data
-COPY requirements.txt requirements.txt
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
 COPY . /data
-CMD [ "gunicorn", "--workers",  "3" , "--bind", "0.0.0.0:5690", "-m", "007", "run:app" ]
+
+RUN apk add --no-cache tzdata && \
+    pip3 install --no-cache --upgrade pip && \
+    pip3 install --no-cache -r requirements.txt
+
 EXPOSE 5690
+CMD [ "gunicorn", "--workers",  "3" , "--bind", "0.0.0.0:5690", "-m", "007", "run:app" ]


### PR DESCRIPTION
- Run in a single layer to reduce space
- Don't cache pip installs
- Update `.dockerignore` entries