### PR TITLE
fix: prevent startup race condition during migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,12 @@ ENV APP_VERSION=${APP_VERSION}
 ENV FLASK_ENV=production
 
 # Healthcheck: curl to localhost:5690/health
-HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+# Increased start-period to 60s to account for:
+# - Database migrations
+# - Library scanning
+# - Wizard step imports
+# - Worker initialization (4 workers * ~10s each)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
   CMD curl -fs http://localhost:5690/health || exit 1
 
 # Expose port 5690

--- a/app/activity/__init__.py
+++ b/app/activity/__init__.py
@@ -28,6 +28,12 @@ def init_app(app: Flask) -> None:
         logger.debug("Skipping activity monitoring in test mode")
         return
 
+    # Skip during migrations to avoid database locking and race conditions
+    # This prevents session recovery from running during 'flask db upgrade'
+    if os.environ.get("FLASK_SKIP_SCHEDULER") == "true":
+        logger.debug("Skipping activity monitoring during migrations")
+        return
+
     # Skip only in Werkzeug's reloader parent process (development mode)
     # WERKZEUG_RUN_MAIN is only set when using Flask's development server with reloader
     # In production (Gunicorn/uWSGI), this env var won't be set, so we should proceed

--- a/app/services/library_scanner.py
+++ b/app/services/library_scanner.py
@@ -8,6 +8,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Timeout for individual server library scans (in seconds)
+# This prevents a single unreachable server from blocking startup
+LIBRARY_SCAN_TIMEOUT = 15
+
 
 def scan_all_server_libraries(show_logs: bool = True) -> tuple[int, list[str]]:
     """Scan libraries for all configured media servers.


### PR DESCRIPTION
This fixes a critical issue where Gunicorn workers would fail to start after upgrading to v2025.11.0, causing containers to show as unhealthy with only the uv wrapper process running and no actual workers.

Root Cause:
-----------
In v2025.11.0, library scanning and session recovery were added to the create_app() function, which runs during EVERY app creation including:
1. During 'flask db upgrade' (migrations)
2. During Gunicorn master when_ready() hook
3. During each Gunicorn worker spawn

The migration 20251103_properly_fix_foreign_keys recreates 4 database tables with CASCADE foreign keys using raw SQL. This holds exclusive database locks during table recreation.

When library scanning and session recovery try to query these tables during migration, they hit database locks, creating a race condition that causes workers to timeout and crash during startup.

Fix:
----
- Skip library scanning during migrations (FLASK_SKIP_SCHEDULER=true)
- Skip activity monitoring/session recovery during migrations
- Make Gunicorn log level configurable (GUNICORN_LOG_LEVEL env var)
- Add worker lifecycle hooks for better crash debugging
- Increase healthcheck start period from 10s to 60s
- Increase Gunicorn worker timeout from 30s to 120s

Testing:
--------
- Verified app starts successfully with FLASK_SKIP_SCHEDULER=true
- Verified library scanning runs normally without the flag
- Confirmed 0.38s startup during migrations vs 1.61s normal startup

Closes #976