### PR TITLE
Plex specific setting defaults (Allow Downloads)

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -32,6 +32,21 @@ def invite():
         .first()
     )
     server_type = server_type_setting.value if server_type_setting else None
+
+    allow_downloads_plex = (
+        Settings.query
+        .filter_by(key="allow_downloads_plex")
+        .first()
+    )
+    allow_downloads_plex = allow_downloads_plex.value if allow_downloads_plex else False
+
+    invite_to_plex_home = (
+        Settings.query
+        .filter_by(key="invite_to_plex_home")
+        .first()
+    )
+    invite_to_plex_home = invite_to_plex_home.value if invite_to_plex_home else False
+
     if request.method == "POST":
         try:
             code = request.form.get("code") or None
@@ -55,6 +70,8 @@ def invite():
             link=link,
             invitations=invitations,
             server_type=server_type,
+            allow_downloads_plex=allow_downloads_plex,
+            invite_to_plex_home=invite_to_plex_home,
         )
 
     # GET
@@ -63,6 +80,8 @@ def invite():
         "admin/invite.html",
         needUpdate=needs_update(),
         server_type=server_type,
+        allow_downloads_plex=allow_downloads_plex,
+        invite_to_plex_home=invite_to_plex_home,
     )
 
 

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -40,13 +40,6 @@ def invite():
     )
     allow_downloads_plex = allow_downloads_plex.value if allow_downloads_plex else False
 
-    invite_to_plex_home = (
-        Settings.query
-        .filter_by(key="invite_to_plex_home")
-        .first()
-    )
-    invite_to_plex_home = invite_to_plex_home.value if invite_to_plex_home else False
-
     if request.method == "POST":
         try:
             code = request.form.get("code") or None
@@ -71,7 +64,6 @@ def invite():
             invitations=invitations,
             server_type=server_type,
             allow_downloads_plex=allow_downloads_plex,
-            invite_to_plex_home=invite_to_plex_home,
         )
 
     # GET
@@ -81,7 +73,6 @@ def invite():
         needUpdate=needs_update(),
         server_type=server_type,
         allow_downloads_plex=allow_downloads_plex,
-        invite_to_plex_home=invite_to_plex_home,
     )
 
 

--- a/app/forms/settings.py
+++ b/app/forms/settings.py
@@ -18,7 +18,6 @@ class SettingsForm(FlaskForm):
     ombi_api_key  = StringField("Ombi API Key",  validators=[Optional()])
     discord_id    = StringField("Discord ID",    validators=[Optional()])
     allow_downloads_plex = BooleanField("Allow Downloads", default=False)
