### PR TITLE
ci(semantic-release): 🔧 explicity define breaking changes

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -59,6 +59,10 @@ const config = {
                     //     type: "test",
                     //     release: "patch",
                     // },
+                    {
+                        breaking: true,
+                        release: "major",
+                    },
                 ],
             },
         ],


### PR DESCRIPTION
[skip ci]