### PR TITLE
fix(frontend): 🐛 users without token no longer cause error on scan

### DIFF
--- a/apps/wizarr-frontend/src/modules/admin/components/Users/UserList/UserItem.vue
+++ b/apps/wizarr-frontend/src/modules/admin/components/Users/UserList/UserItem.vue
@@ -66,8 +66,8 @@ export default defineComponent({
     },
     data() {
         return {
-            profilePicture: "https://ui-avatars.com/api/?uppercase=true&name=" + this.user.username[0],
-            backupPicture: "https://ui-avatars.com/api/?uppercase=true&name=" + this.user.username[0],
+            profilePicture: "https://ui-avatars.com/api/?uppercase=true&name=" + this.user.username,
+            backupPicture: "https://ui-avatars.com/api/?uppercase=true&name=" + this.user.username,
             disabled: {
                 delete: false,
             },
@@ -103,6 +103,9 @@ export default defineComponent({
     },
     methods: {
         async getProfilePicture() {
+            if (!this.user.username) {
+                return;
+            }
             const response = this.$axios.get(`/api/users/${this.user.token}/profile-picture`, {
                 responseType: "blob",
             });


### PR DESCRIPTION
when scanning plex server causes an error occur when guest account is enabled