### PR TITLE
Ignore .vite files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ delete/
 *.backup
 swagger.json
 dev-dist
+.vite
 
 # Created by https://www.toptal.com/developers/gitignore/api/pycharm,flask,python
 # Edit at https://www.toptal.com/developers/gitignore?templates=pycharm,flask,python


### PR DESCRIPTION
The .gitignore file has been updated to exclude .vite files from being tracked in Git. This change prevents .vite files from cluttering the repository and helps maintain a clean commit history. .vite files are typically generated by Vite, a build tool for web applications.