### PR TITLE
Release v2025.10.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.10.8",
+  "version": "2025.10.9",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.10.8"
+version = "2025.10.9"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -147,7 +147,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.10.8"
+version = "2025.10.9"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1592,7 +1592,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.10.8"
+version = "2025.10.9"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.10.9

## What's Changed

### 🐛 Bug Fixes
- audiobookshelf history import order
- update Dockerfile to copy application code after source files and mark subproject as dirty
- update .dockerignore to include app directory and mark subproject as dirty
- kavita api errors closes #952
- Add locale normalization and improve language selection logic
- Improve date formatting in invite cards for consistency and clarity closes #947

### 🔧 Build System / Dependencies
- bump tiny-markdown-editor in /app/static
- bump @alpinejs/collapse in /app/static
- bump htmx.org from 2.0.7 to 2.0.8 in /app/static
- bump ty from 0.0.1a23 to 0.0.1a24
- bump structlog from 25.4.0 to 25.5.0
- bump tiny-markdown-editor in /app/static
- bump python-dotenv from 1.1.1 to 1.2.1
- bump the linting-tools group with 2 updates
- bump alpinejs from 3.15.0 to 3.15.1 in /app/static

### 🧹 Chores
- 
- 

### 📝 Other Changes
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.10.9...v2025.10.9

## 📋 All Commits Included (19 commits)

<details>
<summary>Click to expand commit list</summary>

```
7102a1d4 chore: release v2025.10.9
05ec6a1d build(deps): bump tiny-markdown-editor in /app/static
f574120a fix: audiobookshelf history import order
c9341eda i18n: refresh POT and update PO files [skip ci]
500a142e chore: release v2025.10.8
cfc74396 fix: update Dockerfile to copy application code after source files and mark subproject as dirty
26d78431 fix: update .dockerignore to include app directory and mark subproject as dirty
eca653b1 fix: kavita api errors closes #952
d029528c build(deps): bump @alpinejs/collapse in /app/static
74d41450 build(deps): bump htmx.org from 2.0.7 to 2.0.8 in /app/static
306e283e build(deps): bump ty from 0.0.1a23 to 0.0.1a24
4f80aa4b fix: Add locale normalization and improve language selection logic
31d1bba0 fix: Improve date formatting in invite cards for consistency and clarity closes #947
15ffa850 build(deps): bump structlog from 25.4.0 to 25.5.0
2d334ee8 build(deps): bump tiny-markdown-editor in /app/static
290c2678 build(deps): bump python-dotenv from 1.1.1 to 1.2.1
11c3b7b3 build(deps): bump the linting-tools group with 2 updates
7c3610e2 build(deps): bump alpinejs from 3.15.0 to 3.15.1 in /app/static
1d722032 i18n: refresh POT and update PO files [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.10.9`
- Deploy to production
- Build Docker images with `:latest` and `v2025.10.9` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation