### PR TITLE
RC v2025.9.2-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.9.1-rc.1",
+  "version": "2025.9.2-rc.1",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.9.1-rc.1"
+version = "2025.9.2-rc.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -84,7 +84,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.9.1-rc.1"
+version = "2025.9.2-rc.1"
 version_files = [
     "pyproject.toml:version"
 ]


### PR DESCRIPTION
# 🧪 Release Candidate v2025.9.2-rc.1

## What's Changed

### 🚀 Features
- remove RC workflow and simplify to stable releases only
- UI speedup
- implement wizard step interaction requirement system
- implement dual PR workflow with RC and Release branches
- complete migration chaos solution with full renaming
- use RELEASE_PLEASE_TOKEN to trigger CI workflows on release PRs
- implement CalVer automation with release PR generation and changelog

### 🐛 Bug Fixes
- handle RC versions in CalVer automation version parsing
- ensure release branches are always up-to-date with main
- clarify handling of server-specific expiry during user edits
- failing tests
- resolve test failures and lint issues
- implement changes requested from automated code reviews
- test invitation performance
- prevent unlimited invitation users from being incorrectly linked by identity
- use uv run for migration name checker in Docker entrypoint
- resolve remaining linting issues in migration scripts
- migration test
- redirect log messages to stderr to avoid contaminating function output
- get only first version line from pyproject.toml
- correct bash regex syntax in CalVer automation script
- user modal delete
- bug in using delete modal

### 📝 Other Changes
- GITBOOK-14: No subject
- build(deps): bump htmx.org from 2.0.6 to 2.0.7 in /app/static
- i18n: refresh POT [skip ci]
- build(deps): bump plexapi from 4.17.0 to 4.17.1
- build(deps): bump playwright from 1.54.0 to 1.55.0
- build(deps): bump cachetools from 6.1.0 to 6.2.0
- build(deps): bump ruff from 0.12.10 to 0.12.12
- build(deps): bump markdown from 3.8.2 to 3.9
- i18n: refresh POT [skip ci]
- i18n: refresh POT [skip ci]
- cleanup: remove unnecessary migration scripts and complexity
- i18n: refresh POT [skip ci]
- remove: completely remove Release-It setup


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.9.1-rc.1...v2025.9.2

---

## Beta Testing Phase

**Merge this PR when**: You're ~90% confident and ready for beta/staging deployment

**This will**:
- Create GitHub pre-release `v2025.9.2-rc.1`
- Deploy to staging/beta environment  
- Build Docker images with `:rc` and `:beta` tags
- Notify beta testers

**Next steps**: After beta validation, merge the main Release PR for production

---

🤖 Auto-generated by CalVer Automation