### PR TITLE
RC v2025.9.1-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.9.0",
+  "version": "2025.9.1-rc.1",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.9.0"
+version = "2025.9.1-rc.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -84,7 +84,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.8.4"
+version = "2025.9.1-rc.1"
 version_files = [
     "pyproject.toml:version"
 ]


### PR DESCRIPTION
# 🧪 Release Candidate v2025.9.1-rc.1

## What's Changed

### 🚀 Features
- implement dual PR workflow with RC and Release branches

### 🐛 Bug Fixes  
- redirect log messages to stderr to avoid contaminating function output
- get only first version line from pyproject.toml
- correct bash regex syntax in CalVer automation script

### 📝 Other Changes
- feat: use RELEASE_PLEASE_TOKEN to trigger CI workflows on release PRs

---

## Beta Testing Phase

**Merge this PR when**: You're ~90% confident and ready for beta/staging deployment

**This will**:
- Create GitHub pre-release `v2025.9.1-rc.1`
- Deploy to staging/beta environment  
- Build Docker images with `:rc` and `:beta` tags
- Notify beta testers

**Next steps**: After beta validation, merge the main Release PR for production

---

🤖 Auto-generated by CalVer Automation