### PR TITLE
fix: Remove runtime directory creation in /etc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,6 @@ COPY --chown=1000:1000 --from=builder /app/app /app/app
 # Create data directory for database (backward compatibility)
 RUN mkdir -p /data/database
 
-# Create wizard steps config directory
-RUN mkdir -p /etc/wizarr/wizard_steps
-
 # Create directories that need to be writable
 RUN mkdir -p /.cache
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,15 +35,11 @@ if [ "$(id -u)" = "0" ]; then
 
   # Ensure critical data directories exist
   mkdir -p /data/database
-  
-  # Create wizard_steps directory in /etc for template customization
-  mkdir -p /etc/wizarr/wizard_steps
 
-  
   # Only recurse into bind mount directories and cache
   echo "[entrypoint] ⚙️  Fixing ownership for bind mounts…"
   chown -R "$TARGET_USER":"$TARGET_GRP" \
-    /data/database /etc/wizarr/wizard_steps /.cache /opt/default_wizard_steps
+    /data/database /.cache /opt/default_wizard_steps
 
 
   # Fix ownership of bind-mounts (only persistent data directories)
@@ -52,7 +48,6 @@ if [ "$(id -u)" = "0" ]; then
 
     # Fix ownership of persistent user data only
     [ -d /data/database ] && chown -R "$PUID":"$PGID" /data/database
-    [ -d /etc/wizarr/wizard_steps ] && chown -R "$PUID":"$PGID" /etc/wizarr/wizard_steps
   else
     echo "[entrypoint] ⚙️  Default UID/GID; skipping chown."
   fi
@@ -62,43 +57,6 @@ if [ "$(id -u)" = "0" ]; then
 fi
 
 echo "[entrypoint] 👍 Running as $(id -un):$(id -gn) ($(id -u):$(id -g))"
-
-# ─────────────────────────────────────────────────────────────────────────────
-# 2) Seed wizard steps per-server (SEEDING ONLY)
-#
-#   NOTE: Wizard steps are managed through the database/frontend UI. This seeding
-#   process only provides DEFAULT markdown files that get imported into the DB
-#   on first run or when new server types are added.
-#
-#   • For every directory inside $DEFAULT (e.g. plex/ jellyfin/ …) we check if
-#     the matching subdir in $TARGET exists **and** contains at least one
-#     visible file.  Only if it's empty (or missing) do we copy in the
-#     defaults for that server type.  This allows users to customise the DEFAULT
-#     templates for one media server without having to keep copies for all others.
-# ─────────────────────────────────────────────────────────────────────────────
-
-TARGET=/etc/wizarr/wizard_steps
-DEFAULT=/opt/default_wizard_steps
-
-# ensure both directories exist
-mkdir -p "$TARGET"
-
-if [ -d "$DEFAULT" ]; then
-  for src in "$DEFAULT"/*; do
-    [ -d "$src" ] || continue  # skip non-dirs
-    name="$(basename "$src")"
-    dst="$TARGET/$name"
-
-    # The dst folder is considered "empty" if it has no regular files
-    if [ ! -d "$dst" ] || [ -z "$(find "$dst" -type f -print -quit 2>/dev/null)" ]; then
-      echo "[entrypoint] ✨ Seeding default wizard steps for $name…"
-      mkdir -p "$dst"
-      cp -a "$src/." "$dst/"
-    else
-      echo "[entrypoint] ↩️  Custom wizard steps for $name detected – keeping user files"
-    fi
-  done
-fi
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 3) DB Migrations


### PR DESCRIPTION
###   Description:

  Resolves #1129

###   Summary

  This pull request fixes a critical regression that prevents the Wizarr container from starting in hardened, read-only environments like Kubernetes. The docker-entrypoint.sh script attempts to write to /etc/wizarr/wizard_steps at runtime, which violates security best practices and the Filesystem Hierarchy Standard (FHS), causing a "Permission denied" failure.

###   The Problem

  The issue was introduced in commit fad484b5709c3a040fa25c754b3ca53c6d296ff9, which changed the wizard steps directory from /data/wizard_steps to /etc/wizarr/wizard_steps.

  This change was unnecessary and incorrect. An earlier commit (5c664331cd8da96db35823f7a8a9db8ca048f28c) had already refactored the application to manage wizard steps via the UI, explicitly removing the need for a custom, file-based override directory. The code comment "No override directory – wizard steps are now managed from the UI" confirms this intent.

  The subsequent modification to the entrypoint script was a misguided implementation of a "bootstrap" process that did not account for read-only filesystems.

###   The Solution

  This pull request removes the redundant and problematic logic from both the docker-entrypoint.sh script and the Dockerfile.

  Specifically, it removes:
   * The mkdir -p /etc/wizarr/wizard_steps command from the Dockerfile.
   * All logic related to creating, seeding, and changing ownership of /etc/wizarr/wizard_steps from docker-entrypoint.sh.

  The application's Python code (app/services/wizard_seed.py) already handles the seeding of wizard steps correctly from its bundled wizard_steps directory at application start. Removing the conflicting entrypoint logic aligns the container's behavior with the application's intended design and restores compatibility with secure, read-only environments.

###   How to Test

   1. Build the Docker image with these changes.
   2. Run the container in an environment with a read-only root filesystem.
   3. Verify that the container starts successfully and that the wizard steps are correctly seeded and available in the UI on a fresh installation.