### PR TITLE
API endpoint feature for widget

### DIFF
--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -7,6 +7,7 @@ from .wizard.routes  import wizard_bp
 from .plex.routes import plex_bp
 from .notifications.routes import notify_bp
 from .jellyfin.routes import jellyfin_bp
+from .status.routes import status_bp 
 
 all_blueprints = (public_bp, wizard_bp, admin_bp, auth_bp,
-                  settings_bp, setup_bp, plex_bp, notify_bp, jellyfin_bp)
+                  settings_bp, setup_bp, plex_bp, notify_bp, jellyfin_bp, status_bp)

--- a/app/blueprints/status/routes.py
+++ b/app/blueprints/status/routes.py
@@ -1,0 +1,59 @@
+from flask import Blueprint, request, jsonify
+import sqlite3
+import datetime
+import os
+import traceback
+
+status_bp = Blueprint("status", __name__)
+
+# Path to Wizarr DB
+DB_PATH = "/data/database/database.db"
+API_KEY = os.environ.get("WIZARR_API_KEY")  
+
+@status_bp.route("/api/status", methods=["GET"])
+def wizarr_status():
+    try:
+        # Enforce explicit API key
+        if not API_KEY:
+            return jsonify({"error": "API key not configured"}), 401
+
+        # Verify incoming key
+        key = request.headers.get("X-API-Key")
+        if key != API_KEY:
+            return jsonify({"error": "Unauthorized"}), 401
+
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+
+        cursor.execute("SELECT COUNT(*) FROM user")
+        users = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM invitation")
+        invites = cursor.fetchone()[0]
+
+        now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+
+        cursor.execute("""
+            SELECT COUNT(*) FROM invitation 
+            WHERE used = 0 AND (expires IS NULL OR expires >= ?)
+        """, (now,))
+        pending = cursor.fetchone()[0]
+
+        cursor.execute("""
+            SELECT COUNT(*) FROM invitation 
+            WHERE expires IS NOT NULL AND expires < ?
+        """, (now,))
+        expired = cursor.fetchone()[0]
+
+        conn.close()
+
+        return jsonify({
+            "users": users,
+            "invites": invites,
+            "pending": pending,
+            "expired": expired
+        })
+
+    except Exception as e:
+        traceback.print_exc()
+        return jsonify({"error": str(e)}), 500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
             - ./test-data:/data/database
         environment:
             - TZ=Europe/London
+            #- WIZARR_API_KEY= # Optional: create your own key to enable /api/status endpoint


### PR DESCRIPTION
Created a new blueprint called status to enable an api endpoint /api/status for a widget. Queries database and outputs JSON.
Requires an API Key else is not accessible. This is for use with getHomepage service widgets customapi configuration. If you merge this, then a built in service could be added to Homepage as well. 

    - Wizarr:
        icon: /icons/wizarr.png
        href: "{{HOMEPAGE_VAR_WIZARR_HREF}}"
        #target: _self
        ping: http://wizarr:5690
        description: plex invite manager
        widget:
            type: customapi
            url: http://wizarr:5690/api/status
            refreshInterval: 60000
            method: GET
            display: block
            useProxy: true
            headers:
                X-API-Key: "{{HOMEPAGE_VAR_WIZARR_API}}"
            mappings:
                - field: users
                  label: Users
                  format: number            
                - field: invites
                  label: Invites
                  format: number
                - field: pending
                  label: Pending
                  format: number
                - field: expired
                  label: Expired
                  format: number

![Screenshot 2025-05-28 204407](https://github.com/user-attachments/assets/853d7e7c-9980-4705-8481-438dc2e6b9d4)