### PR TITLE
Add user filtering and search

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -150,7 +150,8 @@ def users_table():
         users = list_users() or []
     except Exception as exc:
         logging.error("Error fetching users: %s", exc)
-    return render_template("tables/user_card.html", users=users)
+    now = datetime.datetime.now()
+    return render_template("tables/user_card.html", users=users, now=now)
 
 
 @admin_bp.route("/user/<int:db_id>", methods=["GET", "POST"])
@@ -170,7 +171,8 @@ def user_detail(db_id: int):
         # Re-render the grid the same way /users/table does
 
         users = list_users(clear_cache=True)
-        return render_template("tables/user_card.html", users=users)
+        now = datetime.datetime.now()
+        return render_template("tables/user_card.html", users=users, now=now)
 
     # ── GET → serve the compact modal ─────────────────────────────
     return render_template("admin/user_modal.html", user=user)

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -3,16 +3,18 @@
         <div hx-get="/users/table" hx-trigger="load" hx-target="#user_table" hx-swap="outerHTML"
             class="p-4 mb-6 rounded-lg overflow-x-auto ">
             <div class="relative sm:rounded-lg">
-                <div class="hidden flex px-5 py-5 items-center justify-between pb-4 bg-white dark:bg-gray-900">
-                    <div >
-                        <select disabled id="action"
-                            class="hidden bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
-                            <option selected>Action (currently unavailable)</option>
-                            <option>Delete</option>
+                <div class="flex px-5 py-5 items-center justify-between pb-4 bg-white dark:bg-gray-900">
+                    <div>
+                        <label for="status-filter" class="sr-only">Filter</label>
+                        <select id="status-filter"
+                            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+                            <option value="all">{{ _("All") }}</option>
+                            <option value="active">{{ _("Active") }}</option>
+                            <option value="expired">{{ _("Expired") }}</option>
                         </select>
                     </div>
 
-                    <label for="table-search" class="sr-only">Search</label>
+                    <label for="table-search-users" class="sr-only">Search</label>
                     <div class="relative">
                         <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
                             <svg class="w-5 h-5 text-gray-500 dark:text-gray-400" aria-hidden="true" fill="currentColor"
@@ -23,8 +25,8 @@
                             </svg>
                         </div>
                         <input type="text" id="table-search-users"
-                            class="hidden block p-2 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg w-80 bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                            placeholder="Search for users">
+                            class="block p-2 pl-10 text-sm text-gray-900 border border-gray-300 rounded-lg w-80 bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                            placeholder="{{ _('Search for users') }}">
                     </div>
                 </div>
                 <div id="user_table">
@@ -88,4 +90,49 @@
         }
     }
 
+</script>
+<script>
+    function setupUserFilter() {
+        const search = document.getElementById('table-search-users');
+        const filter = document.getElementById('status-filter');
+        if (!search || !filter) return;
+
+        function applyFilter() {
+            const query = search.value.toLowerCase();
+            const status = filter.value;
+            const cards = document.querySelectorAll('#user_table .user-card');
+            let any = false;
+            cards.forEach(card => {
+                const username = card.dataset.username;
+                const email = card.dataset.email;
+                const expired = card.dataset.expired === 'true';
+                const matchesSearch = username.includes(query) || email.includes(query);
+                const matchesStatus = status === 'all' || (status === 'active' && !expired) || (status === 'expired' && expired);
+                if (matchesSearch && matchesStatus) {
+                    card.classList.remove('hidden');
+                    any = true;
+                } else {
+                    card.classList.add('hidden');
+                }
+            });
+            const noRes = document.getElementById('no_results');
+            if (noRes) {
+                if (any) {
+                    noRes.classList.add('hidden');
+                } else {
+                    noRes.classList.remove('hidden');
+                }
+            }
+        }
+
+        search.addEventListener('input', applyFilter);
+        filter.addEventListener('change', applyFilter);
+        applyFilter();
+    }
+
+    document.body.addEventListener('htmx:afterSwap', function(evt) {
+        if (evt.detail.target.id === 'user_table') {
+            setupUserFilter();
+        }
+    });
 </script>

--- a/app/templates/tables/user_card.html
+++ b/app/templates/tables/user_card.html
@@ -4,7 +4,10 @@
     {% else %}
     
     {% for user in users %}
-    <div class="mb-4 animate__animated flex flex-col justify-between bg-white dark:bg-gray-800 dark:border-gray-700 rounded-lg shadow-xs overflow-hidden border border-gray-200 dark:border-gray-700">
+    <div class="user-card mb-4 animate__animated flex flex-col justify-between bg-white dark:bg-gray-800 dark:border-gray-700 rounded-lg shadow-xs overflow-hidden border border-gray-200 dark:border-gray-700"
+         data-username="{{ user.username|lower }}"
+         data-email="{{ user.email|lower }}"
+         data-expired="{% if user.expires and user.expires < now %}true{% else %}false{% endif %}">
         <div class="p-4">
             <!-- Header with username and photo -->
             <div class="flex items-center mb-3">
@@ -94,7 +97,9 @@
             </button>
         </div>
     </div>
+    </div>
     {% endfor %}
+    <p id="no_results" class="hidden text-center col-span-full dark:text-white">{{ _("No users match your filters.") }}</p>
     {% endif %}
 </div>
 


### PR DESCRIPTION
## Summary
- add dataset attributes and no-results placeholder to user card template
- add filtering dropdown and search input to users page
- implement client-side filtering logic
- supply current time for templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684701ec69208328976e4867a79cf9fa