### PR TITLE
Allow Plex media servers to select Jellyseerr

### DIFF
--- a/apps/wizarr-frontend/src/modules/settings/components/Forms/RequestForm.vue
+++ b/apps/wizarr-frontend/src/modules/settings/components/Forms/RequestForm.vue
@@ -64,7 +64,7 @@ export default defineComponent({
                     label: 'Jellyseerr',
                     value: 'jellyseerr',
                     attrs: {
-                        disabled: this.settings.server_type !== 'jellyfin' && this.settings.server_type !== 'emby',
+                        disabled: false,
                     },
                 },
                 {


### PR DESCRIPTION
Jellyseerr supports Plex. No reason why this should be disabled for Plex users.