### PR TITLE
Release v2025.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.11.1",
+  "version": "2025.11.2",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.11.1"
+version = "2025.11.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -148,7 +148,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.11.1"
+version = "2025.11.2"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1605,7 +1605,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.11.1"
+version = "2025.11.2"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.11.2

## What's Changed

### 🚀 Features
- implement server-specific color theming for invitations and wizards closes #982

### 🐛 Bug Fixes
- adjust wizard progress bar position and enhance padding for content overlap closes #971
- update user fetching method to use API call during invitation acceptance chore: add peer flag to tailwindcss license entry in package-lock.json

### 🧹 Chores
- 

### 📝 Other Changes
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.11.2...v2025.11.2

## 📋 All Commits Included (6 commits)

<details>
<summary>Click to expand commit list</summary>

```
0c047d22 chore: release v2025.11.2
fca67912 feat: implement server-specific color theming for invitations and wizards closes #982
cba043aa fix: adjust wizard progress bar position and enhance padding for content overlap closes #971
96e2bb8e fix: update user fetching method to use API call during invitation acceptance chore: add peer flag to tailwindcss license entry in package-lock.json
8f91b68a i18n: refresh POT and update PO files [skip ci]
81a23b27 i18n: refresh POT and update PO files [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.11.2`
- Deploy to production
- Build Docker images with `:latest` and `v2025.11.2` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation