### PR TITLE
Release v2025.10.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.10.6",
+  "version": "2025.10.7",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.10.6"
+version = "2025.10.7"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -147,7 +147,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.10.6"
+version = "2025.10.7"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1592,7 +1592,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.10.6"
+version = "2025.10.7"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.10.7

## What's Changed

### 🧪 Tests
- add integration tests for invite table route with timezone-aware datetime handling

### 🔧 Build System / Dependencies
- bump the ui-frameworks group

### 🧹 Chores
- 

### 📝 Other Changes
- Refactor test fixtures to include session parameter for improved database handling
- Fix timezone handling for expiring users to ensure accurate day calculations
- Refactor media server deletion logic to improve clarity and ensure proper cleanup of related records
- Refactor wizard bundle ID handling in InvitationFlowManager and InvitationWorkflow to improve readability and maintainability
- Enhance wizard step management and UI
- i18n: refresh POT and update PO files [skip ci]
- Fix datetime timezone comparison error in user expiry
- Initial plan
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.10.7...v2025.10.7

## 📋 All Commits Included (13 commits)

<details>
<summary>Click to expand commit list</summary>

```
84f1b202 chore: release v2025.10.7
1fb58814 Refactor test fixtures to include session parameter for improved database handling
159a25da Fix timezone handling for expiring users to ensure accurate day calculations
325239fd Refactor media server deletion logic to improve clarity and ensure proper cleanup of related records
986cf1e1 Refactor wizard bundle ID handling in InvitationFlowManager and InvitationWorkflow to improve readability and maintainability
5feaf513 Enhance wizard step management and UI
c1435270 i18n: refresh POT and update PO files [skip ci]
b79b9fa4 Fix datetime timezone comparison error in user expiry
f6a7226d Initial plan
17280941 i18n: refresh POT and update PO files [skip ci]
44a93813 test: add integration tests for invite table route with timezone-aware datetime handling
9a277511 build(deps-dev): bump the ui-frameworks group
228be7f0 i18n: refresh POT and update PO files [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.10.7`
- Deploy to production
- Build Docker images with `:latest` and `v2025.10.7` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation