### PR TITLE
Modify last migration to use 'name' instead of 'server_name' in SQL query, making migration pass

### DIFF
--- a/migrations/versions/20250729_squashed_connections_expiry_system.py
+++ b/migrations/versions/20250729_squashed_connections_expiry_system.py
@@ -104,7 +104,7 @@ def upgrade():
         # Get all Plex and Emby servers
         servers_result = connection.execute(
             text(
-                "SELECT id, server_name FROM media_server WHERE server_type IN ('plex', 'emby')"
+                "SELECT id, name FROM media_server WHERE server_type IN ('plex', 'emby')"
             )
         )
 


### PR DESCRIPTION
The latest commit  (de4e70b) containing a migration refers to a "server_name" column in the media_server table, which does not exist. The original name is "name". Changing this query makes the migration succeed. Fixes #748 but I'd like some more tests.

Cheers