### PR TITLE
fix: use universal column to create invite

### DIFF
--- a/app/services/invites.py
+++ b/app/services/invites.py
@@ -88,8 +88,8 @@ def create_invite(form: Any) -> Invitation:
         wizard_bundle_id=(int(form.get("wizard_bundle_id")) if form.get("wizard_bundle_id") else None),
         
         # New Jellyfin flags
-        jellyfin_allow_downloads=bool(form.get("jellyfin_allow_downloads")),
-        jellyfin_allow_live_tv=bool(form.get("jellyfin_allow_live_tv")),
+        allow_downloads=bool(form.get("jellyfin_allow_downloads")),
+        allow_live_tv=bool(form.get("jellyfin_allow_live_tv")),
     )
     db.session.add(invite)
     db.session.flush()  # so invite.id exists, but not yet committed


### PR DESCRIPTION
This fixes a recent issue that an invitation to jellyfin wasn't able to get created cause it wasn't using the new universal columns introduced in https://github.com/wizarrrr/wizarr/commit/b36e417a9f1dff15b811350802e6d515616fe80f

Was showing this log previously on latest master commit:

```
Traceback (most recent call last):
  File "/data/.venv/lib/python3.13/site-packages/gunicorn/workers/sync.py", line 134, in handle
    self.handle_request(listener, req, client, addr)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/.venv/lib/python3.13/site-packages/gunicorn/workers/sync.py", line 177, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 1536, in __call__
    return self.wsgi_app(environ, start_response)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 1514, in wsgi_app
    response = self.handle_exception(e)
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/data/.venv/lib/python3.13/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/data/app/blueprints/admin/routes.py", line 89, in invite
    invite = create_invite(request.form)
  File "/data/app/services/invites.py", line 76, in create_invite
    invite = Invitation(
        code=code,
    ...<14 lines>...
        jellyfin_allow_live_tv=bool(form.get("jellyfin_allow_live_tv")),
    )
  File "<string>", line 4, in __init__
  File "/data/.venv/lib/python3.13/site-packages/sqlalchemy/orm/state.py", line 571, in _initialize_instance
    with util.safe_reraise():
         ~~~~~~~~~~~~~~~~~^^
  File "/data/.venv/lib/python3.13/site-packages/sqlalchemy/util/langhelpers.py", line 224, in __exit__
    raise exc_value.with_traceback(exc_tb)
  File "/data/.venv/lib/python3.13/site-packages/sqlalchemy/orm/state.py", line 569, in _initialize_instance
    manager.original_init(*mixed[1:], **kwargs)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/data/.venv/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 2173, in _declarative_constructor
    raise TypeError(
        "%r is an invalid keyword argument for %s" % (k, cls_.__name__)
    )
TypeError: 'jellyfin_allow_downloads' is an invalid keyword argument for Invitation
[2025-07-15 11:58:09 +0700] [69] [ERROR] Error handling request /invite
Traceback (most recent call last):
  File "/data/.venv/lib/python3.13/site-packages/gunicorn/workers/sync.py", line 134, in handle
    self.handle_request(listener, req, client, addr)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/.venv/lib/python3.13/site-packages/gunicorn/workers/sync.py", line 177, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 1536, in __call__
    return self.wsgi_app(environ, start_response)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 1514, in wsgi_app
    response = self.handle_exception(e)
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/data/.venv/lib/python3.13/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/data/.venv/lib/python3.13/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/data/app/blueprints/admin/routes.py", line 89, in invite
    invite = create_invite(request.form)
  File "/data/app/services/invites.py", line 76, in create_invite
    invite = Invitation(
        code=code,
    ...<14 lines>...
        jellyfin_allow_live_tv=bool(form.get("jellyfin_allow_live_tv")),
    )
  File "<string>", line 4, in __init__
  File "/data/.venv/lib/python3.13/site-packages/sqlalchemy/orm/state.py", line 571, in _initialize_instance
    with util.safe_reraise():
         ~~~~~~~~~~~~~~~~~^^
  File "/data/.venv/lib/python3.13/site-packages/sqlalchemy/util/langhelpers.py", line 224, in __exit__
    raise exc_value.with_traceback(exc_tb)
  File "/data/.venv/lib/python3.13/site-packages/sqlalchemy/orm/state.py", line 569, in _initialize_instance
    manager.original_init(*mixed[1:], **kwargs)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/data/.venv/lib/python3.13/site-packages/sqlalchemy/orm/decl_base.py", line 2173, in _declarative_constructor
    raise TypeError(
        "%r is an invalid keyword argument for %s" % (k, cls_.__name__)
    )
TypeError: 'jellyfin_allow_downloads' is an invalid keyword argument for Invitation
```

