### PR TITLE
Removed version tag from docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ docker run -d \
 
 ```
 ---
-version: "3.5"
 services:
   wizarr:
     container_name: wizarr


### PR DESCRIPTION
docker-compose.yml: `version` is obsolete