### PR TITLE
feat: ✨Ability to specify whether a user displays on login page

### DIFF
--- a/apps/wizarr-backend/wizarr_backend/app/migrator/migrations/2024-04-30_16-44-17.py
+++ b/apps/wizarr-backend/wizarr_backend/app/migrator/migrations/2024-04-30_16-44-17.py
@@ -1,0 +1,32 @@
+#
+# CREATED ON VERSION: V4.0.0
+# MIGRATION: 2024-04-30_16-44-17
+# CREATED: Tue Apr 30 2024
+#
+
+from peewee import *
+from playhouse.migrate import *
+
+from app import db
+
+# Do not change the name of this file,
+# migrations are run in order of their filenames date and time
+
+def run():
+    # Use migrator to perform actions on the database
+    migrator = SqliteMigrator(db)
+
+    # Add new Column to users table, its a boolean field with a default value of True
+    with db.transaction():
+        # Check if the column exists
+        cursor = db.cursor()
+        cursor.execute("PRAGMA table_info(invitations);")
+        columns = cursor.fetchall()
+        column_names = [column[1] for column in columns]
+
+        if "hide_user" not in column_names:
+            db.execute_sql("ALTER TABLE invitations ADD COLUMN hide_user INTEGER SET DEFAULT 1")
+        else:
+            print("Column hide_user already exists")
+
+    print("Migration 2024-04-30_16-44-17 complete")

--- a/apps/wizarr-backend/wizarr_backend/app/models/database/invitations.py
+++ b/apps/wizarr-backend/wizarr_backend/app/models/database/invitations.py
@@ -16,3 +16,4 @@ class Invitations(BaseModel):
     plex_home = BooleanField(null=True, default=None)
     sessions = CharField(null=True, default=None)
     live_tv = BooleanField(null=True, default=None)
+    hide_user = BooleanField(null=True, default=True)

--- a/apps/wizarr-backend/wizarr_backend/app/models/wizarr/invitations.py
+++ b/apps/wizarr-backend/wizarr_backend/app/models/wizarr/invitations.py
@@ -42,6 +42,7 @@ class InvitationsModel(Model):
     plex_home = BooleanType(required=False, default=False)
     used_at = DateTimeType(required=False, default=None, convert_tz=True)
     created = DateTimeType(required=False, default=datetime.utcnow(), convert_tz=True)
+    hide_user = BooleanType(required=False, default=True)
 
 
     # ANCHOR - Validate Code

