### PR TITLE
fix(frontend): cant remove discord widget id

### DIFF
--- a/apps/wizarr-frontend/src/modules/settings/pages/Discord.vue
+++ b/apps/wizarr-frontend/src/modules/settings/pages/Discord.vue
@@ -75,8 +75,6 @@ export default defineComponent({
                 }
             });
 
-            console.log(validate);
-
             if (!validate) return;
 
             const response = await this.$axios.put("/api/settings", formData).catch(() => {

--- a/apps/wizarr-frontend/src/modules/settings/pages/Discord.vue
+++ b/apps/wizarr-frontend/src/modules/settings/pages/Discord.vue
@@ -66,13 +66,22 @@ export default defineComponent({
 
             const validate = await this.$rawAxios.get(`https://discord.com/api/guilds/${this.serverId}/widget.json`).catch((validation) => {
                 // Discord Docs: https://discord.com/developers/docs/topics/opcodes-and-status-codes
-                if (validation.response.data.code === 50004) this.$toast.error(this.__("Unable to save due to widgets being disabled on this server."));
+                if (validation.response.data.code === 50004) {
+                    this.$toast.error(this.__("Unable to save due to widgets being disabled on this server."));
+                } else if (this.serverId === "") {
+                    return Promise.resolve(true); // No server ID, so we can save it
+                } else {
+                    this.$toast.error(this.__("Unable to save due to an invalid server ID."));
+                }
             });
+
+            console.log(validate);
 
             if (!validate) return;
 
             const response = await this.$axios.put("/api/settings", formData).catch(() => {
                 this.$toast.error(this.__("Unable to save connection."));
+                return;
             });
 
             if (!response?.data) return;


### PR DESCRIPTION
Currently no issues on the repo, but was mentioned in the discord. 

The user can now remove the discord widget id if the field is left empty and saved. Before the user couldn't even remove it at all.

