### PR TITLE
Update auth/routes.py

### DIFF
--- a/app/blueprints/auth/routes.py
+++ b/app/blueprints/auth/routes.py
@@ -47,7 +47,12 @@ def login():
         login_user(AdminUser(), remember=bool(request.form.get("remember")))
         return redirect("/")
 
-    logging.warning("Failed login for user %s", username)
+    # Get IP address from headers or fallback to remote_addr
+    client_ip = request.headers.get("X-Forwarded-For", request.remote_addr).split(",")[0].strip()
+
+    # Log failed login with IP
+    logging.warning(f"AUTH FAIL: Failed login for user '{username}' from {client_ip}")
+
     return render_template("login.html", error=_("Invalid username or password"))
 
 


### PR DESCRIPTION
Added IP address in logs for login auth. Helpful for banning IP's on failed attempts with fail2ban etc.

EXAMPLE REGEX:

wizarr-auth.conf
[Definition]
failregex = ^.*AUTH FAIL: Failed login for user '.*' from <HOST>$
