### PR TITLE
Release v2025.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.10.8",
+  "version": "2025.11.0",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.10.8"
+version = "2025.11.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -148,7 +148,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.10.8"
+version = "2025.11.0"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1601,7 +1601,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.10.8"
+version = "2025.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.11.0

## What's Changed

### 🚀 Features
- enhance Plex session management with Tautulli-inspired polling and immediate enrichment
- improve user deletion process and fix foreign key constraints
- allow user edit

### 🐛 Bug Fixes
- update redirects from public.index to public.root for consistency

### 🧹 Chores
- 

### 📝 Other Changes
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Translated using Weblate (Chinese (Traditional Han script))
- Translated using Weblate (Chinese (Simplified Han script))
- Translated using Weblate (Chinese (Simplified Han script))
- Translated using Weblate (Chinese (Simplified Han script))
- Translated using Weblate (Swedish)
- Translated using Weblate (Swedish)
- Translated using Weblate (Russian)
- Translated using Weblate (Russian)
- Translated using Weblate (Romanian)
- Translated using Weblate (Portuguese (Brazil))
- Translated using Weblate (Portuguese (Brazil))
- Translated using Weblate (Portuguese)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Dutch)
- Translated using Weblate (Dutch)
- Translated using Weblate (Dutch)
- Translated using Weblate (Norwegian Bokmål)
- Translated using Weblate (Lithuanian)
- Translated using Weblate (Italian)
- Translated using Weblate (Icelandic)
- Translated using Weblate (Hungarian)
- Translated using Weblate (Hungarian)
- Translated using Weblate (Hungarian)
- Translated using Weblate (Croatian)
- Translated using Weblate (Hebrew)
- Translated using Weblate (Hebrew)
- Translated using Weblate (Alemannic)
- Translated using Weblate (French)
- Translated using Weblate (French)
- Translated using Weblate (French)
- Translated using Weblate (French)
- Translated using Weblate (French)
- Translated using Weblate (French)
- Translated using Weblate (French)
- Translated using Weblate (French)
- Translated using Weblate (French)
- Translated using Weblate (Persian)
- Translated using Weblate (Spanish)
- Translated using Weblate (Spanish)
- Translated using Weblate (Spanish)
- Translated using Weblate (Spanish)
- Translated using Weblate (Spanish)
- Translated using Weblate (German)
- Translated using Weblate (German)
- Translated using Weblate (German)
- Translated using Weblate (German)
- Translated using Weblate (Danish)
- Translated using Weblate (Danish)
- Translated using Weblate (Czech)
- Translated using Weblate (Catalan)
- Translated using Weblate (Catalan)


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.11.0...v2025.11.0

## 📋 All Commits Included (60 commits)

<details>
<summary>Click to expand commit list</summary>

```
b1a01744 chore: release v2025.11.0
ff92ad1c feat: enhance Plex session management with Tautulli-inspired polling and immediate enrichment
a8fe651c fix: update redirects from public.index to public.root for consistency
0b04a5f5 feat: improve user deletion process and fix foreign key constraints
0050f4b6 feat: allow user edit
cab8f7d6 i18n: refresh POT and update PO files [skip ci]
af215fde i18n: refresh POT and update PO files [skip ci]
4ee4d92b i18n: refresh POT and update PO files [skip ci]
43deab59 Translated using Weblate (Chinese (Traditional Han script))
20f273fd Translated using Weblate (Chinese (Simplified Han script))
5b65d30b Translated using Weblate (Chinese (Simplified Han script))
083818f9 Translated using Weblate (Chinese (Simplified Han script))
4978fe47 Translated using Weblate (Swedish)
04fbb83f Translated using Weblate (Swedish)
e7088f41 Translated using Weblate (Russian)
8db3c589 Translated using Weblate (Russian)
9e5a5ace Translated using Weblate (Romanian)
d78830d5 Translated using Weblate (Portuguese (Brazil))
6c1274ad Translated using Weblate (Portuguese (Brazil))
b608b1c1 Translated using Weblate (Portuguese)
27aa70cb Translated using Weblate (Polish)
74893d3f Translated using Weblate (Polish)
31d6702e Translated using Weblate (Dutch)
d2705964 Translated using Weblate (Dutch)
130447ea Translated using Weblate (Dutch)
d004eeb7 Translated using Weblate (Norwegian Bokmål)
d900485d Translated using Weblate (Lithuanian)
f2084e2a Translated using Weblate (Italian)
09d86905 Translated using Weblate (Icelandic)
0810a69f Translated using Weblate (Hungarian)
63be17ef Translated using Weblate (Hungarian)
c6b3c3ff Translated using Weblate (Hungarian)
9afd8fa4 Translated using Weblate (Croatian)
c7bc5717 Translated using Weblate (Hebrew)
1178d3bf Translated using Weblate (Hebrew)
c777443c Translated using Weblate (Alemannic)
9be301a3 Translated using Weblate (French)
adbd4e1e Translated using Weblate (French)
6e19cd3e Translated using Weblate (French)
b55b14e4 Translated using Weblate (French)
d0bd4850 Translated using Weblate (French)
0533bb59 Translated using Weblate (French)
152fcc46 Translated using Weblate (French)
fa24c340 Translated using Weblate (French)
840a7a7f Translated using Weblate (French)
d415dd0f Translated using Weblate (Persian)
c54b81d3 Translated using Weblate (Spanish)
4c4b2fa4 Translated using Weblate (Spanish)
59c7d037 Translated using Weblate (Spanish)
ab1c768b Translated using Weblate (Spanish)
f6b936c7 Translated using Weblate (Spanish)
54cd0f69 Translated using Weblate (German)
f198adc4 Translated using Weblate (German)
77e34a2a Translated using Weblate (German)
a3b12625 Translated using Weblate (German)
c5dd60cc Translated using Weblate (Danish)
c6914d9c Translated using Weblate (Danish)
271759dc Translated using Weblate (Czech)
31f8d43c Translated using Weblate (Catalan)
bbacd8f6 Translated using Weblate (Catalan)
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.11.0`
- Deploy to production
- Build Docker images with `:latest` and `v2025.11.0` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation