### PR TITLE
Fix API calls for JF / Emby being positional with **kwargs

### DIFF
--- a/app/services/media/emby.py
+++ b/app/services/media/emby.py
@@ -22,7 +22,7 @@ class EmbyClient(JellyfinClient):
     def create_user(self, username: str, password: str) -> str:
         """Create user and set password"""
         # Step 1: Create user without password
-        user = self.post("/Users/New", {"Name": username}).json()
+        user = self.post("/Users/New", json={"Name": username}).json()
         user_id = user["Id"]
         
         # Step 2: Set password
@@ -30,7 +30,7 @@ class EmbyClient(JellyfinClient):
             logging.info(f"Setting password for user {username} (ID: {user_id})")
             password_response = self.post(
                 f"/Users/{user_id}/Password",
-                {
+                json={
                     "NewPw": password,
                     "CurrentPw": "",  # No current password for new users
                     "ResetPassword": False  # Important! Don't reset password

--- a/app/services/media/jellyfin.py
+++ b/app/services/media/jellyfin.py
@@ -41,11 +41,11 @@ class JellyfinClient(RestApiMixin):
     def create_user(self, username: str, password: str) -> str:
         return self.post(
             "/Users/New",
-            {"Name": username, "Password": password}
+            json={"Name": username, "Password": password}
         ).json()["Id"]
 
     def set_policy(self, user_id: str, policy: dict) -> None:
-        self.post(f"/Users/{user_id}/Policy", policy)
+        self.post(f"/Users/{user_id}/Policy", json=policy)
 
     def delete_user(self, user_id: str) -> None:
         self.delete(f"/Users/{user_id}")
@@ -68,7 +68,7 @@ class JellyfinClient(RestApiMixin):
                         val = [] if val == "" else val.split(", ")
                     current[section][key] = val
 
-        return self.post(f"/Users/{jf_id}", current).json()
+        return self.post(f"/Users/{jf_id}", json=current).json()
 
     def list_users(self) -> list[User]:
         """Sync users from Jellyfin into the local DB and return the list of User records."""


### PR DESCRIPTION
This pull request fixes the API requests made in `emby.py` and `jellyfin.py` scripts to work with `**kwargs` in `client-base.py` as the payload was previously positional. I've changed the payload to explicitly define it as a `json` parameter which fixed an issue I encountered where I was unable to create a new Jellyfin user due to 3 positional arguments being given.
> [!IMPORTANT]
> Jellyfin and Emby having the same problem is a coincidence, it's just the other servers implemented already defined the params correctly
## Errors fixed
### Create User
> cant find it, although its the same thing as set policy
### Set Policy (appears after patching create user)
```
Traceback (most recent call last):
  File "/home/vera/PycharmProjects/wizarr/app/services/media/jellyfin.py", line 188, in join
    self._set_specific_folders(user_id, sections)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/vera/PycharmProjects/wizarr/app/services/media/jellyfin.py", line 150, in _set_specific_folders
    self.set_policy(user_id, current)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/vera/PycharmProjects/wizarr/app/services/media/jellyfin.py", line 48, in set_policy
    self.post(f"/Users/{user_id}/Policy", policy)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: RestApiMixin.post() takes 2 positional arguments but 3 were given
```
> [!NOTE]
> This is my first time contributing to FOSS, how'd I do?