### PR TITLE
Release v2025.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.9.4",
+  "version": "2025.9.5",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.9.4"
+version = "2025.9.5"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -84,7 +84,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.9.4"
+version = "2025.9.5"
 version_files = [
     "pyproject.toml:version"
 ]


### PR DESCRIPTION
# 🚀 Stable Release v2025.9.5

## What's Changed

### 📝 Other Changes
- i18n: refresh POT [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.9.4...v2025.9.5

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.9.5`
- Deploy to production
- Build Docker images with `:latest` and `v2025.9.5` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation