### PR TITLE
Restrict wizard access

### DIFF
--- a/app/blueprints/emby/routes.py
+++ b/app/blueprints/emby/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify, abort, render_template, redirect
+from flask import Blueprint, request, jsonify, abort, render_template, redirect, session
 from flask_login import login_required
 import logging
 import datetime
@@ -51,6 +51,7 @@ def public_join():
             code=form.code.data,
         )
         if ok:
+            session["wizard_access"] = form.code.data
             return redirect("/wizard/")
         error = msg
     else:

--- a/app/blueprints/jellyfin/routes.py
+++ b/app/blueprints/jellyfin/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify, abort, render_template, redirect
+from flask import Blueprint, request, jsonify, abort, render_template, redirect, session
 from flask_login import login_required
 from app.services.media.jellyfin import JellyfinClient
 from app.forms.join import JoinForm
@@ -43,6 +43,7 @@ def public_join():
             code=form.code.data,
         )
         if ok:
+            session["wizard_access"] = form.code.data
             return redirect("/wizard/")
         error = msg
     else:

--- a/app/blueprints/public/routes.py
+++ b/app/blueprints/public/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, redirect, render_template, send_from_directory, request, jsonify, url_for
+from flask import Blueprint, redirect, render_template, send_from_directory, request, jsonify, url_for, session
 import os, threading
 from app.extensions import db
 from app.models import Settings
@@ -83,6 +83,7 @@ def join():
             args=(app, token, code),
             daemon=True
         ).start()
+        session["wizard_access"] = code
         return redirect(url_for("wizard.start"))
     elif server_type == "jellyfin" or server_type == "emby":
         return render_template("welcome-jellyfin.html", code=code, server_type=server_type)

--- a/app/blueprints/wizard/routes.py
+++ b/app/blueprints/wizard/routes.py
@@ -1,13 +1,22 @@
 from flask_babel import _
 from pathlib import Path
 import frontmatter, markdown
-from flask import Blueprint, render_template, abort, request
+from flask import Blueprint, render_template, abort, request, session, redirect
+from flask_login import current_user
 from app.models import Settings
 from app.services.ombi_client import run_all_importers
 
 
 wizard_bp = Blueprint("wizard", __name__, url_prefix="/wizard")
 BASE_DIR  = Path(__file__).resolve().parent.parent.parent.parent / "wizard_steps"
+
+# Only allow access right after signup or when logged in
+@wizard_bp.before_request
+def restrict_wizard():
+    if current_user.is_authenticated:
+        return
+    if not session.get("wizard_access"):
+        return redirect("/")
 
 
 # ─── helpers ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- allow wizard access only for logged in users or new signups
- mark new signups in session so the wizard works once authentication completes

## Testing
- `uv sync --locked`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68485f0da41883288989a3d99d9b4c73