### PR TITLE
feat: add GET /admins endpoint

### DIFF
--- a/app/blueprints/api/models.py
+++ b/app/blueprints/api/models.py
@@ -15,6 +15,25 @@ status_model = api.model(
     },
 )
 
+# Admin Models
+admin_model = api.model(
+    "Admin",
+    {
+        "id": fields.Integer(description="Admin ID"),
+        "username": fields.String(description="Admin username"),
+        "passkeys": fields.Integer(description="Number of passkeys for this admin"),
+        "created": fields.DateTime(description="Creation date (ISO format)"),
+    },
+)
+
+admin_list_model = api.model(
+    "AdminList",
+    {
+        "admins": fields.List(fields.Nested(admin_model)),
+        "count": fields.Integer(description="Total number of admins"),
+    },
+)
+
 # User Models
 user_model = api.model(
     "User",

--- a/tests/test_api_restx.py
+++ b/tests/test_api_restx.py
@@ -246,6 +246,35 @@ class TestAPIUsers:
         assert data["error"] == "User not found"
 
 
+class TestAPIAdmins:
+    """Test the API admins endpoints."""
+
+    def test_list_admins_unauthorized(self, client):
+        """Test admins list without authentication."""
+        response = client.get("/api/admins")
+        assert response.status_code == 401
+        data = response.get_json()
+        assert data["error"] == "Unauthorized"
+
+    def test_list_admins_success(self, client, api_key, sample_data):
+        """Test successful admins list."""
+        response = client.get("/api/admins", headers={"X-API-Key": api_key})
+        assert response.status_code == 200
+
+        data = response.get_json()
+        assert "admins" in data
+        assert "count" in data
+        assert data["count"] == len(data["admins"])
+
+        # Check user data structure
+        if data["admins"]:
+            admin = data["admins"][0]
+            assert "id" in admin
+            assert "username" in admin
+            assert "passkeys" in admin
+            assert "created" in admin
+
+
 class TestAPIInvitations:
     """Test the API invitations endpoints."""
 


### PR DESCRIPTION
# feat: Add GET /admins endpoint

## Overview
Added a new API endpoint that provides a list of Wizarr admins, following the same pattern as the existing GET /users endpoint. This allows external tools to programmatically retrieve basic administrator information.

## Changes
- Created `/api/admins` namespace and implemented GET /admins endpoint
- Added Admin and AdminList models in `api/models.py` to support the new endpoint
- Followed existing codebase patterns for consistency

## Functionality
The GET /admins endpoint returns:
- List of admin accounts (`admins`)
- Total admin count (`count`)

Each admin object contains:
- ID (`id`)
- Username (`username`) 
- Number of passkeys (`passkeys`)
- Creation date (`created`)

## Testing
Tested the endpoint by:
- Verifying admin list is correctly returned
- Ensuring proper authentication requirements
- Confirming response format matches expected models

I kept the implementation minimal and consistent with existing patterns.
Please let me know if I need to make any adjustments. Thank you very much.