### PR TITLE
Release v2025.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.9.4",
+  "version": "2025.9.5",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.9.4"
+version = "2025.9.5"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -84,7 +84,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.9.4"
+version = "2025.9.5"
 version_files = [
     "pyproject.toml:version"
 ]


### PR DESCRIPTION
# 🚀 Stable Release v2025.9.5

## What's Changed

### 🐛 Bug Fixes
- update automation working
- audiobookshelf admin policy

### 🔧 Build System / Dependencies
- bump ruff from 0.12.12 to 0.13.0
- bump ty from 0.0.1a19 to 0.0.1a20
- bump pytest-playwright from 0.7.0 to 0.7.1
- bump webauthn from 2.6.0 to 2.7.0
- bump pyright from 1.1.404 to 1.1.405
- bump pytest from 8.4.1 to 8.4.2

### 📝 Other Changes
- i18n: refresh POT [skip ci]
- i18n: refresh POT [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.9.4...v2025.9.5

## 📋 All Commits Included (11 commits)

<details>
<summary>Click to expand commit list</summary>

```
7262b6a6 chore: release v2025.9.5
67e20181 fix: update automation working
6909e3c5 fix: audiobookshelf admin policy
aa90afd9 build(deps): bump ruff from 0.12.12 to 0.13.0
741a066f build(deps): bump ty from 0.0.1a19 to 0.0.1a20
67824ae1 build(deps): bump pytest-playwright from 0.7.0 to 0.7.1
598e756b build(deps): bump webauthn from 2.6.0 to 2.7.0
92117638 build(deps): bump pyright from 1.1.404 to 1.1.405
e89305ec build(deps): bump pytest from 8.4.1 to 8.4.2
034a3d5e i18n: refresh POT [skip ci]
9d59292e i18n: refresh POT [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.9.5`
- Deploy to production
- Build Docker images with `:latest` and `v2025.9.5` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation