### PR TITLE
Release v2025.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.10.1",
+  "version": "2025.10.2",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.10.1"
+version = "2025.10.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -85,7 +85,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.10.1"
+version = "2025.10.2"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1429,7 +1429,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.10.1"
+version = "2025.10.2"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.10.2

## What's Changed

### 🚀 Features
- display application version in general settings page
- enhance Komga integration with API key updates and user management improvements closes [BUG] Komga Setup Returning a 401 error when Komga is set up and working fine Fixes #693
- add in-app browser escape functionality with Bowser and InAppSpy support

### 🐛 Bug Fixes
- remove 'Drop' option from server type selection in create and edit modals
- implement image proxy token generation for now playing cards closes and fixes #891

### 🔧 Build System / Dependencies
- bump apprise from 1.9.4 to 1.9.5
- bump the linting-tools group with 2 updates

### 🧹 Chores
- 

### 📝 Other Changes
- i18n: refresh POT [skip ci]
- i18n: refresh POT [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.10.2...v2025.10.2

## 📋 All Commits Included (10 commits)

<details>
<summary>Click to expand commit list</summary>

```
692bce8f chore: release v2025.10.2
f41cd7d8 feat: display application version in general settings page
39830707 fix: remove 'Drop' option from server type selection in create and edit modals
8c189770 feat: enhance Komga integration with API key updates and user management improvements closes [BUG] Komga Setup Returning a 401 error when Komga is set up and working fine Fixes #693
8f5bf181 build(deps): bump apprise from 1.9.4 to 1.9.5
913137c7 build(deps): bump the linting-tools group with 2 updates
65fd09e6 feat: add in-app browser escape functionality with Bowser and InAppSpy support
290b5f34 fix: implement image proxy token generation for now playing cards closes and fixes #891
849f9602 i18n: refresh POT [skip ci]
1466c6a7 i18n: refresh POT [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.10.2`
- Deploy to production
- Build Docker images with `:latest` and `v2025.10.2` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation