### PR TITLE
fix(backend): user sync error on plex managed/guest users

### DIFF
--- a/apps/wizarr-backend/wizarr_backend/helpers/plex.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/plex.py
@@ -298,7 +298,6 @@ def sync_plex_users(server_api_key: Optional[str] = None, server_url: Optional[s
 
     # If database_users.token is not in plex_users.id, remove user from database
     for database_user in database_users:
-        info(f"{database_user.username}")
         if str(database_user.token) not in [str(plex_user.id) for plex_user in plex_users]:
             database_user.delete_instance()
             info(f"User {database_user.username} successfully removed from database")

--- a/apps/wizarr-backend/wizarr_backend/helpers/plex.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/plex.py
@@ -277,7 +277,6 @@ def sync_plex_users(server_api_key: Optional[str] = None, server_url: Optional[s
 
     # Get users from plex
     plex_users = get_plex_users(server_api_key=server_api_key, server_url=server_url)
-    info(f"{plex_users}")
 
     # Get users from database
     database_users = get_users(as_dict=False)
@@ -287,7 +286,6 @@ def sync_plex_users(server_api_key: Optional[str] = None, server_url: Optional[s
         if str(plex_user.id) not in [str(database_user.token) for database_user in database_users]:
             create_user(username=plex_user.username, token=plex_user.id, email=plex_user.email)
             info(f"User {plex_user.username} successfully imported to database")
-            info(f"DEBUG: {plex_user.id} added")
 
     # If database_users.token is not in plex_users.id, remove user from database
     for database_user in database_users:

--- a/apps/wizarr-backend/wizarr_backend/helpers/plex.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/plex.py
@@ -287,8 +287,18 @@ def sync_plex_users(server_api_key: Optional[str] = None, server_url: Optional[s
             create_user(username=plex_user.title, token=plex_user.id, email=plex_user.email)
             info(f"User {plex_user.title} successfully imported to database")
 
+        # Handle Plex Managed/Guest users.
+        # Update DB username to Plex user title.
+        # This value is the same as username for normal accounts.
+        # For managed accounts without a public username,
+        # this value is set to 'Guest' or local username
+        elif str(plex_user.username) == "" and plex_user.email is None:
+            create_user(username=plex_user.title, token=plex_user.id, email=plex_user.email)
+            info(f"Managed User {plex_user.title} successfully updated to database")
+
     # If database_users.token is not in plex_users.id, remove user from database
     for database_user in database_users:
+        info(f"{database_user.username}")
         if str(database_user.token) not in [str(plex_user.id) for plex_user in plex_users]:
             database_user.delete_instance()
             info(f"User {database_user.username} successfully removed from database")

--- a/apps/wizarr-backend/wizarr_backend/helpers/plex.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/plex.py
@@ -284,8 +284,8 @@ def sync_plex_users(server_api_key: Optional[str] = None, server_url: Optional[s
     # If plex_users.id is not in database_users.token, add user to database
     for plex_user in plex_users:
         if str(plex_user.id) not in [str(database_user.token) for database_user in database_users]:
-            create_user(username=plex_user.username, token=plex_user.id, email=plex_user.email)
-            info(f"User {plex_user.username} successfully imported to database")
+            create_user(username=plex_user.title, token=plex_user.id, email=plex_user.email)
+            info(f"User {plex_user.title} successfully imported to database")
 
     # If database_users.token is not in plex_users.id, remove user from database
     for database_user in database_users:

--- a/apps/wizarr-backend/wizarr_backend/helpers/plex.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/plex.py
@@ -286,7 +286,7 @@ def sync_plex_users(server_api_key: Optional[str] = None, server_url: Optional[s
         if str(plex_user.id) not in [str(database_user.token) for database_user in database_users]:
             create_user(username=plex_user.username, token=plex_user.id, email=plex_user.email)
             info(f"User {plex_user.username} successfully imported to database")
-
+            info(f"DEBUG: {plex_user.id} added")
 
     # If database_users.token is not in plex_users.id, remove user from database
     for database_user in database_users:

--- a/apps/wizarr-backend/wizarr_backend/helpers/plex.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/plex.py
@@ -325,7 +325,7 @@ def get_plex_profile_picture(user_id: str, server_api_key: Optional[str] = None,
     # Get the user
     user = get_plex_user(user_id=user_id, server_api_key=server_api_key, server_url=server_url)
 
-    if user.email is not None:
+    if str(user.email) != "":
         try:
             # Get the profile picture from Plex
             url = user.thumb

--- a/apps/wizarr-backend/wizarr_backend/helpers/plex.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/plex.py
@@ -316,14 +316,15 @@ def get_plex_profile_picture(user_id: str, server_api_key: Optional[str] = None,
     # Get the user
     user = get_plex_user(user_id=user_id, server_api_key=server_api_key, server_url=server_url)
 
-    try:
-        # Get the profile picture from Plex
-        url = user.thumb
-        response = get(url=url, timeout=30)
-    except RequestException:
-        # Backup profile picture using ui-avatars.com if Jellyfin fails
-        username = f"{user.username}&length=1" if user else "ERROR&length=60&font-size=0.28"
-        response = get(url=f"https://ui-avatars.com/api/?uppercase=true&name={username}", timeout=30)
+    if user.email is not None:
+        try:
+            # Get the profile picture from Plex
+            url = user.thumb
+            response = get(url=url, timeout=30)
+        except RequestException:
+            # Backup profile picture using ui-avatars.com if Jellyfin fails
+            username = f"{user.username}&length=1" if user else "ERROR&length=60&font-size=0.28"
+            response = get(url=f"https://ui-avatars.com/api/?uppercase=true&name={username}", timeout=30)
 
     # Raise exception if either Jellyfin or ui-avatars.com fails
     if response.status_code != 200:

--- a/apps/wizarr-backend/wizarr_backend/helpers/plex.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/plex.py
@@ -277,6 +277,7 @@ def sync_plex_users(server_api_key: Optional[str] = None, server_url: Optional[s
 
     # Get users from plex
     plex_users = get_plex_users(server_api_key=server_api_key, server_url=server_url)
+    info(f"{plex_users}")
 
     # Get users from database
     database_users = get_users(as_dict=False)

--- a/apps/wizarr-backend/wizarr_backend/helpers/users.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/users.py
@@ -155,9 +155,14 @@ def create_user(**kwargs) -> Users:
     form = UsersModel(**kwargs)
     user_model = form.model_dump()
 
+    #
+    # Lookup by token to fix Issue #322 and #352
+    # https://github.com/wizarrrr/wizarr/issues/322
+    # https://github.com/wizarrrr/wizarr/issues/352
+    #
     # If user already exists raise error (maybe change this to update user)
-    if get_user_by_username(form.username, verify=False) is not None:
-        user: Users = Users.update(**user_model).where(Users.username == form.username)
+    if get_user_by_token(form.token, verify=False) is not None:
+        user: Users = Users.update(**user_model).where(Users.token == form.token)
     else:
         user: Users = Users.create(**user_model)
 

--- a/apps/wizarr-backend/wizarr_backend/helpers/users.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/users.py
@@ -162,7 +162,7 @@ def create_user(**kwargs) -> Users:
     #
     # If user already exists raise error (maybe change this to update user)
     if get_user_by_token(form.token, verify=False) is not None:
-        user: Users = Users.update(**user_model).where(Users.token == form.token)
+        user: Users = Users.update(**user_model).where(Users.token == form.token).execute()
     else:
         user: Users = Users.create(**user_model)
 


### PR DESCRIPTION
This refactors the create_user function to lookup user by token rather than username. This fixes the sync error related to Plex Managed/Guest users, allowing them to be properly added to the database.

Fixes #322 and #352