### PR TITLE
Release v2025.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.9.7",
+  "version": "2025.10.0",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.9.7"
+version = "2025.10.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -85,7 +85,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.9.7"
+version = "2025.10.0"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1428,7 +1428,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.9.7"
+version = "2025.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.10.0

## What's Changed

### 🧹 Chores
- 


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.10.0...v2025.10.0

## 📋 All Commits Included (1 commits)

<details>
<summary>Click to expand commit list</summary>

```
98a705dc chore: release v2025.10.0
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.10.0`
- Deploy to production
- Build Docker images with `:latest` and `v2025.10.0` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation