### PR TITLE
fix: sponsor carousel displaying over modal backdrop

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -126,7 +126,7 @@
             </div>
         </header>
 
-        <div id="content" class="flex-1 overflow-y-auto pb-16 md:pb-0"></div>
+        <div id="content" class="flex-1 z-10 overflow-y-auto pb-16 md:pb-0"></div>
 
         <!-- Mobile Bottom Navigation -->
         <nav class="md:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 z-50">


### PR DESCRIPTION
This pr fixes the sponsor carousel displaying over modals on the admin dashboard. The carousel would block elements in modals depending on window size and would not be blurred by the backdrop.