### PR TITLE
Fix: Correct Plex Session Status Detection (Direct Streaming vs Transcoding)

### DIFF
--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -375,14 +375,39 @@ class PlexClient(MediaClient):
                 if artwork_url is None and thumb_url:
                     artwork_url = thumb_url
 
-                transcode_sessions = getattr(session, "transcodeSessions", [])
-                is_transcoding = bool(transcode_sessions)
+                # Check for transcoding using Plex API structure
+                is_transcoding = False
                 transcode_speed = None
-                if is_transcoding and transcode_sessions:
-                    transcode_speed = getattr(transcode_sessions[0], "speed", None)
+                media_list = getattr(session, "media", [])
+
+                # Method 1: Check for TranscodeSession using python-plexapi properties
+                # This is the most reliable method as it directly reflects the actual transcoding state
+                transcode_session = getattr(session, "transcodeSession", None)
+                if transcode_session:
+                    # TranscodeSession object has videoDecision and audioDecision attributes
+                    video_decision = getattr(transcode_session, "videoDecision", None)
+                    audio_decision = getattr(transcode_session, "audioDecision", None)
+
+                    # Only consider it transcoding if either video or audio is actually being transcoded
+                    # "copy" and "direct" mean no transcoding is happening
+                    if video_decision == "transcode" or audio_decision == "transcode":
+                        is_transcoding = True
+                        transcode_speed = getattr(transcode_session, "speed", None)
+
+                # Method 2: Check transcodeSessions list property (fallback)
+                if not is_transcoding and not transcode_session:
+                    transcode_sessions = getattr(session, "transcodeSessions", [])
+                    if transcode_sessions:
+                        # Check each transcode session for actual transcoding
+                        for ts in transcode_sessions:
+                            ts_video_decision = getattr(ts, "videoDecision", None)
+                            ts_audio_decision = getattr(ts, "audioDecision", None)
+                            if ts_video_decision == "transcode" or ts_audio_decision == "transcode":
+                                is_transcoding = True
+                                transcode_speed = getattr(ts, "speed", None)
+                                break
 
                 video_codec = audio_codec = container = video_resolution = None
-                media_list = getattr(session, "media", None)
                 if media_list:
                     media_obj = media_list[0]
                     video_codec = getattr(media_obj, "videoCodec", None)


### PR DESCRIPTION
**Fixes #723 — Plex always shows as transcoding**

### Problem

Plex sessions always display as “transcoding” even when they are direct streaming.

### Solution

- Adjusted the detection logic for Plex sessions to correctly distinguish between transcoding and direct streaming.
- Updated relevant functions/components to ensure accurate status reporting.

### Details

- Modified how the session type is determined based on Plex API responses.
- Added/updated unit tests to cover direct streaming scenarios.

### Screenshots

<img width="303" height="426" alt="Screenshot 2025-07-19 105122" src="https://github.com/user-attachments/assets/e8358461-70e9-458b-ab97-43b17e9ac0e0" />

<img width="415" height="215" alt="Screenshot 2025-07-19 105128" src="https://github.com/user-attachments/assets/28fcdc65-21a3-4e46-b6a9-cd1e095f6ed0" />
<img width="297" height="427" alt="image" src="https://github.com/user-attachments/assets/22128c46-fa01-4d6b-b24c-473828d82e85" />
<img width="417" height="211" alt="image" src="https://github.com/user-attachments/assets/c1f900f9-15c7-444a-bb7f-3140bc835bfe" />

