### PR TITLE
Release v2026.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.12.0",
+  "version": "2026.1.0",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.12.0"
+version = "2026.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -148,7 +148,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.12.0"
+version = "2026.1.0"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1576,7 +1576,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.12.0"
+version = "2026.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2026.1.0

## What's Changed

### 🚀 Features
- complete Italian translation (100%)

### 🐛 Bug Fixes
- clean Italian translation formatting and fix 34 incorrect translations

### 🔧 Build System / Dependencies
- bump ty from 0.0.1a32 to 0.0.7
- bump alpinejs from 3.15.2 to 3.15.3 in /app/static
- bump the ui-frameworks group
- bump tiny-markdown-editor in /app/static
- bump sqlalchemy in the flask-ecosystem group
- bump playwright in the testing-tools group
- bump cachetools from 6.2.2 to 6.2.4
- bump the linting-tools group across 1 directory with 2 updates
- bump tiny-markdown-editor in /app/static
- bump actions/cache from 4 to 5
- bump commitizen from 4.10.0 to 4.10.1

### 🧹 Chores
- 
- 
- 

### 📝 Other Changes
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- update translation due to context
- pt_BR full translation
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Implement APScheduler shutdown on Gunicorn exit
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Update Italian translations and metadata


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2026.1.0...v2026.1.0

## 📋 All Commits Included (52 commits)

<details>
<summary>Click to expand commit list</summary>

```
18c835cd chore: release v2026.1.0
04ea8a37 i18n: refresh POT and update PO files [skip ci]
e885a983 i18n: refresh POT and update PO files [skip ci]
603b403c update translation due to context
632cf6a5 pt_BR full translation
c2e1741c i18n: refresh POT and update PO files [skip ci]
fa2dacda i18n: refresh POT and update PO files [skip ci]
ca900b1d build(deps-dev): bump ty from 0.0.1a32 to 0.0.7
efb09127 build(deps): bump alpinejs from 3.15.2 to 3.15.3 in /app/static
9a5d4b97 build(deps-dev): bump the ui-frameworks group
e54693a7 i18n: refresh POT and update PO files [skip ci]
a0b5a739 build(deps): bump tiny-markdown-editor in /app/static
a96a8939 build(deps): bump sqlalchemy in the flask-ecosystem group
5af76c93 build(deps-dev): bump playwright in the testing-tools group
0bd6f1cb i18n: refresh POT and update PO files [skip ci]
852e922b i18n: refresh POT and update PO files [skip ci]
a325b269 i18n: refresh POT and update PO files [skip ci]
00d697a7 i18n: refresh POT and update PO files [skip ci]
6aa528d1 i18n: refresh POT and update PO files [skip ci]
549ca4ea i18n: refresh POT and update PO files [skip ci]
ef783a29 Implement APScheduler shutdown on Gunicorn exit
4d2f4098 i18n: refresh POT and update PO files [skip ci]
42c6551f build(deps): bump cachetools from 6.2.2 to 6.2.4
db8a9b45 i18n: refresh POT and update PO files [skip ci]
8a74d2c8 i18n: refresh POT and update PO files [skip ci]
092109ba i18n: refresh POT and update PO files [skip ci]
729a02e3 i18n: refresh POT and update PO files [skip ci]
e7c08b28 i18n: refresh POT and update PO files [skip ci]
e8e24533 i18n: refresh POT and update PO files [skip ci]
753879ab i18n: refresh POT and update PO files [skip ci]
2c5ebf97 build(deps-dev): bump the linting-tools group across 1 directory with 2 updates
5ac8352b build(deps): bump tiny-markdown-editor in /app/static
99e2eb37 i18n: refresh POT and update PO files [skip ci]
f5808596 i18n: refresh POT and update PO files [skip ci]
6ae86863 i18n: refresh POT and update PO files [skip ci]
ea0d25ef i18n: refresh POT and update PO files [skip ci]
4e13d768 i18n: refresh POT and update PO files [skip ci]
4758b7f3 i18n: refresh POT and update PO files [skip ci]
0afacbbd i18n: refresh POT and update PO files [skip ci]
006898db build(deps): bump actions/cache from 4 to 5
ad3e3fd6 build(deps-dev): bump commitizen from 4.10.0 to 4.10.1
5fac6cdd i18n: refresh POT and update PO files [skip ci]
3d393538 i18n: refresh POT and update PO files [skip ci]
54235584 i18n: refresh POT and update PO files [skip ci]
85d840ce i18n: refresh POT and update PO files [skip ci]
70eedd3c i18n: refresh POT and update PO files [skip ci]
d5929c22 i18n: refresh POT and update PO files [skip ci]
f3770f9b chore: revert .gitignore to original state, using docs-internal locally
f3cb48bb fix(i18n): clean Italian translation formatting and fix 34 incorrect translations
30c75489 Update Italian translations and metadata
17b76d40 chore: ignore #operational directory
4b66e7d8 feat(i18n): complete Italian translation (100%)
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2026.1.0`
- Deploy to production
- Build Docker images with `:latest` and `v2026.1.0` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation