### PR TITLE
Create user/group at runtime in docker-entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,8 @@ ENV PGID=1000
 # Copy the UV binaries from the "astral-sh/uv" image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Install curl (for the HEALTHCHECK), tzdata (if you need timezones), and nodejs (for npm)
-RUN apk add --no-cache curl tzdata nodejs npm
-
-# ─── 1. Create a non-root user and group ────────────────────────────────────
-
-# Create a group called "wizarrgroup" and a user "wizarruser" in that group.
-# Using the environment variables for UID and GID
-RUN addgroup -S -g ${PGID} wizarrgroup && \
-    adduser -S -G wizarrgroup -u ${PUID} wizarruser
+# Install curl (for the HEALTHCHECK), tzdata (if you need timezones), nodejs (for npm), and su-exec for user switching
+RUN apk add --no-cache curl tzdata nodejs npm su-exec
 
 # ─── 2. Copy your application code ──────────────────────────────────────────
 
@@ -25,11 +18,6 @@ WORKDIR /data
 
 # Copy the entire build context (your source code) into /data.
 COPY . /data
-
-
-
-# If you also have files under /opt/default_wizard_steps, make sure that
-# wizarruser can access them too. We'll adjust ownership after we copy them below.
 
 # ─── 3. Run your build steps (still as root) ───────────────────────────────
 
@@ -40,18 +28,11 @@ RUN uv run pybabel compile -d app/translations
 
 RUN npm --prefix app/static/ install
 
-# Ensure that "wizarruser" owns everything in /data, so it can read/write if needed.
-# If your code needs to write to /data (e.g. logs, caches), this is essential.
-RUN chown -R wizarruser:wizarrgroup /data
-
-RUN mkdir /.cache
-RUN chown -R wizarruser:wizarrgroup /.cache
-
+# Create directories that need to be writable
+RUN mkdir -p /.cache
 
 ARG APP_VERSION=dev
 ENV APP_VERSION=${APP_VERSION}
-
-# ─── 4. Copy extra files and fix ownership ─────────────────────────────────
 
 # Healthcheck: curl to localhost:5690/health
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
@@ -60,22 +41,12 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 # Expose port 5690
 EXPOSE 5690
 
-# Copy any wizard steps into /opt and chown them for wizarruser
+# Copy any wizard steps into /opt
 COPY wizard_steps /opt/default_wizard_steps
-RUN chown -R wizarruser:wizarrgroup /opt/default_wizard_steps
 
 # Copy entrypoint script and make it executable
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
-    chown wizarruser:wizarrgroup /usr/local/bin/docker-entrypoint.sh
-
-# ─── 5. Switch to non-root user ─────────────────────────────────────────────
-
-# From now on, everything will run as "wizarruser" (UID 1000).
-#
-# If someone does `docker run --user 2000:3000 ...`,
-# Docker will override this and run as UID 2000 inside the container.
-USER wizarruser
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Entrypoint and default CMD
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,37 @@
 #!/usr/bin/env sh
 set -eu
 
+echo "[entrypoint] 🚀 Starting Wizarr container..."
+
 # ─────────────────────────────────────────────────────────────────────────────
-# 1) Seed wizard steps if the target is truly empty (no visible files at all)
+# 1) Handle PUID/PGID setup (only if running as root)
+# ─────────────────────────────────────────────────────────────────────────────
+# Default values
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+if [ "$(id -u)" = "0" ]; then
+    echo "[entrypoint] 👤 Setting up user environment with PUID=$PUID and PGID=$PGID"
+    
+    # Create group and user
+    addgroup -S -g "$PGID" wizarrgroup
+    adduser -S -G wizarrgroup -u "$PUID" wizarruser
+    
+    # Fix ownership of important directories
+    echo "[entrypoint] 🔧 Fixing ownership of directories..."
+    chown -R wizarruser:wizarrgroup /data
+    chown -R wizarruser:wizarrgroup /.cache
+    chown -R wizarruser:wizarrgroup /opt/default_wizard_steps
+    
+    # Switch to wizarruser and re-execute this script
+    echo "[entrypoint] 🔄 Switching to wizarruser..."
+    exec su-exec wizarruser "$0" "$@"
+fi
+
+echo "[entrypoint] 👤 Running as user $(id -u):$(id -g)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2) Seed wizard steps if the target is truly empty (no visible files at all)
 # ─────────────────────────────────────────────────────────────────────────────
 TARGET=/data/wizard_steps
 DEFAULT=/opt/default_wizard_steps
@@ -19,7 +48,7 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 2) Legacy DB rename + migrations + import
+# 3) Legacy DB rename + migrations + import
 # ─────────────────────────────────────────────────────────────────────────────
 echo "[entrypoint] 🔄 Renaming legacy database (if any)…"
 uv run python -m app.legacy_migration.rename_legacy
@@ -31,6 +60,6 @@ echo "[entrypoint] 🗄️ Importing legacy data…"
 uv run python -m app.legacy_migration.import_legacy
 
 # ─────────────────────────────────────────────────────────────────────────────
-# 3) Hand off to your CMD (e.g. gunicorn)
+# 4) Hand off to your CMD (e.g. gunicorn)
 # ─────────────────────────────────────────────────────────────────────────────
 exec "$@"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,13 +20,14 @@ services:
   wizarr:
     container_name: wizarr
     image: ghcr.io/wizarrrr/wizarr
-    user: 1000:1000 #Set UID/GID
     ports:
       - 5690:5690
     volumes:
       - /path/to/appdata/config/database:/data/database
       - /path/to/appdata/config/wizard:/data/wizard_steps
     environment:
+      - PUID=1000 #Set UID
+      - PGID=1000 #Set GID
       - DISABLE_BUILTIN_AUTH=false #Set to true ONLY if you are using another auth provider (Authelia, Authentik, etc)
       - TZ=Europe/London #Set your timezone here
 ```


### PR DESCRIPTION
Sorry for the multiple PRs on this, I didn't understand how to properly set user/group in Docker until now. 😅

The changes that were made to the Dockerfile didn't quite work since environment variables set at runtime won't change anything that uses them in the Dockerfile. So the user/group creation needs to happen in the `docker-entrypoint.sh` script so that if the user/group is set as an environment variable it will create the user/group properly and take ownership of the required folders.

I still need to test this further (specifically if this fixes the issues I have been having running Wizarr on my TrueNAS machine), but this should be the correct way to do this.