### PR TITLE
Release v2025.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.11.2",
+  "version": "2025.11.3",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.11.2"
+version = "2025.11.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -148,7 +148,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.11.2"
+version = "2025.11.3"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1605,7 +1605,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.11.2"
+version = "2025.11.3"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.11.3

## What's Changed

### 🐛 Bug Fixes
- Refactor invitation handling to use individual user's acceptance timestamp and update package-lock.json for peer dependency closes #1015
- Enhance Media Server deletion process to clear dependent records and update invitation associations

### 🔧 Build System / Dependencies
- bump @alpinejs/collapse in /app/static
- bump flowbite in /app/static in the ui-frameworks group
- bump alpinejs from 3.15.1 to 3.15.2 in /app/static
- bump ty from 0.0.1a25 to 0.0.1a26
- bump cachetools from 6.2.1 to 6.2.2
- bump commitizen from 4.9.1 to 4.10.0
- bump ruff from 0.14.4 to 0.14.5 in the linting-tools group
- bump playwright in the testing-tools group
- bump inapp-spy from 5.0.7 to 5.0.8 in /app/static
- bump tiny-markdown-editor in /app/static
- bump the ui-frameworks group across 1 directory with 3 updates
- bump inapp-spy from 5.0.6 to 5.0.7 in /app/static
- bump markdown from 3.9 to 3.10
- bump ty from 0.0.1a24 to 0.0.1a25
- bump the linting-tools group with 2 updates

### 🧹 Chores
- 

### 📝 Other Changes
- Add delay to prevent hammering the media server's database during user deletion and disabling Increase request timeout for media client API calls to  improve reliability closes #995 closes #1014
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Fixes Media Server deletion closes #1003
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.11.3...v2025.11.3

## 📋 All Commits Included (33 commits)

<details>
<summary>Click to expand commit list</summary>

```
50d26b0c chore: release v2025.11.3
f9ae61e1 fix: Refactor invitation handling to use individual user's acceptance timestamp and update package-lock.json for peer dependency closes #1015
bf223c89 Add delay to prevent hammering the media server's database during user deletion and disabling Increase request timeout for media client API calls to  improve reliability closes #995 closes #1014
69689e64 build(deps): bump @alpinejs/collapse in /app/static
31011b48 build(deps): bump flowbite in /app/static in the ui-frameworks group
9daade1b i18n: refresh POT and update PO files [skip ci]
80b1a835 i18n: refresh POT and update PO files [skip ci]
81639887 fix: Enhance Media Server deletion process to clear dependent records and update invitation associations
533f972b Fixes Media Server deletion closes #1003
76f470a0 build(deps): bump alpinejs from 3.15.1 to 3.15.2 in /app/static
2844a676 build(deps): bump ty from 0.0.1a25 to 0.0.1a26
5363d129 build(deps): bump cachetools from 6.2.1 to 6.2.2
f75ba5a1 build(deps): bump commitizen from 4.9.1 to 4.10.0
73b90bb0 build(deps): bump ruff from 0.14.4 to 0.14.5 in the linting-tools group
f1504352 build(deps): bump playwright in the testing-tools group
00759e2b i18n: refresh POT and update PO files [skip ci]
cd89feca i18n: refresh POT and update PO files [skip ci]
08c4e1d2 i18n: refresh POT and update PO files [skip ci]
0422171f build(deps): bump inapp-spy from 5.0.7 to 5.0.8 in /app/static
1b04418f i18n: refresh POT and update PO files [skip ci]
de25b2a0 build(deps): bump tiny-markdown-editor in /app/static
2d6045c8 build(deps): bump the ui-frameworks group across 1 directory with 3 updates
174a4e6c i18n: refresh POT and update PO files [skip ci]
76a22d48 i18n: refresh POT and update PO files [skip ci]
9a77afa3 build(deps): bump inapp-spy from 5.0.6 to 5.0.7 in /app/static
65081e84 i18n: refresh POT and update PO files [skip ci]
ed7d67e3 build(deps): bump markdown from 3.9 to 3.10
221362c0 build(deps): bump ty from 0.0.1a24 to 0.0.1a25
0652244a build(deps): bump the linting-tools group with 2 updates
0b94311d i18n: refresh POT and update PO files [skip ci]
88f2bd20 i18n: refresh POT and update PO files [skip ci]
f9cb9fe4 i18n: refresh POT and update PO files [skip ci]
1739d480 i18n: refresh POT and update PO files [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.11.3`
- Deploy to production
- Build Docker images with `:latest` and `v2025.11.3` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation