### PR TITLE
Direct App download based on users device

### DIFF
--- a/app/templates/wizard/jellyfin/download.html
+++ b/app/templates/wizard/jellyfin/download.html
@@ -6,20 +6,133 @@
     </a>
     <p class="mb-3 font-bold text-gray-700 dark:text-gray-400">
         {{ _("Great news! You now have access to our server's media collection. Let's make sure you know how to use
-        it with Jellyfin.") }}
+        it with Jellyfin.") }}</p>
+
     <p class="mb-3 font-normal text-gray-700 dark:text-gray-400">
         {{ _("Planning on watching Movies on this device? Download Jellyfin for this device.") }}</p>
-    <a href="https://jellyfin.org/downloads" target="_blank"
-        class="inline-flex items-center py-2 px-3 text-sm font-medium text-center text-white bg-primary rounded-lg hover:bg-violet-800 focus:ring-4 focus:outline-none focus:ring-violet-300 dark:bg-violet-600 dark:hover:bg-violet-700 dark:focus:ring-violet-800">
-        {{ _("Download") }}
+
+    <div class="flex p-2 text-sm text-gray-800 border border-gray-300 rounded-lg bg-gray-50 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 mb-3" role="alert">
+        <svg aria-hidden="true" class="flex-shrink-0 inline w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path></svg>
+    <span class="sr-only">Info</span>
+    <div>
+        {{ _("If you don't wish to Download the App feel free to use Jellyfin in your devices web browser, just click \"Next\".") }}
+    </div>
+    </div>
+
+    <div class="flex justify-center p-1">
+        <a href="#" class="inline-flex items-center text-sm font-medium text-center text-primary" id="serverurlbtn">
+        {{ _("Show Server URL") }}
+        </a>
+    </div>
+
+    <div class="flex flex-col justify-center" style="margin-top: 25px; margin-bottom: 25px; display: none;" id="serverurl">
+        <h1 class="mb-1 text-center font-bold text-gray-700 dark:text-gray-400">{{ _("Server URL") }}</h1>
+
+        <div class="flex flex-row justify-center">
+            <p class="p-2 border border-gray-200 rounded-l-lg rounded-r-none dark:border-gray-700 text-gray-700 dark:text-gray-400 px-5" id="serverurltxt">{% if server_url %}{{ server_url }}{% else %}Could not get Server URL{% endif %}</p>
+            <p class="p-2 border border-gray-200 rounded-r-lg rounded-l-none dark:border-gray-700 dark:bg-gray-700 bg-primary text-gray-700 dark:text-gray-400 text-white px-5 cursor-pointer" id="copybtn">{{ _("Copy") }}</p>
+        </div>
+    </div>
+
+    <div class="flex flex-row relative">
+    
+        {# Direct Link for IOS #}
+        <a href="https://apps.apple.com/us/app/swiftfin/id1604098728?itsct=apps_box_link&itscg=30200" target="_blank" style="display: none;" id="ios">
+    <svg xmlns="http://www.w3.org/2000/svg" width="119.7" height="40"><path d="M110.1 0H7.5a13.2 13.2 0 0 0-2 .2 6.7 6.7 0 0 0-1.9.6A6.4 6.4 0 0 0 2 2 6.3 6.3 0 0 0 .8 3.6a6.6 6.6 0 0 0-.6 2 13 13 0 0 0-.2 2v24.9a13 13 0 0 0 .2 2 6.6 6.6 0 0 0 .6 1.9A6.2 6.2 0 0 0 2 38a6.3 6.3 0 0 0 1.6 1.2 6.7 6.7 0 0 0 2 .6 13.5 13.5 0 0 0 2 .2h104.6a13.3 13.3 0 0 0 2-.2 6.8 6.8 0 0 0 1.8-.6 6.3 6.3 0 0 0 1.7-1.2 6.4 6.4 0 0 0 1.1-1.6 6.6 6.6 0 0 0 .7-2 13.5 13.5 0 0 0 .2-2V7.6a13.5 13.5 0 0 0-.2-2 6.6 6.6 0 0 0-.7-1.9A6.5 6.5 0 0 0 116 .8a6.8 6.8 0 0 0-1.9-.6 13 13 0 0 0-2-.2h-1.9Z"/><path fill="#fff" d="M8.4 39.1h-.9a12.7 12.7 0 0 1-1.8-.1 5.9 5.9 0 0 1-1.7-.6 5.4 5.4 0 0 1-1.4-1 5.3 5.3 0 0 1-1-1.4 5.7 5.7 0 0 1-.5-1.7 12.4 12.4 0 0 1-.2-1.8v-25A12.4 12.4 0 0 1 1 5.7 5.8 5.8 0 0 1 1.6 4a5.4 5.4 0 0 1 1-1.4 5.6 5.6 0 0 1 1.4-1 5.8 5.8 0 0 1 1.7-.5A12.6 12.6 0 0 1 7.5.9h104.7a12.4 12.4 0 0 1 1.8.2 6 6 0 0 1 1.7.5A5.6 5.6 0 0 1 118 4a5.8 5.8 0 0 1 .5 1.7 13 13 0 0 1 .2 1.9v24.9a12.7 12.7 0 0 1-.2 1.8 5.7 5.7 0 0 1-.5 1.7 5.5 5.5 0 0 1-1 1.4 5.4 5.4 0 0 1-1.4 1 5.9 5.9 0 0 1-1.7.6 12.5 12.5 0 0 1-1.9.1h-1.9Z"/><g data-name="&lt;Group&gt;"><g data-name="&lt;Group&gt;"><path d="M25 19.9a5.1 5.1 0 0 1 2.4-4.3 5.3 5.3 0 0 0-4.1-2.3c-1.7-.2-3.4 1-4.3 1-1 0-2.3-1-3.8-1a5.5 5.5 0 0 0-4.6 3c-2 3.4-.5 8.5 1.4 11.3 1 1.4 2 3 3.5 2.9 1.5 0 2-1 3.8-1 1.7 0 2.2 1 3.7 1s2.5-1.4 3.5-2.8a11.4 11.4 0 0 0 1.5-3.2 5 5 0 0 1-3-4.6ZM22.2 11.5a5 5 0 0 0 1.1-3.7A5.2 5.2 0 0 0 20 9.6a4.8 4.8 0 0 0-1.2 3.5 4.3 4.3 0 0 0 3.4-1.6Z" data-name="&lt;Path&gt;"/></g><path d="M42.3 27.1h-4.7l-1.2 3.4h-2L39 18.1h2l4.6 12.4h-2Zm-4.2-1.5h3.7L40 20ZM55.2 26c0 2.8-1.5 4.6-3.8 4.6a3 3 0 0 1-2.9-1.6v4.5h-1.9v-12h1.8v1.4a3.2 3.2 0 0 1 3-1.6c2.2 0 3.8 1.9 3.8 4.7Zm-2 0c0-1.9-.9-3-2.3-3-1.5 0-2.4 1.2-2.4 3s1 3 2.4 3 2.3-1.2 2.3-3ZM65.1 26c0 2.8-1.5 4.6-3.8 4.6a3 3 0 0 1-2.8-1.6v4.5h-1.9v-12h1.8v1.4a3.2 3.2 0 0 1 3-1.6c2.2 0 3.7 1.9 3.7 4.7Zm-1.9 0c0-1.9-1-3-2.4-3s-2.4 1.2-2.4 3 1 3 2.4 3c1.5 0 2.4-1.2 2.4-3ZM71.7 27c.1 1.3 1.3 2 3 2 1.5 0 2.7-.7 2.7-1.8 0-1-.7-1.6-2.3-2l-1.6-.4c-2.3-.5-3.4-1.6-3.4-3.3 0-2.2 1.9-3.6 4.6-3.6 2.6 0 4.4 1.4 4.4 3.6h-1.8c-.2-1.3-1.2-2-2.7-2s-2.5.8-2.5 1.9c0 .8.7 1.4 2.3 1.7l1.3.4c2.6.6 3.6 1.6 3.6 3.4 0 2.3-1.8 3.8-4.8 3.8-2.7 0-4.6-1.4-4.7-3.7ZM83.3 19.3v2.1h1.8V23h-1.8v5c0 .8.4 1.1 1.1 1.1a5.8 5.8 0 0 0 .7 0v1.5a5.1 5.1 0 0 1-1 0c-2 0-2.6-.6-2.6-2.4v-5.2h-1.3v-1.5h1.3v-2.1ZM86 26c0-2.9 1.7-4.7 4.4-4.7 2.6 0 4.3 1.8 4.3 4.7 0 2.8-1.7 4.6-4.3 4.6-2.7 0-4.3-1.8-4.3-4.6Zm6.8 0c0-2-1-3.1-2.4-3.1S88 24 88 25.9c0 2 .9 3.2 2.4 3.2s2.4-1.2 2.4-3.1ZM96.2 21.4H98V23a2.2 2.2 0 0 1 2.2-1.7 2.9 2.9 0 0 1 .6.1v1.8a2.6 2.6 0 0 0-.8-.2 1.9 1.9 0 0 0-2 2.1v5.4h-1.8ZM109.4 27.8c-.3 1.7-1.9 2.8-4 2.8-2.5 0-4.2-1.8-4.2-4.6s1.7-4.7 4.2-4.7 4 1.8 4 4.5v.6h-6.3v.1a2.4 2.4 0 0 0 2.4 2.6 2 2 0 0 0 2.1-1.3Zm-6.3-2.7h4.5a2.2 2.2 0 0 0-2.2-2.3 2.3 2.3 0 0 0-2.3 2.3Z"/></g><g data-name="&lt;Group&gt;"><path d="M37.8 8.7a2.6 2.6 0 0 1 2.8 3c0 1.9-1 3-2.8 3h-2.1v-6ZM36.6 14h1.1a1.9 1.9 0 0 0 2-2.2 1.9 1.9 0 0 0-2-2.1h-1.1ZM41.7 12.4a2.1 2.1 0 1 1 4.2 0 2.1 2.1 0 1 1-4.2 0Zm3.3 0c0-1-.4-1.5-1.2-1.5-.8 0-1.2.6-1.2 1.5 0 1 .4 1.6 1.2 1.6.8 0 1.2-.6 1.2-1.6ZM51.6 14.7h-1l-.9-3.3-1 3.3h-.9l-1.2-4.5h.9l.8 3.4 1-3.4h.8l1 3.4.8-3.4h1ZM53.9 10.2h.8v.7a1.3 1.3 0 0 1 1.4-.8 1.5 1.5 0 0 1 1.6 1.7v2.9h-1V12c0-.7-.2-1-.9-1a1 1 0 0 0-1 1v2.7h-1ZM59 8.4h1v6.3h-1ZM61.2 12.4a2.1 2.1 0 1 1 4.3 0 2.1 2.1 0 1 1-4.3 0Zm3.4 0c0-1-.5-1.5-1.3-1.5-.7 0-1.2.6-1.2 1.5 0 1 .5 1.6 1.2 1.6.8 0 1.3-.6 1.3-1.6ZM66.4 13.4c0-.8.6-1.3 1.7-1.3h1.2v-.5c0-.5-.3-.7-1-.7-.4 0-.8.2-.9.5h-.8c0-.8.8-1.3 1.8-1.3 1.1 0 1.8.6 1.8 1.5v3.1h-.9v-.6a1.5 1.5 0 0 1-1.4.7 1.4 1.4 0 0 1-1.5-1.4Zm2.9-.4v-.3h-1.1c-.6 0-1 .3-1 .7 0 .4.4.6 1 .6a1 1 0 0 0 1.1-1ZM71.3 12.4c0-1.4.8-2.3 2-2.3a1.5 1.5 0 0 1 1.3.8V8.4h1v6.3h-.9V14a1.6 1.6 0 0 1-1.5.8c-1.1 0-1.9-1-1.9-2.4Zm1 0c0 1 .4 1.6 1.2 1.6.7 0 1.2-.6 1.2-1.6 0-.9-.5-1.5-1.2-1.5-.8 0-1.2.6-1.2 1.5ZM79.2 12.4a2.1 2.1 0 1 1 4.3 0 2.1 2.1 0 1 1-4.3 0Zm3.4 0c0-1-.5-1.5-1.2-1.5-.8 0-1.3.6-1.3 1.5 0 1 .5 1.6 1.3 1.6.7 0 1.2-.6 1.2-1.6ZM84.7 10.2h.8v.7a1.3 1.3 0 0 1 1.4-.8 1.5 1.5 0 0 1 1.6 1.7v2.9h-.9V12c0-.7-.3-1-1-1a1 1 0 0 0-1 1v2.7h-1ZM93.5 9v1.2h1v.8h-1v2.3c0 .5.2.7.7.7a3 3 0 0 0 .3 0v.7a3 3 0 0 1-.5 0c-1 0-1.4-.3-1.4-1.2V11H92v-.8h.7V9.1ZM95.7 8.4h.9V11a1.4 1.4 0 0 1 1.4-.8 1.5 1.5 0 0 1 1.6 1.7v2.9h-1V12c0-.7-.2-1-.9-1a1 1 0 0 0-1.1 1v2.7h-.9ZM104.8 13.5a1.8 1.8 0 0 1-2 1.3 2 2 0 0 1-2-2.3 2 2 0 0 1 2-2.4c1.3 0 2 .9 2 2.3v.3h-3.2a1.2 1.2 0 0 0 1.2 1.3 1 1 0 0 0 1.1-.5Zm-3.2-1.5h2.3a1 1 0 0 0-1.1-1.1 1.2 1.2 0 0 0-1.2 1.1Z"/></g></svg>
+        </a>
+
+        {# Direct Link for MacOS #}
+        <a href="/setup/open-Jellyfin" target="_blank" style="display: none;" id="mac"
+            class="inline-flex items-center py-2 px-3 text-sm font-medium text-center text-white bg-primary rounded-lg hover:bg-primary_hover focus:ring-4 focus:outline-none focus:ring-amber-300 dark:bg-primary dark:hover:bg-primary_hover dark:focus:ring-primary_hover">
+            {{ _("Open Jellyfin") }}
+            <svg class="ml-2 w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <path
+                    d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z">
+                </path>
+                <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path>
+            </svg>
+        </a>
+
+        {# Direct Link for Android #}
+        <a href='https://play.google.com/store/apps/details?id=dev.jdtech.jellyfin&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1' target="_blank" style="display: none;" id="android">
+            <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="180" height="53.3" version="1.1"><path fill="#100f0d" stroke-width=".1" d="M173.3 53.3H6.7c-3.7 0-6.7-3-6.7-6.6v-40C0 3 3 0 6.7 0h166.6c3.7 0 6.7 3 6.7 6.7v40c0 3.6-3 6.6-6.7 6.6"/><path fill="#a2a2a1" stroke-width=".1" d="M173.3 0H6.7C3 0 0 3 0 6.7v40c0 3.6 3 6.6 6.7 6.6h166.6c3.7 0 6.7-3 6.7-6.6v-40c0-3.7-3-6.7-6.7-6.7zm0 1c3.1 0 5.6 2.6 5.6 5.7v40c0 3-2.5 5.6-5.6 5.6H6.7c-3.1 0-5.6-2.5-5.6-5.6v-40C1 3.6 3.6 1 6.7 1h166.6"/><path fill="#fff" stroke-width=".1" d="M142.6 40h2.5V23.3h-2.5zM165 29.3l-2.9 7.3-3-7.3h-2.7l4.5 10.1-2.6 5.7h2.6l6.9-15.8zm-14.1 8.8c-.8 0-2-.4-2-1.4 0-1.3 1.4-1.8 2.7-1.8 1 0 1.6.2 2.2.6a3 3 0 0 1-3 2.6zm.3-9.1c-1.8 0-3.7.8-4.5 2.5l2.2 1c.5-1 1.4-1.3 2.3-1.3 1.3 0 2.6.8 2.6 2.2v.1c-.4-.2-1.4-.6-2.6-.6-2.3 0-4.8 1.3-4.8 3.7 0 2.3 2 3.7 4.2 3.7 1.7 0 2.6-.7 3.2-1.6V40h2.4v-6.4c0-3-2.2-4.6-5-4.6zm-15.4 2.4h-3.5v-5.7h3.5c1.9 0 3 1.5 3 2.8 0 1.3-1.1 2.9-3 2.9zm0-8h-6V40h2.5v-6.3h3.4c2.8 0 5.5-2 5.5-5.2s-2.7-5.2-5.5-5.2zM103.1 38c-1.7 0-3.1-1.4-3.1-3.4s1.4-3.5 3.1-3.5c1.7 0 3 1.5 3 3.5s-1.3 3.4-3 3.4zm2.9-7.8h-.1a4 4 0 0 0-3-1.3 5.6 5.6 0 0 0-5.4 5.7c0 3.2 2.6 5.6 5.4 5.6 1.4 0 2.4-.6 3-1.2v.8c0 2.1-1 3.3-3 3.3a3.1 3.1 0 0 1-2.8-2L98 42a5.4 5.4 0 0 0 5 3.3c3 0 5.5-1.7 5.5-5.9V29.3H106zm4 9.7h2.6V23.3h-2.5zm6.2-5.5c0-2.2 1.7-3.3 3-3.3 1 0 1.8.5 2.1 1.2zm7.8-1.9c-.5-1.3-2-3.6-4.9-3.6-3 0-5.3 2.3-5.3 5.7 0 3.2 2.4 5.6 5.6 5.6 2.6 0 4.1-1.5 4.7-2.5l-2-1.3c-.6 1-1.4 1.6-2.7 1.6-1.3 0-2.2-.6-2.8-1.7l7.6-3.1zm-60.4-1.9v2.4h5.7a5 5 0 0 1-1.3 3c-.8 1-2.1 1.8-4.4 1.8-3.6 0-6.4-2.8-6.4-6.4s2.8-6.4 6.4-6.4c1.9 0 3.3.8 4.3 1.8l1.7-1.7a8.4 8.4 0 0 0-6-2.5 9 9 0 0 0-9 8.8 9 9 0 0 0 9 8.8 8 8 0 0 0 6.1-2.4 8 8 0 0 0 2-5.7v-1.5zm14.7 7.4c-1.7 0-3.2-1.4-3.2-3.4s1.5-3.5 3.2-3.5c1.7 0 3.2 1.4 3.2 3.5 0 2-1.5 3.4-3.2 3.4zm0-9.1a5.6 5.6 0 0 0-5.7 5.7c0 3.2 2.6 5.6 5.7 5.6 3.2 0 5.7-2.4 5.7-5.6 0-3.3-2.5-5.7-5.7-5.7zm12.4 9.1c-1.7 0-3.2-1.4-3.2-3.4s1.5-3.5 3.2-3.5c1.8 0 3.2 1.4 3.2 3.5 0 2-1.4 3.4-3.2 3.4zm0-9.1a5.6 5.6 0 0 0-5.6 5.7c0 3.2 2.5 5.6 5.6 5.6 3.2 0 5.7-2.4 5.7-5.6 0-3.3-2.5-5.7-5.7-5.7"/><path fill="#eb3131" stroke-width=".1" d="m27.6 25.9-14.2 15a3.8 3.8 0 0 0 5.7 2.4l16-9.3-7.5-8.1"/><path fill="#f6b60b" stroke-width=".1" d="m42 23.3-7-4-7.7 7 7.8 7.7 6.9-4a3.8 3.8 0 0 0 0-6.7"/><path fill="#5778c5" stroke-width=".1" d="m13.4 12.4-.1 1V40l.1 1 14.7-14.7-14.7-14"/><path fill="#3bad49" stroke-width=".1" d="m27.7 26.7 7.4-7.4-16-9.2a3.8 3.8 0 0 0-5.7 2.3l14.3 14.3"/><path fill="#fff" stroke="#fff" stroke-miterlimit="10" stroke-width=".3" d="M63.2 13h-3.9v1h3c-.2.8-.5 1.4-1 1.9a3 3 0 0 1-2 .6 3 3 0 0 1-2.2-.9c-.6-.6-1-1.4-1-2.3 0-.9.4-1.7 1-2.3a3 3 0 0 1 2.2-.9c.5 0 .9 0 1.3.3.4.1.7.4 1 .7l.7-.8c-.4-.4-.8-.6-1.3-.9-.6-.2-1.1-.3-1.7-.3a4 4 0 0 0-3 1.2 4 4 0 0 0-1.2 3 4 4 0 0 0 1.2 3 4 4 0 0 0 3 1.2c1.2 0 2.2-.4 3-1.2.6-.6 1-1.5 1-2.7l-.1-.6zm1.5-3.7v8h4.7v-1h-3.7v-2.5H69v-1h-3.3v-2.5h3.7v-1zm11.3 1v-1h-5.6v1h2.3v7h1v-7zm5-1h-1v8h1zm6.8 1v-1h-5.6v1h2.3v7h1v-7zm10.4 0a4 4 0 0 0-3-1.2 4 4 0 0 0-3 1.2c-.7.8-1.1 1.8-1.1 3s.4 2.2 1.2 3a4 4 0 0 0 3 1.2 4 4 0 0 0 2.9-1.2 4 4 0 0 0 1.1-3 4 4 0 0 0-1.1-3zM93 11a3 3 0 0 1 2.2-.9 3 3 0 0 1 2.2 1c.6.5.9 1.3.9 2.2 0 1-.3 1.7-.9 2.3a3 3 0 0 1-2.2 1 3 3 0 0 1-2.2-1c-.6-.6-.8-1.3-.8-2.3 0-1 .2-1.7.8-2.3zm8.8 1.3v-1.5l4 6.5h1.2v-8h-1V15.6l-4-6.3h-1.2v8h1z"/></svg>
+        </a>
+
+        {# Windows Download Link #}
+        <a href="/setup/open-Jellyfin" target="_blank" style="display: none;" id="windows"
+            class="inline-flex items-center py-2 px-3 text-sm font-medium text-center text-white bg-primary rounded-lg hover:bg-primary_hover focus:ring-4 focus:outline-none focus:ring-amber-300 dark:bg-primary dark:hover:bg-primary_hover dark:focus:ring-primary_hover">
+            {{ _("Open Jellyfin") }}
+            <svg class="ml-2 w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <path
+                    d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z">
+                </path>
+                <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path>
+            </svg>
+        </a>
+
+        {# Linux Download Link #}
+        <a href="https://flathub.org/apps/com.github.iwalton3.jellyfin-media-player" target="_blank" style="display: none;" id="linux">
+            <svg xmlns="http://www.w3.org/2000/svg" width="180" height="60"  version="1.1" viewBox="0 0 600 200" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path fill="#000" stroke-width="3" d="M915.5 825v69L849 936.7v-69z" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" id="reuse-0"/><path fill="#fff" stroke-width="3" d="M783 825v69l66.5 42.8v-69z" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" id="reuse-1"/></defs><g fill-opacity="1" transform="translate(0 -922.5)"><rect width="596.2" height="196.2" x="1.9" y="924.4" fill="#fff" stroke="#000" stroke-dasharray="none" stroke-dashoffset="0" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-opacity="1" stroke-width="3.8" opacity="1" paint-order="normal" rx="32" ry="32" style="marker:none" vector-effect="none"/><g fill="#1d2020" fill-rule="nonzero" stroke="none" stroke-linecap="butt" stroke-linejoin="miter" stroke-opacity="1" stroke-width="1" marker-end="none" marker-mid="none" marker-start="none" aria-label="FLATHUB" color="#000" direction="ltr" display="inline" font-family="Overpass" font-size="64.3" font-stretch="normal" font-style="normal" font-variant="normal" font-weight="700" letter-spacing="0" style="line-height:125%;-inkscape-font-specification:&quot;Overpass, Bold&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-transform:none;marker:none" text-anchor="start" text-decoration="none" visibility="visible" word-spacing="0" writing-mode="lr-tb"><path d="M253 1069.3h7.7v-19.6h13.6v-7.3h-13.6v-10.9H282v-7.2h-29z"/><path d="M289.4 1069.3H319v-7.4H297v-37.6h-7.7z"/><path d="M356 1069.3h8.1l-16.7-45h-7.7l-16.7 45h8.1l3.6-9.9h17.8zm-6-16.8h-12.9l5-13.5 1.5-4.6c.3 1.4 1 3.3 1.5 4.6z"/><path d="M383.5 1031.7h12.8v-7.4H363v7.4h12.7v37.6h7.8z"/><path d="M431.6 1069.3h7.7v-45h-7.7v18.2H412v-18.2h-7.7v45h7.7v-19.6h19.6z"/><path d="M467.4 1070c9.6 0 17.6-4.6 17.6-17.9v-27.8h-7.7v27.8c0 8.2-4 10.5-9.9 10.5-5.8 0-9.8-2.3-9.8-10.5v-27.8h-7.7v27.8c0 13.5 8.3 18 17.5 18z"/><path d="M495.5 1024.3v45H515c11.1 0 15-7.1 15-13.3 0-4-2-8.5-7.4-10.4 4-2 5.8-5.5 5.8-9.3 0-6.1-3.5-12-14.4-12zm17.4 18.1h-9.7v-11h11c5.2 0 6.3 2.8 6.3 5.5 0 3.3-2.5 5.5-7.6 5.5zm2.4 19.7h-12v-12.6h10.2c7 0 8.6 3.3 8.6 6.7 0 2.7-1.5 6-6.8 6z"/></g><g fill-rule="nonzero" stroke="#000" stroke-dasharray="none" stroke-dashoffset="0" stroke-linecap="square" stroke-miterlimit="4" stroke-opacity="1" marker-end="none" marker-mid="none" marker-start="none" clip-rule="nonzero" color="#000" color-interpolation="sRGB" color-interpolation-filters="linearRGB" color-rendering="auto" image-rendering="auto" paint-order="normal" shape-rendering="auto" text-rendering="auto" visibility="visible"><path fill="#000" stroke-linejoin="miter" stroke-width="12" d="m856 830.2-66.7 43.5v35l33.3 21.6 33.4-21.7v0h0l33.4 21.7 33.4-21.7v-35z" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" transform="translate(-733.6 141.6)"/><g stroke-linejoin="round" stroke-width=".8" transform="translate(-733.6 141.6) matrix(.50222 0 0 .50637 429.6 432.9)"><rect width="79.1" height="79.1" x="1289.9" y="279.4" fill="#000" stroke-width="3.2" display="inline" enable-background="accumulate" opacity="1" overflow="visible" rx="0" ry="0" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" transform="scale(1.18821 .76691) rotate(45)"/><rect width="79.1" height="79.1" x="1226.3" y="215.8" fill="#fff" stroke-width="3.2" display="inline" enable-background="accumulate" opacity="1" overflow="visible" rx="0" ry="0" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" transform="scale(1.18821 .76691) rotate(45)"/><use stroke-width="3" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" xlink:href="#reuse-0"/><use stroke-width="3" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" xlink:href="#reuse-1"/></g><g stroke-linejoin="round" stroke-width=".8" transform="translate(-733.6 141.6) matrix(.50222 0 0 .50637 463 454.6)"><rect width="79.1" height="79.1" x="1289.9" y="279.4" fill="#000" stroke-width="3.2" display="inline" enable-background="accumulate" opacity="1" overflow="visible" rx="0" ry="0" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" transform="scale(1.18821 .76691) rotate(45)"/><rect width="79.1" height="79.1" x="1226.3" y="215.8" fill="#fff" stroke-width="3.2" display="inline" enable-background="accumulate" opacity="1" overflow="visible" rx="0" ry="0" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" transform="scale(1.18821 .76691) rotate(45)"/><use stroke-width="3" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" xlink:href="#reuse-0"/><use stroke-width="3" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" xlink:href="#reuse-1"/></g><g stroke-linejoin="round" stroke-width=".8" transform="translate(-733.6 141.6) matrix(.50222 0 0 .50637 396.3 454.6)"><rect width="79.1" height="79.1" x="1289.9" y="279.4" fill="#000" stroke-width="3.2" display="inline" enable-background="accumulate" opacity="1" overflow="visible" rx="0" ry="0" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" transform="scale(1.18821 .76691) rotate(45)"/><rect width="79.1" height="79.1" x="1226.3" y="215.8" fill="#fff" stroke-width="3.2" display="inline" enable-background="accumulate" opacity="1" overflow="visible" rx="0" ry="0" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" transform="scale(1.18821 .76691) rotate(45)"/><use stroke-width="3" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" xlink:href="#reuse-0"/><use stroke-width="3" display="inline" enable-background="accumulate" opacity="1" overflow="visible" style="isolation:auto;mix-blend-mode:normal;solid-color:#000;solid-opacity:1;marker:none" xlink:href="#reuse-1"/></g></g><g fill="#000" stroke="none" stroke-width="1" aria-label="Download On" font-family="Overpass" font-size="36.2" font-stretch="normal" font-style="normal" font-variant="normal" font-weight="300" letter-spacing="6.6" style="line-height:1.25;-inkscape-font-specification:&quot;Overpass, Light&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start" text-anchor="start" word-spacing="0" writing-mode="lr-tb"><path d="M253.1 968.7v25.4h6.6c9.1 0 11.6-6.9 11.6-12.7 0-6.2-2.9-12.7-11.5-12.7zm6.8 23.1h-4.3V971h4.7c6 0 8.4 5.2 8.4 10.4 0 5-2 10.4-8.8 10.4zM290.4 994.5c4.7 0 8-3.6 8-9.7s-3.3-9.6-8-9.6-8 3.6-8 9.7 3.3 9.6 8 9.6zm0-2.3c-3.4 0-5.3-2.7-5.3-7.3 0-4.9 1.9-7.5 5.3-7.5s5.3 2.8 5.3 7.4c0 4.7-2 7.4-5.3 7.4zM313 994h2.3L319 983l.8-2.5.8 2.5 3.7 11.2h2.3l4.5-18.5h-2.5l-3 13.3-.4 2.2-.6-2.2-4-13.3H319l-4 13.3-.5 2-.4-2-3-13.3h-2.6zM353.7 994h2.6v-10.2c0-6-2.1-8.6-6.7-8.6-2 0-3.6.8-4.7 2.4v-2h-2.6V994h2.6v-11.4c0-4 2-5.3 4.5-5.3s4.3 1.5 4.3 5.4zM369.4 994h2.6v-26l-2.6 1.2zM392 994.5c4.7 0 7.9-3.6 7.9-9.7s-3.2-9.6-8-9.6c-4.7 0-7.9 3.6-7.9 9.7s3.2 9.6 8 9.6zm0-2.3c-3.5 0-5.3-2.7-5.3-7.3 0-4.9 1.8-7.5 5.3-7.5 3.4 0 5.2 2.8 5.2 7.4 0 4.7-1.9 7.4-5.2 7.4zM422.4 994h2.4v-12.4c0-5.3-3.5-6.4-6.2-6.4-2.5 0-5 1-6.4 2l.7 2.2c1.4-1 3.6-2 5.5-2 2 0 4 .8 4 4.5v1.5c-1.8-1-3.4-1.3-5-1.3-3.5 0-6.7 1.9-6.7 6.2 0 4.1 2.6 6.2 6.3 6.2 2 0 4-.9 5.4-2.2zm-5.1-1.7c-2.7 0-4.2-1.6-4.2-4 0-2.7 2.1-4 4.6-4 1.6 0 3.6.8 4.7 1.6v3.6c-1 1.3-2.9 2.8-5.1 2.8zM443.6 994.5c2.3 0 3.8-.9 5-2v1.6h2.5V968l-2.6 1.2v7.7a7.5 7.5 0 0 0-4.9-1.7c-4.7 0-7.6 3.5-7.6 9.6 0 6 2.9 9.7 7.6 9.7zm.3-2.3c-3.2 0-5.3-3.3-5.3-7.4 0-4.7 2-7.4 5.3-7.4 2.4 0 3.9 1.5 4.6 2.7v9.2a5.3 5.3 0 0 1-4.6 3zM489 994.5c7.8 0 10.5-6.8 10.5-13 0-6.3-2.7-13.2-10.5-13.2s-10.5 6.9-10.5 13.1c0 6.3 2.7 13.1 10.5 13.1zm0-2.3c-5.8 0-7.8-5.3-7.8-10.8 0-5 2-10.8 7.8-10.8s7.9 5.3 7.9 10.8c0 5-2 10.8-7.9 10.8zM523.4 994h2.5v-10.2c0-6-2.1-8.6-6.6-8.6-2 0-3.6.8-4.8 2.4v-2H512V994h2.5v-11.4c0-4 2-5.3 4.6-5.3 2.4 0 4.3 1.5 4.3 5.4z" style="-inkscape-font-specification:&quot;Overpass, Light&quot;;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start"/></g></g></svg>
+        </a>
+
+        {# Default Download Link #}
+        <a href="https://jellyfin.org/downloads" target="_blank" id="default"
+        class="inline-flex items-center text-sm font-medium text-center text-primary absolute bottom-0 right-0">
+        {{ _("Other Download") }}
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
             class="ml-2 -mr-1 w-4 h-4">
             <path stroke-linecap="round" stroke-linejoin="round"
                 d="M9 8.25H7.5a2.25 2.25 0 00-2.25 2.25v9a2.25 2.25 0 002.25 2.25h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25H15M9 12l3 3m0 0l3-3m-3 3V2.25" />
         </svg>
-    </a>
+        </a>
 
+    </div>
 
+<script>
+var platform = navigator.platform;
 
+var serverurl = document.getElementById("serverurl");
+var serverurlbtn = document.getElementById("serverurlbtn");
+var serverurlbtncontainer = serverurlbtn.parentElement;
+
+var copybtn = document.getElementById("copybtn");
+
+if (platform.startsWith('Mac')) {
+    document.getElementById("mac").style.display = "flex";
+} else if (platform.startsWith('Win')) {
+    document.getElementById("windows").style.display = "flex";
+} else if (platform.startsWith('Linux')) {
+    document.getElementById("linux").style.display = "flex";
+} else if (platform.includes('iPhone') || platform.includes('iPad') || platform.includes('iPod')) {
+    document.getElementById("ios").style.display = "flex";
+
+    serverurlbtncontainer.style.display = "none";
+    serverurl.style.display = "flex";
+} else if (platform.includes('Android')) {
+    document.getElementById("android").style.display = "flex";
+    
+    serverurlbtncontainer.style.display = "none";
+    serverurl.style.display = "flex";
+} else {
+    document.getElementById("default").style.display = "flex";
+    console.log('Unable to determine the current system.');
+}
+
+serverurlbtn.addEventListener("click", function() {
+    serverurlbtncontainer.style.display = "none";
+    serverurl.style.display = "flex";
+});
+
+copybtn.addEventListener("click", function() {
+    var copyText = document.getElementById("serverurltxt").innerText;
+    navigator.clipboard.writeText(copyText);
+
+    copybtn.innerHTML = "{{ _("Copied!") }}";
+
+    setTimeout(function() {
+        copybtn.innerHTML = "{{ _("Copy") }}";
+    }, 2000);
+});
+</script>
 
 </div>

--- a/app/web.py
+++ b/app/web.py
@@ -56,7 +56,7 @@ def setup():
     ombi_run_all_user_importers()
 
     resp = make_response(render_template(
-        "wizard.html", server_type=Settings.get(Settings.key == "server_type").value))
+        "wizard.html", server_type=Settings.get(Settings.key == "server_type").value, server_url=Settings.get(Settings.key == "server_url").value))
     resp.set_cookie('current', "0")
 
     return resp
@@ -119,6 +119,7 @@ def wizard(action):
             discord_id=settings.get("discord_id"),
             overseerr_url=settings.get("overseerr_url"),
             custom_html=settings.get("custom_html"),
+            server_url=settings.get("server_url"),
             next=True))
         resp.headers['current'] = str(next_step)
         resp.headers['max'] = "1" if next_step == max_step else "0"
@@ -133,6 +134,7 @@ def wizard(action):
             discord_id=settings.get("discord_id"),
             overseerr_url=settings.get("overseerr_url"),
             custom_html=settings.get("custom_html"),
+            server_url=settings.get("server_url"),
             prev=True))
         resp.headers['current'] = str(prev_step)
         resp.headers['max'] = "0"


### PR DESCRIPTION
Replaced the default Download button that directs you to Jellyfin website with a smaller Other Download button and in place of the old button is direct download buttons based on the users device. If the users device does not support any type of direct app then user is given the option just to open in the web browser.

I might add a feature at some point to allow the admin to change the download links for each app using environment variables because currently the apps are hard coded urls to Swiftfin, Findroid and Flatpack.

![3530-212-159-75-75 ngrok-free app_setup](https://github.com/Wizarrrr/wizarr/assets/16636012/01c59687-bcf2-4d45-8d14-5553837f60d2)
![3530-212-159-75-75 ngrok-free app_setup (1)](https://github.com/Wizarrrr/wizarr/assets/16636012/137b974a-cf1e-4a55-8969-27ab1fa11595)
![3530-212-159-75-75 ngrok-free app_setup(iPhone 12 Pro)](https://github.com/Wizarrrr/wizarr/assets/16636012/76218eac-dc79-4acf-9d3f-ef46aae0f825)
![3530-212-159-75-75 ngrok-free app_setup (2)](https://github.com/Wizarrrr/wizarr/assets/16636012/d5ad4cf8-0c06-4eda-b71c-f91d28d806ce)
![3530-212-159-75-75 ngrok-free app_setup (3)](https://github.com/Wizarrrr/wizarr/assets/16636012/70247822-a56c-4d64-8ed7-30e00b6160ce)

