### PR TITLE
Show error message for invalid invitations

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -17,6 +17,12 @@
   <meta name="HandheldFriendly" content="true" />
 
   <meta name="robots" content="noindex">
+
+  <title>{% block title %}{% endblock %} - {{ _(server_name) }}</title>
+
+  <meta property="og:title" content="{% block og_title %}{% endblock %}" />
+  <meta property="og:description" content="{% block og_description %}{% endblock %}" />
+
   <script>
     // On page load or when changing themes, best to add inline in `head` to avoid FOUC
     if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {

--- a/app/templates/invalid-invite.html
+++ b/app/templates/invalid-invite.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block title %}Invalid Invite{% endblock %}
+
+{% block main %}
+
+<section class="bg-gray-50 dark:bg-gray-900">
+  <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
+    <a href="#" class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
+      {{ _(server_name) }}
+    </a>
+    <div
+      class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
+      <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
+        <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
+          {{ _("Invalid Invitation") }}
+        </h1>
+        <p class="mt-2 text-sm text-red-600 dark:text-red-500"><span class="font-medium">
+            {{ _(error) }}
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -9,7 +9,7 @@ Login
 <section class="bg-gray-50 dark:bg-gray-900">
   <div class="flex flex-col items-center justify-center px-6 py-8 mx-auto md:h-screen lg:py-0">
     <a href="#" class="flex items-center mb-6 text-2xl font-semibold text-gray-900 dark:text-white">
-      Wizarr
+      {{ _(server_name) }}
     </a>
     <div
       class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">

--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -1,15 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}
+{% block title %}Accept Invite{% endblock %}
 
-{% endblock %}
+{% block og_title %}{{ _(server_name) }}{% endblock %}
+
+{% block og_description %}{{ _("You've been invited to join the %(name)s server!", name=server_name) }}{% endblock %}
 
 {% block main %}
 <section class="bg-white dark:bg-gray-900">
     <div class="flex flex-col items-center justify-center px-6 mx-auto md:h-screen lg:py-0">
         <h1
             class="mb-4 text-2xl font-extrabold tracking-tight leading-none text-gray-900 md:text-3xl lg:text-4xl dark:text-white">
-            🧙🏼‍♂️ {{ _("You've been invited to join the %(name)s server!", name=name) }}</h1>
+            🧙🏼‍♂️ {{ _("You've been invited to join the %(name)s server!", name=server_name) }}</h1>
 
         <div class="flex flex-col mb-8 lg:mb-16 space-y-4 sm:flex-row sm:justify-center sm:space-y-0 sm:space-x-4">
 

--- a/app/templates/welcome-jellyfin.html
+++ b/app/templates/welcome-jellyfin.html
@@ -1,15 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}
+{% block title %}Accept Invite{% endblock %}
 
-{% endblock %}
+{% block og_title %}{{ _(server_name) }}{% endblock %}
+
+{% block og_description %}{{ _("You've been invited to join the %(name)s server!", name=server_name) }}{% endblock %}
 
 {% block main %}
 <section class="bg-white dark:bg-gray-900">
     <div class="flex flex-col items-center justify-center px-6 mx-auto md:h-screen lg:py-0">
         <h1
             class="mb-4 text-2xl font-extrabold tracking-tight leading-none text-gray-900 md:text-3xl lg:text-4xl dark:text-white">
-            🧙🏼‍♂️ {{ _("You've been invited to join the %(name)s server!", name=name) }}</h1>
+            🧙🏼‍♂️ {{ _("You've been invited to join the %(name)s server!", name=server_name) }}</h1>
 
         <div
             class="w-full bg-white rounded-lg shadow dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">

--- a/app/web.py
+++ b/app/web.py
@@ -1,14 +1,11 @@
 import logging
-from re import I
 import os
 import os.path
-import datetime
-from flask import request, redirect, render_template, abort, make_response, send_from_directory
-from app import app, Invitations, Settings, VERSION, get_locale
+from flask import request, redirect, render_template, make_response, send_from_directory
+from app import app, Invitations, Settings, get_locale
 from app.plex import *
 from app.ombi import *
 from app.helpers import *
-from flask_babel import _
 import threading
 
 
@@ -31,14 +28,7 @@ def plex(code):
         return render_template("welcome-jellyfin.html", code=code)
     if not Invitations.select().where(Invitations.code == code).exists():
         return render_template('401.html'), 401
-    name = Settings.get_or_none(
-        Settings.key == "server_name")
-    if name:
-        name = name.value
-    else:
-        name = "Wizarr"
-    resp = make_response(render_template(
-        'user-plex-login.html', name=name, code=code))
+    resp = make_response(render_template('user-plex-login.html', code=code))
     resp.set_cookie('code', code)
     return resp
 
@@ -177,4 +167,4 @@ def inject_user():
     except:
         name = "Wizarr"
         print("Could not find name :( ")
-    return dict(header_name=name)
+    return dict(server_name=name)

--- a/app/web.py
+++ b/app/web.py
@@ -24,13 +24,13 @@ def favicon():
 
 @app.route("/j/<code>", methods=["GET"])
 def plex(code):
+    valid, message = is_invite_valid(code)
+
+    if not valid:
+        return render_template('invalid-invite.html', error=message)
     if Settings.get(key="server_type").value == "jellyfin":
         return render_template("welcome-jellyfin.html", code=code)
-    if not Invitations.select().where(Invitations.code == code).exists():
-        return render_template('401.html'), 401
-    resp = make_response(render_template('user-plex-login.html', code=code))
-    resp.set_cookie('code', code)
-    return resp
+    return render_template('user-plex-login.html', code=code)
 
 
 @app.route("/join", methods=["POST"])
@@ -84,7 +84,6 @@ def wizard(action):
 
     if video_lang not in videos:
         video_lang = "en"
-    
 
     # Get current step from cookies
     current = int(request.cookies.get('current'))


### PR DESCRIPTION
This adds a user friendly error page. Previously it would render a 500 for Plex servers (due to an incorrect template name), or no error for Jellyfin servers (due to the check being after the Jellyfin render).

This is based on #123, please look at the second commit for the diff.