### PR TITLE
docs: update regex for public bypasses

### DIFF
--- a/docs/using-wizarr/single-sign-on-sso.md
+++ b/docs/using-wizarr/single-sign-on-sso.md
@@ -11,8 +11,8 @@ To Disable Wizarr's inbuilt authentication in order to put it behind a Proxy Pro
 In order to make the invitation process available for non signed in users, make sure you whitelist the following paths:
 
 ```
-- /join
-- /j/*
-- /setup*
-- /static/*
+- '^/join/'
+- '^/j/'
+- '^/setup/*'
+- '^/static/'
 ```


### PR DESCRIPTION
The current regex for bypasses in the SSO documentation are a little broken. One rule matches any path that starts with `/j`, which seems unnecessary. Another rule matched `setu` instead of `setup`. The regex was also not escaped with single quotes as recommended by Authelia's documentation (current regex looks like an Authelia rule).

The modified regex will match any paths starting with:
`/join/`
`/j/`
`/setup`
`/static/`
The previous regex matched any paths starting with:
`/join`
`/j`
`/setu`
`/static`

I added `/` to three of the bypasses (`join`, `j`, and `static`) as I don't think they are ever accessible without something after the `/`. If that is not accurate then it can be changed.