### PR TITLE
ci(deps): setup dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Basic `dependabot.yml` file with
+# minimum configuration for two package managers
+
+version: 2
+updates:
+  # Enable version updates for npm project
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+
+  # Enable version updates for poetry backend
+  - package-ecosystem: "pip"
+    # Look for `pyproject.toml` and `lock` files in the `backend` directory
+    directory: "/apps/wizarr_backend/"
+    # Check the pip registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    reviewers:
+     - JamsRepos
+     - PhantomMantis
+     - MrDynamo
 
   # Enable version updates for poetry backend
   - package-ecosystem: "pip"
@@ -18,3 +22,19 @@ updates:
     # Check the pip registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    reviewers:
+     - JamsRepos
+     - PhantomMantis
+     - MrDynamo
+
+  # Enable version updates for github actions
+  - package-ecosystem: "github-actions"
+    # Defaults to .github/workflows directory
+    directory: "/"
+    # Check the actions registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+    reviewers:
+     - JamsRepos
+     - PhantomMantis
+     - MrDynamo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,9 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-     - JamsRepos
-     - PhantomMantis
-     - MrDynamo
+      - JamsRepos
+      - PhantomMantis
+      - MrDynamo
 
   # Enable version updates for poetry backend
   - package-ecosystem: "pip"
@@ -23,9 +23,9 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-     - JamsRepos
-     - PhantomMantis
-     - MrDynamo
+      - JamsRepos
+      - PhantomMantis
+      - MrDynamo
 
   # Enable version updates for github actions
   - package-ecosystem: "github-actions"
@@ -35,6 +35,6 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-     - JamsRepos
-     - PhantomMantis
-     - MrDynamo
+      - JamsRepos
+      - PhantomMantis
+      - MrDynamo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,11 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
-    reviewers:
-      - JamsRepos
-      - PhantomMantis
-      - MrDynamo
+    # NOTE: Removed reviewers as the pr-review-request workflow will accomplish the same thing on all PR types.
+    # reviewers:
+    #   - JamsRepos
+    #   - PhantomMantis
+    #   - MrDynamo
     target-branch: "develop"
 
   # Enable version updates for poetry backend
@@ -23,10 +24,11 @@ updates:
     # Check the pip registry for updates every day (weekdays)
     schedule:
       interval: "daily"
-    reviewers:
-      - JamsRepos
-      - PhantomMantis
-      - MrDynamo
+    # NOTE: Removed reviewers as the pr-review-request workflow will accomplish the same thing on all PR types.
+    # reviewers:
+    #   - JamsRepos
+    #   - PhantomMantis
+    #   - MrDynamo
     target-branch: "develop"
 
   # Enable version updates for github actions
@@ -36,8 +38,9 @@ updates:
     # Check the actions registry for updates every day (weekdays)
     schedule:
       interval: "daily"
-    reviewers:
-      - JamsRepos
-      - PhantomMantis
-      - MrDynamo
+    # NOTE: Removed reviewers as the pr-review-request workflow will accomplish the same thing on all PR types.
+    # reviewers:
+    #   - JamsRepos
+    #   - PhantomMantis
+    #   - MrDynamo
     target-branch: "develop"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
       - JamsRepos
       - PhantomMantis
       - MrDynamo
+    target-branch: "develop"
 
   # Enable version updates for poetry backend
   - package-ecosystem: "pip"
@@ -26,6 +27,7 @@ updates:
       - JamsRepos
       - PhantomMantis
       - MrDynamo
+    target-branch: "develop"
 
   # Enable version updates for github actions
   - package-ecosystem: "github-actions"
@@ -38,3 +40,4 @@ updates:
       - JamsRepos
       - PhantomMantis
       - MrDynamo
+    target-branch: "develop"


### PR DESCRIPTION
Sets up dependabot to automatically update npm, poetry(pip), and github actions dependencies.

Squash on merge. 

[skip ci]