### PR TITLE
Update logging_config.py

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -21,7 +21,7 @@ LOGGING_CONFIG = {
         # ○ add a rotating-file handler if you fancy
         # "file": {
         #     "class": "logging.handlers.RotatingFileHandler",
-        #     "filename": Path(__file__).resolve().parent.parent / "logs" / "app.log",
+        #     "filename": str(Path(__file__).resolve().parent.parent / "logs" / "wizarr.log"),
         #     "maxBytes": 5_000_000,
         #     "backupCount": 3,
         #     "formatter": "default",
@@ -43,4 +43,8 @@ LOGGING_CONFIG = {
 
 def configure_logging() -> None:
     """Call this once at start-up."""
+    if "file" in LOGGING_CONFIG.get("handlers", {}):
+        log_path = Path(LOGGING_CONFIG["handlers"]["file"]["filename"])
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
     logging.config.dictConfig(LOGGING_CONFIG)


### PR DESCRIPTION
Created a directory check for "logs" if the file handler is uncommented. Renamed log for clarity.

Fixes a startup crash when the "file" logging handler is enabled but the logs/ directory does not exist.

Previously, if file logging was enabled and the logs/ directory was missing, the app would raise a FileNotFoundError on startup.

This change ensures the logs/ directory is created automatically if and only if the "file" handler is configured.

