### PR TITLE
Release v2025.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.9.7",
+  "version": "2025.10.0",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.9.7"
+version = "2025.10.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -85,7 +85,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.9.7"
+version = "2025.10.0"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1428,7 +1428,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.9.7"
+version = "2025.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.10.0

## What's Changed

### 🚀 Features
- enhance wizard presets and widgets with improved templates and styles
- implement mobile optimization and enhance wizard navigation with swipe gestures
- add progress indicator closes Feature Request: Add a progress indicator to steps closes #861
- add user disable functionality and integrate with media server service

### 🐛 Bug Fixes
- update wizarr version to 2025.9.7 in uv.lock
- streamline YAML file checking by using uv to run the Python script

### ♻️ Code Refactoring
- enhance widget rendering with context and improve markdown content for Audiobookshelf
- fix ruff linting and ty type errors

### 🔧 Build System / Dependencies
- bump the ui-frameworks group
- bump the flask-ecosystem group across 1 directory with 2 updates
- bump ruff from 0.13.1 to 0.13.2 in the linting-tools group
- bump pyyaml from 6.0.2 to 6.0.3

### 📝 Other Changes
- i18n: refresh POT [skip ci]
- i18n: refresh POT [skip ci]
- i18n: refresh POT [skip ci]
- i18n: refresh POT [skip ci]
- Translated using Weblate (French)
- Translated using Weblate (Spanish)
- Translated using Weblate (German)
- i18n: refresh POT [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.9.7...v2025.10.0

## 📋 All Commits Included (21 commits)

<details>
<summary>Click to expand commit list</summary>

```
010e00ad chore: release v2025.10.0
cd195683 feat: enhance wizard presets and widgets with improved templates and styles
ea6858c4 feat: implement mobile optimization and enhance wizard navigation with swipe gestures
060d74ba refactor: enhance widget rendering with context and improve markdown content for Audiobookshelf
09879e49 build(deps-dev): bump the ui-frameworks group
c52c5af9 i18n: refresh POT [skip ci]
fc49da65 refactor: fix ruff linting and ty type errors
23ff62c8 build(deps): bump the flask-ecosystem group across 1 directory with 2 updates
602470e8 build(deps): bump ruff from 0.13.1 to 0.13.2 in the linting-tools group
ead15a6f i18n: refresh POT [skip ci]
5a2351be i18n: refresh POT [skip ci]
75232f1d build(deps): bump pyyaml from 6.0.2 to 6.0.3
0c357dc5 i18n: refresh POT [skip ci]
c55125b1 feat: add progress indicator closes Feature Request: Add a progress indicator to steps closes #861
24ca665f Translated using Weblate (French)
2ec27d89 Translated using Weblate (Spanish)
22032aec Translated using Weblate (German)
7036abd2 fix: update wizarr version to 2025.9.7 in uv.lock
27a57025 feat: add user disable functionality and integrate with media server service
13d10cee fix: streamline YAML file checking by using uv to run the Python script
de89c3c8 i18n: refresh POT [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.10.0`
- Deploy to production
- Build Docker images with `:latest` and `v2025.10.0` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation