### PR TITLE
Fix first load of /admin for Plex server

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -65,7 +65,7 @@
   </div>
 </nav>
 
-<div id="content">
+<div id="content" hx-get="/invite" hx-trigger="load" hx-swap="innerHTML">
   {% include "admin/invite.html" %}
 </div>
 


### PR DESCRIPTION
For Plex servers, the first load of the /admin page would not show the "Invite to Plex Home" and "Allow Downloads" checkboxes. Once clicking the "Home" button, then the options would show up.

This now does `hx-get="/invite"` rather than just the `{% include %}` since the `server_type` wasn't getting fetched/set correctly in the `/admin` route, but it does get fetched/set in `/invite`. The include can be left so that something is shown before the Javascript runs.