### PR TITLE
Code placeholder now shows example with correct length

### DIFF
--- a/app/templates/admin/invite.html
+++ b/app/templates/admin/invite.html
@@ -24,14 +24,13 @@
                             </label>
                             <input
                                 minlength="6"
-                                maxlength="12"
                                 type="text"
                                 name="code"
                                 id="code"
                                 class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg
                        focus:ring-primary focus:border-primary block w-full p-2.5
                        dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary"
-                                placeholder="XMFGEJI"
+                                placeholder="E.g. XMFGEJIKNQ"
                             >
                         </div>
 

--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -27,9 +27,9 @@
                     <div>
                         <label for="code" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{
                             _("Invite Code") }}</label>
-                        <input type="code" name="code" id="code"
+                        <input minlength="6" type="code" name="code" id="code"
                             class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                            placeholder="XMFGEJI" value="{{ code }}" required="">
+                            placeholder="E.g. XMFGEJIKNQ" value="{{ code }}" required="">
                         <input type="hidden" name="token" id="token" value="">
                     </div>
                     {% endif %}
@@ -39,9 +39,9 @@
                             class="block mb-2 text-sm font-medium text-red-700 dark:text-red-500">{{
                             _("Invite Code")
                             }}</label>
-                        <input type="code" name="code" id="code" minlength="6" maxlength="6"
+                        <input minlength="6" type="code" name="code" id="code"
                             class="bg-red-50 border border-red-500 text-red-900 placeholder-red-700 text-sm rounded-lg focus:ring-red-500 focus:border-red-500 block w-full p-2.5 dark:bg-red-100 dark:border-red-400"
-                            placeholder="XMFGEJI" required="">
+                            placeholder="E.g. XMFGEJIKNQ" required="">
                         <p class="mt-2 text-sm text-red-600 dark:text-red-500"><span class="font-medium">{{ _("Oops!")
                                 }}</span>
                             {{ code_error }}</p>


### PR DESCRIPTION
https://github.com/wizarrrr/wizarr/pull/589 updated the code to be 10 characters long, and this updates the UI to reflect this change.

It also removes the code length limit since it isn't really needed and wasn't being enforced everywhere anyways.

<img width="413" alt="image" src="https://github.com/user-attachments/assets/dcdc3643-c930-434a-b0e2-498d5bce1024" />
