### PR TITLE
Add Pushover Integration

### DIFF
--- a/app/blueprints/notifications/routes.py
+++ b/app/blueprints/notifications/routes.py
@@ -14,6 +14,7 @@ from app.services.notifications import (  # your existing helpers
     _apprise,
     _discord,
     _notifiarr,
+    _pushover,
     _ntfy,
 )
 
@@ -45,6 +46,8 @@ def create():
             "type": request.form.get("notification_service"),
             "username": request.form.get("username") or None,
             "password": request.form.get("password") or None,
+            "user_key": request.form.get("user_key") or None,
+            "api_token": request.form.get("api_token") or None,
             "channel_id": request.form.get("channel_id") or None,
             "notification_events": ",".join(events)
             if events
@@ -84,6 +87,8 @@ def create():
                     url,
                     channel_id,
                 )
+        elif form["type"] == "pushover":
+            ok = _pushover(msg="Wizarr test message", title="Wizarr", user_key=form.get("user_key"), api_token=form.get("api_token"))
 
         if ok:
             # from Notification.create(**form) to SQLAlchemy ORM
@@ -125,6 +130,8 @@ def edit(agent_id):
             "type": request.form.get("notification_service"),
             "username": request.form.get("username") or None,
             "password": request.form.get("password") or None,
+            "user_key": request.form.get("user_key") or None,
+            "api_token": request.form.get("api_token") or None,
             "channel_id": request.form.get("channel_id") or None,
             "notification_events": ",".join(events)
             if events
@@ -164,6 +171,8 @@ def edit(agent_id):
                     url,
                     channel_id,
                 )
+        elif form["type"] == "pushover":
+            ok = _pushover(msg="Wizarr test message", title="Wizarr", user_key=form.get("user_key"), api_token=form.get("api_token"))
 
         if ok:
             # Update the agent with new values

--- a/app/models.py
+++ b/app/models.py
@@ -353,6 +353,8 @@ class Notification(db.Model):
     username = db.Column(db.String, nullable=True)
     password = db.Column(db.String, nullable=True)
     channel_id = db.Column(db.Integer, nullable=True)
+    user_key = db.Column(db.String(50), nullable=True)
+    api_token = db.Column(db.String(50), nullable=True) 
     notification_events = db.Column(
         db.String, nullable=False, default="user_joined,update_available"
     )

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -66,6 +66,23 @@ def _ntfy(
         headers["Authorization"] = "Basic " + base64.b64encode(creds.encode()).decode()
     return _send(url, msg, headers)
 
+def _pushover(
+    msg: str,
+    title: str,
+    user_key: str,
+    api_token: str,
+) -> bool:
+    data = {
+        "token": api_token,
+        "user": user_key,
+        "message": msg,
+        "title": title,
+    }
+    pushover_url = "https://api.pushover.net/1/messages.json"
+    return _send(pushover_url, data, headers={})
+
+
+
 
 def _apprise(msg: str, title: str, _tags: str, url: str) -> bool:
     try:
@@ -136,3 +153,5 @@ def notify(
             _apprise(message, title, tags, agent.url)
         elif agent.type == "notifiarr":
             _notifiarr(message, title, agent.url, agent.channel_id)
+        elif agent.type == "pushover":
+            _pushover(message, title, agent.user_key, agent.api_token)

--- a/app/templates/modals/create-notification-agent.html
+++ b/app/templates/modals/create-notification-agent.html
@@ -63,6 +63,7 @@
                 <option value="apprise">Apprise</option>
                 <option value="discord">Discord</option>
                 <option value="notifiarr">Notifiarr</option>
+                <option value="pushover">Pushover</option>
                 <option value="ntfy">Ntfy</option>
               </select>
             </div>
@@ -95,6 +96,23 @@
                      name="password"
                      id="password"
                      class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+            </div>
+            <div>
+            <div id="pushoverSection"
+                 class="notificationAgentInfo"
+                 style="display: none">
+              <label for="user_key"
+                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("User Key") }}</label>
+              <input type="text"
+                     name="user_key"
+                     id="user_key"
+                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" />
+              <label for="api_token"
+                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("API Token") }}</label>
+              <input type="text"
+                     name="api_token"
+                     id="api_token"
+                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" />
             </div>
             <div>
               <label for="url"
@@ -168,9 +186,11 @@
 
         // Trigger sections
         if (value === 'ntfy') {
-            credentialsSection.style.display = 'block';
+            document.getElementById('credentialsSection').style.display = 'block';
         } else if (value === "notifiarr") {
-            notifiarrSection.style.display = 'block';
+            document.getElementById('notifiarrSection').style.display = 'block';
+        } else if (value === "pushover") {
+            document.getElementById('pushoverSection').style.display = 'block';
         }
 
         // Trigger required channel_id
@@ -183,10 +203,24 @@
         // Adjust placeholder text
         const urlEle = document.getElementById('url');
 
+        // Trigger required url
+        if (value === 'pushover') {
+            urlEle.required = false;
+        } else {
+            urlEle.required = true;
+        }
+
         if (value === 'apprise') {
             urlEle.placeholder = "e.g. apprise://hostname/token";
+            urlEle.style.display = "block";
+            document.querySelector('label[for="url"]').style.display = "block";
+        } else if (value === 'pushover') {
+            urlEle.style.display = "none";
+            document.querySelector('label[for="url"]').style.display = "none";
         } else {
             urlEle.placeholder = "e.g. https://example.com";
+            urlEle.style.display = "block";
+            document.querySelector('label[for="url"]').style.display = "block";
         }
     }
 </script>

