### PR TITLE
Add multiple env variables to provide an easy way to set password policies for new users

### DIFF
--- a/app/jellyfin.py
+++ b/app/jellyfin.py
@@ -147,15 +147,17 @@ def join_jellyfin():
     confirm_password = request.form.get('confirm-password')
     code = request.form.get('code')
     email = request.form.get("email")
+    min_password_length = int(os.getenv("MIN_PASSWORD_LENGTH", "8"))
+    max_password_length = int(os.getenv("MAX_PASSWORD_LENGTH", "20"))
 
     if not (re.fullmatch(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b', email)):
         return render_template("welcome-jellyfin.html", username=username, email=email, code=code, error="Invalid email addres")
 
     if not username or not password or not code or not email:
-        return render_template("welcome-jellyfin.html", username=username, email=email, code=code, error="Please fill out all fields")
+        return render_template("welcome-jellyfin.html", username=username, email=email, code=code, error="Please fill out all fields",)
 
     # check password validity
-    if not (len(password) >= 8 and len(password) <= 20):
+    if not (len(password) >= min_password_length and len(password) <= max_password_length):
         return render_template("welcome-jellyfin.html", username=username, email=email, code=code, error="Password must be between 8 and 20 characters")
 
     if password != confirm_password:

--- a/app/jellyfin.py
+++ b/app/jellyfin.py
@@ -157,8 +157,8 @@ def join_jellyfin():
         return render_template("welcome-jellyfin.html", username=username, email=email, code=code, error="Please fill out all fields",)
 
     # check password validity
-    if not (len(password) >= min_password_length and len(password) <= max_password_length):
-        return render_template("welcome-jellyfin.html", username=username, email=email, code=code, error="Password must be between 8 and 20 characters")
+    if not (min_password_length <= len(password) <= max_password_length):
+        return render_template("welcome-jellyfin.html", username=username, email=email, code=code, error=f"Password must be between {min_password_length} and {max_password_length} characters")
 
     if password != confirm_password:
         return render_template("welcome-jellyfin.html", username=username, email=email, code=code, error="Passwords do not match")

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,6 +28,8 @@ services:
       - /path/to/appdata/config:/data/database
     environment:
       - APP_URL=https://wizarr.domain.com #URL at which you will access and share 
+      - MIN_PASSWORD_LENGTH=8 # Minimum password length required for new users (default: 8)
+      - MAX_PASSWORD_LENGTH=20 # Maximum password length for new users (default: 20)
       - DISABLE_BUILTIN_AUTH=false #Set to true ONLY if you are using another auth provider (Authelia, Authentik, etc)
       - TZ=Europe/London #Set your timezone here
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,6 +30,9 @@ services:
       - APP_URL=https://wizarr.domain.com #URL at which you will access and share 
       - MIN_PASSWORD_LENGTH=8 # Minimum password length required for new users (default: 8)
       - MAX_PASSWORD_LENGTH=20 # Maximum password length for new users (default: 20)
+      - MIN_PASSWORD_UPPERCASE=1 # Minimum password chars that are uppercase (default: 1)
+      - MIN_PASSWORD_NUMBERS=1 # Minimum password chars that are numbers (default: 1)
+      - MIN_PASSWORD_SPECIAL=0 # Minimum password chars that are special (default: 0)
       - DISABLE_BUILTIN_AUTH=false #Set to true ONLY if you are using another auth provider (Authelia, Authentik, etc)
       - TZ=Europe/London #Set your timezone here
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Flask-APScheduler
 requests
 flask-htmx
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
+password-strength


### PR DESCRIPTION
This PR adds the following environment variables:
```
- MIN_PASSWORD_LENGTH=8 # Minimum password length required for new users (default: 8)
- MAX_PASSWORD_LENGTH=20 # Maximum password length for new users (default: 20)
- MIN_PASSWORD_UPPERCASE=1 # Minimum password chars that are uppercase (default: 1)
- MIN_PASSWORD_NUMBERS=1 # Minimum password chars that are numbers (default: 1)
- MIN_PASSWORD_SPECIAL=0 # Minimum password chars that are special (default: 0)   
```
with this environment variables the admin can define the password policy via environment variables to provide an easy way to set minimum requirements for the passwords for new users.