### PR TITLE
Fix Plex user count for server stats

### DIFF
--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -634,9 +634,9 @@ class PlexClient(MediaClient):
             transcode_sessions = self.server.transcodeSessions()
 
             try:
-                users = self.server.myPlexAccount().users()
+                users = self.list_users()
                 stats["user_stats"] = {
-                    "total_users": len(users) + 1,
+                    "total_users": len(users),
                     "active_sessions": len(sessions),
                 }
             except Exception as e:


### PR DESCRIPTION
## Summary
- count Plex server users via existing `list_users` method

## Testing
- `pytest` *(fails: 1 failed, 170 passed, 1 skipped, 9 errors; playwright missing browser deps)*

------
https://chatgpt.com/codex/tasks/task_e_68a23883a2d8832893741f5af7380d64