-    invite_to_plex_home = BooleanField("Invite to Plex Home", default=False)
 
     def __init__(self, install_mode: bool = False, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -36,6 +35,5 @@ class SettingsForm(FlaskForm):
         # If server type is not Plex, ensure Plex-specific settings are False
         if self.server_type.data != "plex":
             self.allow_downloads_plex.data = False
-            self.invite_to_plex_home.data = False
 
         return True

--- a/app/forms/settings.py
+++ b/app/forms/settings.py
@@ -1,6 +1,6 @@
 # app/forms/settings.py
 from flask_wtf import FlaskForm
-from wtforms import StringField, SelectField, TextAreaField
+from wtforms import StringField, SelectField, TextAreaField, BooleanField
 from wtforms.validators import DataRequired, Optional, URL
 
 
@@ -17,6 +17,8 @@ class SettingsForm(FlaskForm):
     overseerr_url = StringField("Overseerr/Ombi URL", validators=[Optional(), URL()])
     ombi_api_key  = StringField("Ombi API Key",  validators=[Optional()])
     discord_id    = StringField("Discord ID",    validators=[Optional()])
+    allow_downloads_plex = BooleanField("Allow Downloads", default=False)
+    invite_to_plex_home = BooleanField("Invite to Plex Home", default=False)
 
     def __init__(self, install_mode: bool = False, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -26,3 +28,14 @@ class SettingsForm(FlaskForm):
             self.libraries.validators = [DataRequired()]
             # api_key is mandatory for Plex/Jellyfin
             self.api_key.validators = [DataRequired()]
+
+    def validate(self):
+        if not super().validate():
+            return False
+
+        # If server type is not Plex, ensure Plex-specific settings are False
+        if self.server_type.data != "plex":
+            self.allow_downloads_plex.data = False
+            self.invite_to_plex_home.data = False
+
+        return True

--- a/app/templates/admin/invite.html
+++ b/app/templates/admin/invite.html
@@ -48,7 +48,8 @@
                             {% if server_type == "plex" %}
                                 <div class="flex items-center mb-4">
                                     <input id="plex_home" name="plex_home" type="checkbox" value="  "
-                                           class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+                                           class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                                           {% if invite_to_plex_home %}checked{% endif %}>
                                     <label for="plex_home"
                                            class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300">{{ _("Invite to Plex Home") }}</label>
                                 </div>
@@ -91,7 +92,8 @@
                             {% if server_type == "plex" %}
                                 <div class="flex items-center mb-4">
                                     <input id="allowsync" name="allowsync" type="checkbox" value="  "
-                                           class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+                                           class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
+                                           {% if allow_downloads_plex %}checked{% endif %}>
                                     <label for="allowsync"
                                            class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300">{{ _("Allow Downloads") }}</label>
                                 </div>

--- a/app/templates/admin/invite.html
+++ b/app/templates/admin/invite.html
@@ -48,8 +48,7 @@
                             {% if server_type == "plex" %}
                                 <div class="flex items-center mb-4">
                                     <input id="plex_home" name="plex_home" type="checkbox" value="  "
-                                           class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
-                                           {% if invite_to_plex_home %}checked{% endif %}>
+                                           class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
                                     <label for="plex_home"
                                            class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300">{{ _("Invite to Plex Home") }}</label>
                                 </div>

--- a/app/templates/settings/partials/server_form.html
+++ b/app/templates/settings/partials/server_form.html
@@ -132,15 +132,6 @@
                             <p class="mt-1 text-sm text-red-600 dark:text-red-500">{{ err }}</p>
                         {% endfor %}
                     </div>
-
-                    {# Invite to Plex Home #}
-                    <div class="flex items-center">
-                        {{ form.invite_to_plex_home(class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600") }}
-                        {{ form.invite_to_plex_home.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300") }}
-                        {% for err in form.invite_to_plex_home.errors %}
-                            <p class="mt-1 text-sm text-red-600 dark:text-red-500">{{ err }}</p>
-                        {% endfor %}
-                    </div>
                     {% endif %}
 
                     {# Submit #}

--- a/app/templates/settings/partials/server_form.html
+++ b/app/templates/settings/partials/server_form.html
@@ -123,6 +123,26 @@
                         {% endfor %}
                     </div>
 
+                    {% if form.server_type.data == "plex" %}
+                    {# Allow Downloads #}
+                    <div class="flex items-center">
+                        {{ form.allow_downloads_plex(class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600") }}
+                        {{ form.allow_downloads_plex.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300") }}
+                        {% for err in form.allow_downloads_plex.errors %}
+                            <p class="mt-1 text-sm text-red-600 dark:text-red-500">{{ err }}</p>
+                        {% endfor %}
+                    </div>
+
+                    {# Invite to Plex Home #}
+                    <div class="flex items-center">
+                        {{ form.invite_to_plex_home(class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600") }}
+                        {{ form.invite_to_plex_home.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300") }}
+                        {% for err in form.invite_to_plex_home.errors %}
+                            <p class="mt-1 text-sm text-red-600 dark:text-red-500">{{ err }}</p>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+
                     {# Submit #}
                     <div>
                         <button


### PR DESCRIPTION
Add "Allow Downloads" setting in the server settings so that a default can be set when creating invites. I tried to match all the UI to look right and named it `allow_downloads_plex` since it is specific to the plex server type.