### PR TITLE
fix: correctly fallback to server_url when no override is set

### DIFF
--- a/apps/wizarr-frontend/src/modules/help/components/Download.vue
+++ b/apps/wizarr-frontend/src/modules/help/components/Download.vue
@@ -3,7 +3,7 @@
     <!-- Bottom Bar -->
     <div class="flex flex-row justify-between pt-4">
         <span class="flex justify-end items-center">
-            <a .href="settings.server_url_override ?? settings.server_url" class="bg-primary hover:bg-primary_hover focus:outline-none text-white font-medium rounded dark:bg-primary dark:hover:bg-primary_hover px-5 py-2.5 text-sm whitespace-nowrap flex items-center justify-center relative">
+            <a .href="settings.server_url_override || settings.server_url" class="bg-primary hover:bg-primary_hover focus:outline-none text-white font-medium rounded dark:bg-primary dark:hover:bg-primary_hover px-5 py-2.5 text-sm whitespace-nowrap flex items-center justify-center relative">
                 <span v-if="settings.server_type == 'plex'">{{ __("Open Plex") }}</span>
                 <span v-else-if="settings.server_type == 'jellyfin'">{{ __("Open Jellyfin") }}</span>
                 <span v-else-if="settings.server_type == 'emby'">{{ __("Open Emby") }}</span>


### PR DESCRIPTION
Hey yall! This should resolve https://github.com/wizarrrr/wizarr/issues/482

Tested this and its fully working! 

~~I havent actually tested this yet, Ive been having some trouble getting a local environment up and running to test this. Its a super small fix though, and Im fairly confident this will work.~~

~~If someone could validate real quick that this works, or if anyone is available to help me debug my environment, that would be appreciated!~~

# Cause
Whenever the `server_url_override` is stored, it is defaulted to empty string if a value is not set. This `??` check will only take the right side if the left is null though, empty string does not qualify. So inadvertently, the href property gets set to blank.

# Proposed fix
Switching out the `??` operator for `||` should fix the issue. Empty string will not be truthy, and it will pass through to the server_url