### PR TITLE
Fix settings page not loading when using reverse proxy with https

### DIFF
--- a/app/blueprints/settings/routes.py
+++ b/app/blueprints/settings/routes.py
@@ -50,7 +50,7 @@ def _check_server_connection(data: dict) -> bool:
         return check_plex(data["server_url"], data["api_key"])
     return check_jellyfin(data["server_url"], data["api_key"])
 
-@settings_bp.get("/")
+@settings_bp.get("")
 @login_required
 def page():
     return render_template("settings/index.html")


### PR DESCRIPTION
The issue was that `/settings` was redirecting to `/settings/` and that redirect was causing issues with https (and the settings html request was unique in this regard compared to the other pages because of the `url_prefix`). I don't currently have a way to test with a reverse proxy locally, but this should fix it.

https://github.com/wizarrrr/wizarr/issues/592