### PR TITLE
Fix country code for Sweden

### DIFF
--- a/apps/wizarr-frontend/src/i18n.ts
+++ b/apps/wizarr-frontend/src/i18n.ts
@@ -25,7 +25,7 @@ const availableLanguages: GetTextOptions["availableLanguages"] = {
     pt: "Português",
     ro: "Română",
     ru: "Русский",
-    sv: "Svenska",
+    se: "Svenska",
     zh_cn: "简体中文",
     zh_tw: "繁體中文",
 };


### PR DESCRIPTION
I found that the flag in the language modal was wrong for Sweden. I have now resolved the issue. The country code was wrong. 