### PR TITLE
Allow for maintaining page in admin section when refreshing the page

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -45,6 +45,16 @@ def admin():
             return render_template("admin.html")
     return redirect('/settings')
 
+@app.route('/admin/<path:path>')
+@login_required
+def admin_catch_all(path):
+    setup = Settings.get_or_none(Settings.key == "server_verified")
+    if setup:
+        print(setup.value)
+        if setup.value == "True":
+            return render_template("admin.html")
+    return redirect('/settings')
+
 
 @app.route('/invite', methods=["GET", "POST"])
 @login_required

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,6 +46,21 @@
 
   <script src="{{url_for('static', filename='js/dark-mode-switch.js')}}"></script>
 
+<script>
+var navbarContainer = document.querySelector('#navbar-default');
+navbarContainer.addEventListener('click', function(event) {
+  if (event.target.tagName === 'BUTTON') {
+    var hxGet = event.target.getAttribute('hx-get');
+    hxGet = hxGet.replace(/[^a-zA-Z0-9-]/g, '');
+    history.pushState(null, null, '/admin/' + hxGet);
+  }
+});
+
+var hxGet = window.location.pathname.replace('/admin', '');
+if (hxGet == '/settings') hxGet = '/settings/';
+if (hxGet) htmx.ajax('GET', hxGet, '#content');
+</script>
+
 </body>
 
 


### PR DESCRIPTION
This is kinda of a hack, but it works, feel free to decline this PR

- base.html (first edit)
If the user clicks on a button in the navbar, we want to change the URL to match the page they clicked on

- base.html (second edit)
If the user loads a page directly, we want to load the page they requested and not the default page, /settings has to be /settings/, then we can use htmx.ajax to load the page they requested

- admin.py
Allow for all routes under /admin/, they may be a better way to do this wildcard that I don't know of, feel free to let me know.