### PR TITLE
Release v2025.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.12.0",
+  "version": "2025.12.1",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.12.0"
+version = "2025.12.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -148,7 +148,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.12.0"
+version = "2025.12.1"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1570,7 +1570,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.12.0"
+version = "2025.12.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2025.12.1

## What's Changed

### 🔧 Build System / Dependencies
- bump the linting-tools group across 1 directory with 2 updates
- bump tiny-markdown-editor in /app/static

### 🧹 Chores
- 

### 📝 Other Changes
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2025.12.1...v2025.12.1

## 📋 All Commits Included (19 commits)

<details>
<summary>Click to expand commit list</summary>

```
da64071b chore: release v2025.12.1
e7c08b28 i18n: refresh POT and update PO files [skip ci]
e8e24533 i18n: refresh POT and update PO files [skip ci]
753879ab i18n: refresh POT and update PO files [skip ci]
2c5ebf97 build(deps-dev): bump the linting-tools group across 1 directory with 2 updates
5ac8352b build(deps): bump tiny-markdown-editor in /app/static
99e2eb37 i18n: refresh POT and update PO files [skip ci]
f5808596 i18n: refresh POT and update PO files [skip ci]
6ae86863 i18n: refresh POT and update PO files [skip ci]
ea0d25ef i18n: refresh POT and update PO files [skip ci]
4e13d768 i18n: refresh POT and update PO files [skip ci]
4758b7f3 i18n: refresh POT and update PO files [skip ci]
0afacbbd i18n: refresh POT and update PO files [skip ci]
5fac6cdd i18n: refresh POT and update PO files [skip ci]
3d393538 i18n: refresh POT and update PO files [skip ci]
54235584 i18n: refresh POT and update PO files [skip ci]
85d840ce i18n: refresh POT and update PO files [skip ci]
70eedd3c i18n: refresh POT and update PO files [skip ci]
d5929c22 i18n: refresh POT and update PO files [skip ci]
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2025.12.1`
- Deploy to production
- Build Docker images with `:latest` and `v2025.12.1` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation