### PR TITLE
build(semantic-release): 🧱 changelog commit/discord payload updates

### DIFF
--- a/modules/semantic-release-discord/index.js
+++ b/modules/semantic-release-discord/index.js
@@ -37,22 +37,22 @@ const success = (pluginConfig, context) => {
     const discordPayload = {
         embeds: [
             {
-                title: `🚀 New ${isBeta ? 'Beta' : ''} Release [${version}] 🚀`,
-                description: `We are excited to announce the release of **${version}** of our software! This ${isBeta ? 'beta' : ''} release comes with the following changes. 🎉\n\n**What's New in this ${isBeta ? 'Beta' : ''} Release**\n${parseNotes(notes)}\n**How to Get the ${isBeta ? 'Beta' : ''} Release**\nTo access the ${isBeta ? 'beta' : ''} release, simply pull the latest copy of our ${isBeta ? 'Beta' : ''} Docker Image. Your feedback ${isBeta ? 'on the beta' : ''} is crucial to helping us make this release even better, so please don't hesitate to reach out with any comments, questions, or bug reports.\n\n${isBeta ? 'Thank you for being a part of our beta testing community, and we look forward to your feedback to make this release a success! 🙌' : 'Thank you for being a part of our community, and we look forward to your feedback! 🙌'}\n\n${isBeta ? 'Happy testing! 🧪' : 'Happy updating! 🎉'}`,
+                title: `🚀 New ${isBeta ? "Beta" : ""} Release [${version}] 🚀`,
+                description: `We are excited to announce the release of **${version}** of our software! This ${isBeta ? "beta" : ""} release comes with the following changes. 🎉\n\n**What's New in this ${isBeta ? "Beta" : ""} Release**\n${parseNotes(notes)}\n**How to Get the ${isBeta ? "Beta" : ""} Release**\nTo access the ${isBeta ? "beta" : ""} release, simply pull the latest copy of our ${isBeta ? "Beta" : ""} Docker Image. Your feedback ${isBeta ? "on the beta" : ""} is crucial to helping us make this release even better, so please don't hesitate to reach out with any comments, questions, or bug reports.\n\n${isBeta ? "Thank you for being a part of our beta testing community, and we look forward to your feedback to make this release a success! 🙌" : "Thank you for being a part of our community, and we look forward to your feedback! 🙌"}\n\n${isBeta ? "Happy testing! 🧪" : "Happy updating! 🎉"}${isBeta ? "\n\n<@&1150177174167494826>" : ""}`,
                 url: url,
                 color: 16728405,
                 author: {
                     name: "Wizarr Github",
                     url: "https://github.com/Wizarrrr/wizarr",
-                    icon_url: "https://avatars.githubusercontent.com/u/113373916"
+                    icon_url: "https://avatars.githubusercontent.com/u/113373916",
                 },
                 footer: {
-                    text: "Wizarr Team"
+                    text: "Wizarr Team",
                 },
                 timestamp: new Date().toISOString(),
-            }
+            },
         ],
-        attachments: []
+        attachments: [],
     };
 
     try {

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -12,38 +12,85 @@ const isMaster = branch === "master" || branch === "main";
  * @type {import("semantic-release").GlobalConfig}
  */
 const config = {
-    branches: [
-        "main",
-        "master",
-        { name: "beta", prerelease: true },
-    ],
+    branches: ["main", "master", { name: "beta", prerelease: true }],
     plugins: [
-        ["@semantic-release/exec", {
-            // use semantic-release logger to print the branch name
-            prepareCmd: "echo \"Branch: ${branch}\"",
-        }],
-        "@semantic-release/commit-analyzer",
+        [
+            "@semantic-release/exec",
+            {
+                // use semantic-release logger to print the branch name
+                prepareCmd: 'echo "Branch: ${branch}"',
+            },
+        ],
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                // Modify default release rules to include types that are not breaking change, feat, or fix as a patch release
+                // Default rules: https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js
+                releaseRules: [
+                    {
+                        scope: "no-release",
+                        release: false,
+                    },
+                    {
+                        type: "build",
+                        release: "patch",
+                    },
+                    {
+                        type: "ci",
+                        release: "patch",
+                    },
+                    {
+                        type: "chore",
+                        release: "patch",
+                    },
+                    {
+                        type: "docs",
+                        release: "patch",
+                    },
+                    {
+                        type: "refactor",
+                        release: "patch",
+                    },
+                    {
+                        type: "style",
+                        release: "patch",
+                    },
+                    // {
+                    //     type: "test",
+                    //     release: "patch",
+                    // },
+                ],
+            },
+        ],
         "@semantic-release/release-notes-generator",
-        ["@semantic-release/changelog", {
-            changelogFile: isBeta ? "CHANGELOG-beta.md" : "CHANGELOG.md",
-        }],
-        ["@semantic-release/exec", {
-            prepareCmd: "echo \"${nextRelease.version}\" > latest",
-        }],
-        ["@semantic-release/git", {
-            assets: [
-                "CHANGELOG.md",
-                "CHANGELOG-beta.md",
-                "latest"
-            ],
-            message: "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}",
-        }],
+        [
+            "@semantic-release/changelog",
+            {
+                changelogFile: isBeta ? "CHANGELOG-beta.md" : "CHANGELOG.md",
+            },
+        ],
+        [
+            "@semantic-release/exec",
+            {
+                prepareCmd: 'echo "${nextRelease.version}" > latest',
+            },
+        ],
+        [
+            "@semantic-release/git",
+            {
+                assets: ["CHANGELOG.md", "CHANGELOG-beta.md", "latest"],
+                message: "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}",
+            },
+        ],
         "@wizarrrr/semantic-release-discord",
-        ["@wizarrrr/semantic-release-sentry-releases", {
-            sourcemaps: "dist/apps/wizarr-frontend"
-        }]
-    ]
-}
+        [
+            "@wizarrrr/semantic-release-sentry-releases",
+            {
+                sourcemaps: "dist/apps/wizarr-frontend",
+            },
+        ],
+    ],
+};
 
 if (isMaster) {
     config.plugins.splice(-2, 0, "@semantic-release/github");


### PR DESCRIPTION
Adds commit types other than feat, fix, and breaking change to be included in the changelog/release notes as a patch release.