### PR TITLE
Release v2025.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.11.3",
+  "version": "2025.11.4",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.11.3"
+version = "2025.11.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -148,7 +148,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.11.3"
+version = "2025.11.4"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1605,7 +1605,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.11.3"
+version = "2025.11.4"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.11.4

## What's Changed

### 🔧 Build System / Dependencies
- bump bowser from 2.12.1 to 2.13.0 in /app/static
- bump actions/checkout from 5 to 6
- bump plexapi from 4.17.1 to 4.17.2
- bump ty from 0.0.1a26 to 0.0.1a27
- bump the linting-tools group with 2 updates
- bump the testing-tools group with 2 updates

### 🧹 Chores
- 

### 📝 Other Changes
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Migrate workflows to Blacksmith
- Migrate workflows to Blacksmith
- i18n: refresh POT and update PO files [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.11.4...v2025.11.4

## 📋 All Commits Included (20 commits)

<details>
<summary>Click to expand commit list</summary>

```
77b4e62d chore: release v2025.11.4
bc4d5488 i18n: refresh POT and update PO files [skip ci]
d4a3cc84 i18n: refresh POT and update PO files [skip ci]
7b6f78c5 i18n: refresh POT and update PO files [skip ci]
d494ee96 i18n: refresh POT and update PO files [skip ci]
000207d6 i18n: refresh POT and update PO files [skip ci]
b7becbfd i18n: refresh POT and update PO files [skip ci]
f1536e79 build(deps): bump bowser from 2.12.1 to 2.13.0 in /app/static
4b5ef073 build(deps): bump actions/checkout from 5 to 6
622249c4 build(deps): bump plexapi from 4.17.1 to 4.17.2
a1d37315 build(deps): bump ty from 0.0.1a26 to 0.0.1a27
864dfa99 build(deps): bump the linting-tools group with 2 updates
78ff16f3 build(deps): bump the testing-tools group with 2 updates
9f12e6d1 i18n: refresh POT and update PO files [skip ci]
f3a80f8b i18n: refresh POT and update PO files [skip ci]
ef877cc2 i18n: refresh POT and update PO files [skip ci]
6a992367 i18n: refresh POT and update PO files [skip ci]
76f659f1 Migrate workflows to Blacksmith
c5002be2 Migrate workflows to Blacksmith
b30eb157 i18n: refresh POT and update PO files [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.11.4`
- Deploy to production
- Build Docker images with `:latest` and `v2025.11.4` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation