### PR TITLE
feat: Ability to specify whether a user can download content

### DIFF
--- a/apps/wizarr-backend/wizarr_backend/app/migrator/migrations/2024-06-29_22-44-04.py
+++ b/apps/wizarr-backend/wizarr_backend/app/migrator/migrations/2024-06-29_22-44-04.py
@@ -1,0 +1,32 @@
+#
+# CREATED ON VERSION: V4.1.1
+# MIGRATION: 2024-06-29_22-44-04
+# CREATED: Sat Jun 29 2024
+#
+
+from peewee import *
+from playhouse.migrate import *
+
+from app import db
+
+# Do not change the name of this file,
+# migrations are run in order of their filenames date and time
+
+def run():
+    # Use migrator to perform actions on the database
+    migrator = SqliteMigrator(db)
+
+    # Add new Column to users table, its a boolean field with a default value of True
+    with db.transaction():
+        # Check if the column exists
+        cursor = db.cursor()
+        cursor.execute("PRAGMA table_info(invitations);")
+        columns = cursor.fetchall()
+        column_names = [column[1] for column in columns]
+
+        if "allow_download" not in column_names:
+            db.execute_sql("ALTER TABLE invitations ADD COLUMN allow_download BOOLEAN DEFAULT 1")
+        else:
+            print("Column allow_download already exists")
+
+    print("Migration 2024-06-29_22-44-04 complete")

--- a/apps/wizarr-backend/wizarr_backend/app/models/database/invitations.py
+++ b/apps/wizarr-backend/wizarr_backend/app/models/database/invitations.py
@@ -16,3 +16,4 @@ class Invitations(BaseModel):
     sessions = CharField(null=True, default=None)
     live_tv = BooleanField(null=True, default=None)
     hide_user = BooleanField(null=True, default=True)
+    allow_download = BooleanField(null=True, default=None)

--- a/apps/wizarr-backend/wizarr_backend/app/models/wizarr/invitations.py
+++ b/apps/wizarr-backend/wizarr_backend/app/models/wizarr/invitations.py
@@ -42,6 +42,7 @@ class InvitationsModel(Model):
     used_at = DateTimeType(required=False, default=None, convert_tz=True)
     created = DateTimeType(required=False, default=datetime.utcnow(), convert_tz=True)
     hide_user = BooleanType(required=False, default=True)
+    allow_download = BooleanType(required=False, default=True)
 
 
     # ANCHOR - Validate Code

--- a/apps/wizarr-backend/wizarr_backend/helpers/emby.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/emby.py
@@ -284,6 +284,10 @@ def invite_emby_user(username: str, password: str, code: str, server_api_key: Op
     if invitation.hide_user is not None and invitation.hide_user == False:
         new_policy["IsHiddenRemotely"] = False
 
+    # Set the Allow Download status
+    if invitation.allow_download is not None and invitation.allow_download == False:
+        new_policy["EnableContentDownloading"] = False
+
     # Get users default policy
     old_policy = user_response["Policy"]
 

--- a/apps/wizarr-backend/wizarr_backend/helpers/jellyfin.py
+++ b/apps/wizarr-backend/wizarr_backend/helpers/jellyfin.py
@@ -284,6 +284,10 @@ def invite_jellyfin_user(username: str, password: str, code: str, server_api_key
     if invitation.hide_user is not None and invitation.hide_user == False:
         new_policy["IsHidden"] = False
 
+    # Set the Allow Download status
+    if invitation.allow_download is not None and invitation.allow_download == False:
+        new_policy["EnableContentDownloading"] = False
+
     # Get users default policy
     old_policy = user_response["Policy"]
 

--- a/apps/wizarr-frontend/src/modules/admin/components/Forms/InvitationForm.vue
+++ b/apps/wizarr-frontend/src/modules/admin/components/Forms/InvitationForm.vue
@@ -107,7 +107,7 @@ export default defineComponent({
                 inviteCode: "",
                 expiration: 1440 as number | null | "custom",
                 customExpiration: "" as string,
-                checkboxes: ["live_tv", "hide_user"] as string[],// Add the checkboxes you want to be checked by default
+                checkboxes: ["live_tv", "hide_user", "allow_download"] as string[],// Add the checkboxes you want to be checked by default
                 duration: "unlimited" as number | "unlimited" | "custom",
                 customDuration: "" as string,
                 libraries: [] as string[],
@@ -188,6 +188,10 @@ export default defineComponent({
                         label: "Hide User from the Login Page",
                         value: "hide_user",
                     },
+                    allow_download: {
+                        label: "Allow User to Download Content",
+                        value: "allow_download",
+                    },
                 },
                 emby: {
                     unlimited: {
@@ -201,6 +205,10 @@ export default defineComponent({
                     hide_user: {
                         label: "Hide User from the Login Page",
                         value: "hide_user",
+                    },
+                    allow_download: {
+                        label: "Allow User to Download Content",
+                        value: "allow_download",
                     },
                 },
                 plex: {
@@ -269,6 +277,7 @@ export default defineComponent({
             const plex_allow_sync = invitationData.checkboxes.includes("plex_allow_sync");
             const live_tv = invitationData.checkboxes.includes("live_tv");
             const hide_user = invitationData.checkboxes.includes("hide_user");
+            const allow_download = invitationData.checkboxes.includes("allow_download");
             const sessions = invitationData.sessions;
             const duration = invitationData.duration == "custom" ? this.$filter("toMinutes", invitationData.customDuration) : invitationData.duration == "unlimited" ? null : invitationData.duration;
             const libraries = invitationData.libraries;
@@ -280,6 +289,7 @@ export default defineComponent({
                 plex_allow_sync: plex_allow_sync,
                 live_tv: live_tv,
                 hide_user: hide_user,
+                allow_download: allow_download,
                 sessions: sessions,
                 duration: duration,
                 specific_libraries: JSON.stringify(libraries),

--- a/apps/wizarr-frontend/src/modules/admin/components/InvitationManager/Invitation.vue
+++ b/apps/wizarr-frontend/src/modules/admin/components/InvitationManager/Invitation.vue
@@ -110,6 +110,10 @@ export default defineComponent({
                         label: "Hide User from the Login Page",
                         value: this.invitation.hide_user,
                     },
+                    allow_download: {
+                        label: "Allow User to Download Content",
+                        value: this.invitation.allow_download,
+                    },
                 },
                 emby: {
                     unlimited: {
@@ -123,6 +127,10 @@ export default defineComponent({
                     hide_user: {
                         label: "Hide User from the Login Page",
                         value: this.invitation.hide_user,
+                    },
+                    allow_download: {
+                        label: "Allow User to Download Content",
+                        value: this.invitation.allow_download,
                     },
                 },
                 plex: {

--- a/apps/wizarr-frontend/src/types/api/invitations.ts
+++ b/apps/wizarr-frontend/src/types/api/invitations.ts
@@ -9,6 +9,7 @@ export interface Invitation {
     plex_allow_sync: boolean;
     live_tv: boolean;
     hide_user: boolean;
+    allow_download: boolean;
     sessions: number;
     specific_libraries: string;
     unlimited: boolean;


### PR DESCRIPTION
Added ability for emby and jellyfin to set if a user can download content from the server. Defaults to True as is standard for both emby and jellyfin.

Emby does have an "Allow media downloading that requires transcoding" however it seems dependent on "Allow media downloading", and do not think it is worth including as an invite option for now.