### PR TITLE
feat: 🎊 Any length of invitation code

### DIFF
--- a/apps/wizarr-backend/wizarr_backend/app/models/wizarr/invitations.py
+++ b/apps/wizarr-backend/wizarr_backend/app/models/wizarr/invitations.py
@@ -51,8 +51,8 @@ class InvitationsModel(Model):
         if value is None:
             return
 
-        # Check that the code is a 6 character string of only letters and numbers
-        if not isinstance(value, str) or len(value) != 6 or not value.isalnum():
+        # Check that the code only contains letters and numbers
+        if not isinstance(value, str) or not value.isalnum():
             raise ValidationError("Invalid code")
 
         # Check that the code has not been used
@@ -104,7 +104,7 @@ class InvitationsModel(Model):
             raise ValidationError("Unable to generate a unique code")
 
         # If code is None, generate a new code
-        if not invitation["code"] or len(invitation["code"]) != 6 or not str(invitation["code"]).isalnum():
+        if not invitation["code"] or not str(invitation["code"]).isalnum():
             invitation["code"] = create_code()
 
         # Upper case the code

--- a/apps/wizarr-frontend/src/modules/admin/components/Forms/InvitationForm.vue
+++ b/apps/wizarr-frontend/src/modules/admin/components/Forms/InvitationForm.vue
@@ -5,7 +5,7 @@
                 <FormKit type="form" name="inviteForm" id="inviteForm" @submit="createInvite" :actions="!eventBus" v-model="invitationData" :disabled="disabled" :submit-label="__('Create Invitation')" :submit-attrs="{ inputClass: 'w-full justify-center mt-2' }">
                     <div class="space-y-4">
                         <!-- Invite Code -->
-                        <FormKit type="text" placeholder="XMFGEJI" label="Invitation Code" name="inviteCode" validation="length:6,6|uppercase" />
+                        <FormKit type="text" placeholder="XMFGEJI" label="Invitation Code" name="inviteCode" validation="uppercase" />
 
                         <!-- Select Expiration -->
                         <FormKit type="select" label="Invitation Expiration" name="expiration" :options="expirationOptions" />
@@ -399,8 +399,7 @@ export default defineComponent({
     watch: {
         "invitationData.inviteCode": {
             immediate: true,
-            handler(inviteCode) {
-                if (inviteCode.length >= 7) this.invitationData.inviteCode = inviteCode.slice(0, 6);
+            handler() {
                 this.invitationData.inviteCode = this.invitationData.inviteCode.replace(/[^a-zA-Z0-9]/g, "");
                 this.invitationData.inviteCode = this.invitationData.inviteCode.toUpperCase();
             },

--- a/apps/wizarr-frontend/src/modules/home/pages/JoinForm.vue
+++ b/apps/wizarr-frontend/src/modules/home/pages/JoinForm.vue
@@ -30,8 +30,8 @@ export default defineComponent({
     methods: {
         async join() {
             // Check if the code is inputted
-            if (!this.code || this.code.length !== 6) {
-                this.$toast.info(this.__('Please enter an invite code'));
+            if (!this.code) {
+                this.$toast.info(this.__("Please enter an invite code"));
                 return;
             }
 


### PR DESCRIPTION
I don't know if there was a reason to have a fixed length for invitation codes?

The reason for me implementing this feature is to have an invitation code for users to use for trying my Plex instance. (A code that can be used unlimited number of times with a user duration of 1 week). For this I don't want a random string as the invitation code (I could't come up with something with exactly 6 characters). 

I will later try to implement a new validation feature for invitation codes, that can accept unlimited usages but one one per user. 