--- a/app/templates/modals/edit-notification-agent.html
+++ b/app/templates/modals/edit-notification-agent.html
@@ -43,6 +43,7 @@
                 <option value="discord" {% if agent.type == 'discord' %}selected{% endif %}>Discord</option>
                 <option value="notifiarr"
                         {% if agent.type == 'notifiarr' %}selected{% endif %}>Notifiarr</option>
+                <option value="pushover" {% if agent.type == 'pushover' %}selected{% endif %}>Pushover</option>
                 <option value="ntfy" {% if agent.type == 'ntfy' %}selected{% endif %}>Ntfy</option>
               </select>
             </div>
@@ -90,6 +91,35 @@
                      value="{{ agent.password or '' }}"
                      class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
             </div>
+            <div id="pushoverSection"
+                 class="notificationAgentInfo"
+                 style="display:
+                        {% if agent.type == 'pushover' %}
+                          block
+                        {% else %}
+                          none
+                        {% endif %}">
+              <label for="user_key"
+                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("User Key") }}</label>
+              <input type="text"
+                     name="user_key"
+                     id="user_key"
+                     value="{{ agent.user_key or '' }}"
+                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" 
+                     {% if agent.type == 'pushover' %}
+                        required
+                     {% endif %}/>
+              <label for="api_token"
+                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("API Token") }}</label>
+              <input type="text"
+                     name="api_token"
+                     id="api_token"
+                     value="{{ agent.api_token or '' }}"
+                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" 
+                     {% if agent.type == 'pushover' %}
+                        required
+                     {% endif %}/>
+            </div>
             <div>
               <label for="url"
                      class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Agent URL") }}</label>
@@ -99,7 +129,9 @@
                      value="{{ agent.url }}"
                      placeholder="e.g. https://example.com"
                      class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                     required>
+                     {% if agent.type != 'pushover' %}
+                        required
+                     {% endif %}>
             </div>
             <div>
               <label class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Notification Events") }}</label>
@@ -149,6 +181,13 @@
   </div>
 </div>
 <script>
+    document.body.addEventListener('htmx:afterSwap', function (e) {
+        // only react to swaps that affect the modal/form
+        const select = document.getElementById('notification_service');
+        if (select) {
+            toggleService(select.value);
+        }
+    });
     function closeModal() {
         document.getElementById('create-modal').innerHTML = '';
     }
@@ -161,23 +200,37 @@
         }
 
         if (value === 'ntfy') {
+            document.getElementById('credentialsSection').style.display = 'block';
+        } else if (value === 'notifiarr') {
+            document.getElementById('notifiarrSection').style.display = 'block';
+        } else if (value === 'pushover') {
+            document.getElementById('pushoverSection').style.display = 'block';
+        }
+
+        if (value === 'ntfy') {
             credentialsSection.style.display = 'block';
         } else if (value === "notifiarr") {
             notifiarrSection.style.display = 'block';
         }
 
-        if (value === 'notifiarr') {
-            document.getElementById("channel_id").required = true
-        } else {
-            document.getElementById("channel_id").required = false
-        }
-
         const urlEle = document.getElementById('url');
+        const urlWrapper = urlEle.closest('div');
 
-        if (value === 'apprise') {
-            urlEle.placeholder = "e.g. apprise://hostname/token";
+        if (value === 'pushover') {
+            urlEle.required = false;
+            urlWrapper.style.display = 'none';
         } else {
-            urlEle.placeholder = "e.g. https://example.com";
+            urlEle.required = true;
+            urlWrapper.style.display = 'block';
+
+            if (value === 'apprise') {
+                urlEle.placeholder = 'e.g. apprise://hostname/token';
+            } else {
+                urlEle.placeholder = 'e.g. https://example.com';
+            }
         }
-    }
+}
+
+
+
 </script>

--- a/migrations/versions/20251215_added_pushover_integration.py
+++ b/migrations/versions/20251215_added_pushover_integration.py
@@ -1,0 +1,21 @@
+"""20251215_added_pushover_integration
+Revision ID: add_pushover_integration
+Revises: eecad7c18ac3
+Create Date: 2025-12-15 14:07:53
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'add_pushover_integration'
+down_revision = 'eecad7c18ac3'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('notification', sa.Column('user_key', sa.String(length=50), nullable=True))
+    op.add_column('notification', sa.Column('api_token', sa.String(length=50), nullable=True))
+
+def downgrade():
+    op.drop_column('notification', 'api_token')
+    op.drop_column('notification', 'user_key')


### PR DESCRIPTION
Closes #1070.
Provides an option to add a Pushover integration into Wizarr.

It just uses the Title and Message part of the request body as that is generally what all of the other notification agents do.

Added a database integration to add the `user_key` and `api_token` required to the database.

All other implementation remains the same.
 
<img width="513" height="558" alt="image" src="https://github.com/user-attachments/assets/35f804df-4c8e-4d8e-be87-734a51343bd1" />
