### PR TITLE
Fix navigating to the wrong url after joining through plex

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -44,7 +44,7 @@ def connect():
 
     if Settings.get(key="server_type").value == "plex":
         threading.Thread(target=plex_handle_oauth_token, args=(token, code)).start()
-        return redirect(os.getenv("APP_URL") + "/setup")
+        return redirect(url_for('setup'))
 
     elif Settings.get(key="server_type").value == "jellyfin":
         return render_template("signup-jellyfin.html", code=code)


### PR DESCRIPTION
Fix going to the wrong URL after join. If you have Wizarr hosted at wizarr.example.com then after the plex signup the site will navigate to wizarr.example.com/wizarr.example.com/setup instead of wizarr.example.com/setup as it should if the APP_URL does not start with "http://"