### PR TITLE
fix: 🐛 Solve some issues with markdown preview

### DIFF
--- a/apps/wizarr-frontend/src/assets/scss/md-editor-v3.scss
+++ b/apps/wizarr-frontend/src/assets/scss/md-editor-v3.scss
@@ -2,19 +2,8 @@
     --md-theme-quote-border: 5px solid rgb(208, 49, 67) !important;
     --md-theme-link-color: rgb(208, 49, 67) !important;
     --md-theme-link-hover-color: rgb(208, 49, 67) !important;
-}
-
-.md-editor-preview {
-    word-break: normal !important;
-    
-    h1, h2, h3, h4, h5, h6 {
-        word-break: normal !important;
-    }
-    h1, h2, h3, h4, h5, h6 {
-        &:first-child {
-            margin-top: 0;
-          }
-    }
+    --md-theme-code-inline-color: rgb(208, 49, 67) !important;
+    --md-theme-code-inline-bg-color: rgba(208, 49, 67, 0.1) !important;
 }
 
 .md-editor.md-editor-dark, .md-editor-modal-container[data-theme='dark'] {
@@ -24,6 +13,30 @@
 .md-editor.md-editor-previewOnly {
     background-color: inherit !important;
 }
+
+.md-editor-preview {
+    word-break: normal !important;
+    
+    h1, h2, h3, h4, h5, h6 {
+        word-break: normal !important;
+    }
+    > h1, > h2, > h3, > h4, > h5, > h6 {
+        &:first-child {
+            margin-top: 0;
+          }
+    }
+}
+
+.md-editor-preview {
+    ol {
+        list-style-type: decimal;
+    }
+
+    ul {
+        list-style-type: disc;
+    }
+}
+
 
 .md-editor.md-editor-previewOnly .md-editor-preview-wrapper {
     padding: inherit !important;

--- a/apps/wizarr-frontend/src/assets/scss/md-editor-v3.scss
+++ b/apps/wizarr-frontend/src/assets/scss/md-editor-v3.scss
@@ -4,6 +4,7 @@
     --md-theme-link-hover-color: rgb(208, 49, 67) !important;
     --md-theme-code-inline-color: rgb(208, 49, 67) !important;
     --md-theme-code-inline-bg-color: rgba(208, 49, 67, 0.1) !important;
+    --md-theme-code-block-bg-color: rgb(17, 24, 39) !important;
 }
 
 .md-editor.md-editor-dark, .md-editor-modal-container[data-theme='dark'] {

--- a/apps/wizarr-frontend/src/assets/scss/md-editor-v3.scss
+++ b/apps/wizarr-frontend/src/assets/scss/md-editor-v3.scss
@@ -9,6 +9,8 @@
 
 .md-editor.md-editor-dark, .md-editor-modal-container[data-theme='dark'] {
     --md-color: #fff;
+    --md-bk-color: rgb(55, 65, 81);
+    --md-scrollbar-bg-color: rgb(55, 65, 81);
 }
 
 .md-editor.md-editor-previewOnly {


### PR DESCRIPTION
Below fixes has been implemented

1. Ordered list rendering correctly
2. Unordered list rendering correctly
3. Only remove padding of the first heading-element at top level of markdown preview
4. Change color of code-snippet to follow the theme