--- a/apps/wizarr-backend/wizarr_backend/helpers/emby.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/emby.py
@@ -287,6 +287,14 @@ def invite_emby_user(username: str, password: str, code: str, server_api_key: Op
     else:
         new_policy["EnableLiveTvAccess"] = False
 
+    # Set the hidden user status
+    # There is IsHidden and IsHiddenRemotely. Might need to check if both are needed
+    # Probably want to add an option for both
+    if invitation.hide_user is not None and invitation.hide_user == True:
+        new_policy["IsHidden"] = True
+    else:
+        new_policy["IsHidden"] = False
+
     # Get users default policy
     old_policy = user_response["Policy"]
 

--- a/apps/wizarr-backend/wizarr_backend/helpers/emby.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/emby.py
@@ -288,12 +288,14 @@ def invite_emby_user(username: str, password: str, code: str, server_api_key: Op
         new_policy["EnableLiveTvAccess"] = False
 
     # Set the hidden user status
-    # There is IsHidden and IsHiddenRemotely. Might need to check if both are needed
-    # Probably want to add an option for both
     if invitation.hide_user is not None and invitation.hide_user == True:
         new_policy["IsHidden"] = True
+        new_policy["IsHiddenRemotely"] = True
+        new_policy["IsHiddenFromUnusedDevices"] = True
     else:
         new_policy["IsHidden"] = False
+        new_policy["IsHiddenRemotely"] = False
+        new_policy["IsHiddenFromUnusedDevices"] = False
 
     # Get users default policy
     old_policy = user_response["Policy"]

--- a/apps/wizarr-backend/wizarr_backend/helpers/emby.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/emby.py
@@ -288,14 +288,8 @@ def invite_emby_user(username: str, password: str, code: str, server_api_key: Op
         new_policy["EnableLiveTvAccess"] = False
 
     # Set the hidden user status
-    if invitation.hide_user is not None and invitation.hide_user == True:
-        new_policy["IsHidden"] = True
-        new_policy["IsHiddenRemotely"] = True
-        new_policy["IsHiddenFromUnusedDevices"] = True
-    else:
-        new_policy["IsHidden"] = False
+    if invitation.hide_user is not None and invitation.hide_user == False:
         new_policy["IsHiddenRemotely"] = False
-        new_policy["IsHiddenFromUnusedDevices"] = False
 
     # Get users default policy
     old_policy = user_response["Policy"]

--- a/apps/wizarr-backend/wizarr_backend/helpers/jellyfin.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/jellyfin.py
@@ -282,6 +282,12 @@ def invite_jellyfin_user(username: str, password: str, code: str, server_api_key
     else:
         new_policy["EnableLiveTvAccess"] = False
 
+    # Set the hidden user status
+    if invitation.hide_user is not None and invitation.hide_user == True:
+        new_policy["IsHidden"] = True
+    else:
+        new_policy["IsHidden"] = False
+
     # Get users default policy
     old_policy = user_response["Policy"]
 

--- a/apps/wizarr-backend/wizarr_backend/helpers/jellyfin.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/jellyfin.py
@@ -283,9 +283,7 @@ def invite_jellyfin_user(username: str, password: str, code: str, server_api_key
         new_policy["EnableLiveTvAccess"] = False
 
     # Set the hidden user status
-    if invitation.hide_user is not None and invitation.hide_user == True:
-        new_policy["IsHidden"] = True
-    else:
+    if invitation.hide_user is not None and invitation.hide_user == False:
         new_policy["IsHidden"] = False
 
     # Get users default policy

--- a/apps/wizarr-frontend/src/modules/admin/components/Forms/InvitationForm.vue
+++ b/apps/wizarr-frontend/src/modules/admin/components/Forms/InvitationForm.vue
@@ -185,7 +185,7 @@ export default defineComponent({
                         value: "live_tv",
                     },
                     hide_user: {
-                        label: "Hide User from Dashboard",
+                        label: "Hide User from the Login Page",
                         value: "hide_user",
                     },
                 },
@@ -199,7 +199,7 @@ export default defineComponent({
                         value: "live_tv",
                     },
                     hide_user: {
-                        label: "Hide User from Dashboard",
+                        label: "Hide User from the Login Page",
                         value: "hide_user",
                     },
                 },

--- a/apps/wizarr-frontend/src/modules/admin/components/Forms/InvitationForm.vue
+++ b/apps/wizarr-frontend/src/modules/admin/components/Forms/InvitationForm.vue
@@ -107,7 +107,7 @@ export default defineComponent({
                 inviteCode: "",
                 expiration: 1440 as number | null | "custom",
                 customExpiration: "" as string,
-                checkboxes: ["live_tv"] as string[], // Add the checkboxes you want to be checked by default
+                checkboxes: ["live_tv", "hide_user"] as string[],// Add the checkboxes you want to be checked by default
                 duration: "unlimited" as number | "unlimited" | "custom",
                 customDuration: "" as string,
                 libraries: [] as string[],
@@ -184,6 +184,10 @@ export default defineComponent({
                         label: "Access to Live TV",
                         value: "live_tv",
                     },
+                    hide_user: {
+                        label: "Hide User from Dashboard",
+                        value: "hide_user",
+                    },
                 },
                 emby: {
                     unlimited: {
@@ -193,6 +197,10 @@ export default defineComponent({
                     live_tv: {
                         label: "Access to Live TV",
                         value: "live_tv",
+                    },
+                    hide_user: {
+                        label: "Hide User from Dashboard",
+                        value: "hide_user",
                     },
                 },
                 plex: {
@@ -265,6 +273,7 @@ export default defineComponent({
             const plex_home = invitationData.checkboxes.includes("plex_home");
             const plex_allow_sync = invitationData.checkboxes.includes("plex_allow_sync");
             const live_tv = invitationData.checkboxes.includes("live_tv");
+            const hide_user = invitationData.checkboxes.includes("hide_user");
             const sessions = invitationData.sessions;
             const duration = invitationData.duration == "custom" ? this.$filter("toMinutes", invitationData.customDuration) : invitationData.duration == "unlimited" ? null : invitationData.duration;
             const libraries = invitationData.libraries;
@@ -276,6 +285,7 @@ export default defineComponent({
                 plex_home: plex_home,
                 plex_allow_sync: plex_allow_sync,
                 live_tv: live_tv,
+                hide_user: hide_user,
                 sessions: sessions,
                 duration: duration,
                 specific_libraries: JSON.stringify(libraries),

--- a/apps/wizarr-frontend/src/modules/admin/components/InvitationManager/Invitation.vue
+++ b/apps/wizarr-frontend/src/modules/admin/components/InvitationManager/Invitation.vue
@@ -106,6 +106,10 @@ export default defineComponent({
                         label: "Access to Live TV",
                         value: this.invitation.live_tv,
                     },
+                    hide_user: {
+                        label: "Hide User from Dashboard",
+                        value: this.invitation.hide_user,
+                    },
                 },
                 emby: {
                     unlimited: {
@@ -115,6 +119,10 @@ export default defineComponent({
                     live_tv: {
                         label: "Access to Live TV",
                         value: this.invitation.live_tv,
+                    },
+                    hide_user: {
+                        label: "Hide User from Dashboard",
+                        value: this.invitation.hide_user,
                     },
                 },
                 plex: {

--- a/apps/wizarr-frontend/src/modules/admin/components/InvitationManager/Invitation.vue
+++ b/apps/wizarr-frontend/src/modules/admin/components/InvitationManager/Invitation.vue
@@ -107,7 +107,7 @@ export default defineComponent({
                         value: this.invitation.live_tv,
                     },
                     hide_user: {
-                        label: "Hide User from Dashboard",
+                        label: "Hide User from the Login Page",
                         value: this.invitation.hide_user,
                     },
                 },
@@ -121,7 +121,7 @@ export default defineComponent({
                         value: this.invitation.live_tv,
                     },
                     hide_user: {
-                        label: "Hide User from Dashboard",
+                        label: "Hide User from the Login Page",
                         value: this.invitation.hide_user,
                     },
                 },

--- a/apps/wizarr-frontend/src/types/api/invitations.ts
+++ b/apps/wizarr-frontend/src/types/api/invitations.ts
@@ -9,6 +9,7 @@ export interface Invitation {
     plex_allow_sync: boolean;
     plex_home: boolean;
     live_tv: boolean;
+    hide_user: boolean;
     sessions: number;
     specific_libraries: string;
     unlimited: boolean;


### PR DESCRIPTION
Adds feature requested in #376 and part of #395.

Works for both Emby and Jellyfin.
Emby uses IsHidden, IsHiddenRemotely and IsHiddenFromUnusedDevices while Jellyfin only uses IsHidden.

afaik, this is not a feature needed for plex.