### PR TITLE
Release v2026.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2025.12.0",
+  "version": "2026.2.0",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2025.12.0"
+version = "2026.2.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -148,7 +148,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2025.12.0"
+version = "2026.2.0"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1663,7 +1663,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2025.12.0"
+version = "2026.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2026.2.0

## What's Changed

### 🚀 Features
- implement per-server expiry handling and update invite modal closes #1138
- complete Italian translation (100%)

### 🐛 Bug Fixes
- fall back to global expiry when per-server expiry is unset
- Remove runtime directory creation in /etc
- clean Italian translation formatting and fix 34 incorrect translations

### 🔧 Build System / Dependencies
- batch update all Python and npm dependencies
- bump sortablejs from 1.15.6 to 1.15.7 in /app/static
- bump cryptography from 45.0.7 to 46.0.5
- bump sqlalchemy in the flask-ecosystem group
- bump ruff in the linting-tools group
- bump ty from 0.0.12 to 0.0.13
- bump commitizen from 4.12.0 to 4.12.1
- bump filelock from 3.19.1 to 3.20.3
- bump werkzeug from 3.1.3 to 3.1.5
- bump virtualenv from 20.34.0 to 20.36.1
- bump cbor2 from 5.7.0 to 5.8.0
- bump wlc from 1.16.1 to 1.17.2
- bump ty from 0.0.9 to 0.0.12
- bump commitizen from 4.10.1 to 4.12.0
- bump the linting-tools group with 2 updates
- bump @alpinejs/collapse in /app/static
- bump ty from 0.0.1a32 to 0.0.7
- bump alpinejs from 3.15.2 to 3.15.3 in /app/static
- bump the ui-frameworks group
- bump tiny-markdown-editor in /app/static
- bump sqlalchemy in the flask-ecosystem group
- bump playwright in the testing-tools group
- bump cachetools from 6.2.2 to 6.2.4
- bump the linting-tools group across 1 directory with 2 updates
- bump tiny-markdown-editor in /app/static
- bump actions/cache from 4 to 5
- bump commitizen from 4.10.0 to 4.10.1

### 💄 Styling
- fix djlint formatting in invite templates

### 🧹 Chores
- 
- 
- 

### 📝 Other Changes
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Change library deletes to upserts
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- changed watch to stream
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- update translation due to context
- pt_BR full translation
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Implement APScheduler shutdown on Gunicorn exit
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Update Italian translations and metadata


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2026.2.0...v2026.2.0

## 📋 All Commits Included (118 commits)

<details>
<summary>Click to expand commit list</summary>

```
ed93c6c0 chore: release v2026.2.0
dae83723 style: fix djlint formatting in invite templates
48890075 fix(invites): fall back to global expiry when per-server expiry is unset
ad7f0731 feat(invites): implement per-server expiry handling and update invite modal closes #1138
87415bde build(deps): batch update all Python and npm dependencies
df7d7ee8 i18n: refresh POT and update PO files [skip ci]
0285ecb2 i18n: refresh POT and update PO files [skip ci]
197bbb9d i18n: refresh POT and update PO files [skip ci]
35dfe2eb i18n: refresh POT and update PO files [skip ci]
ce71476e i18n: refresh POT and update PO files [skip ci]
a0781620 i18n: refresh POT and update PO files [skip ci]
c8b30e20 i18n: refresh POT and update PO files [skip ci]
01059336 i18n: refresh POT and update PO files [skip ci]
a3e72f7e i18n: refresh POT and update PO files [skip ci]
5e4ba805 i18n: refresh POT and update PO files [skip ci]
68aba101 i18n: refresh POT and update PO files [skip ci]
04a20c44 build(deps): bump sortablejs from 1.15.6 to 1.15.7 in /app/static
57d5ddbb i18n: refresh POT and update PO files [skip ci]
79792512 i18n: refresh POT and update PO files [skip ci]
d9cab4ab build(deps): bump cryptography from 45.0.7 to 46.0.5
1fbd2579 i18n: refresh POT and update PO files [skip ci]
260165bc Change library deletes to upserts
d9fcaf84 build(deps): bump sqlalchemy in the flask-ecosystem group
879449ed build(deps-dev): bump ruff in the linting-tools group
e05531f7 i18n: refresh POT and update PO files [skip ci]
9c4fb21d i18n: refresh POT and update PO files [skip ci]
5b631916 i18n: refresh POT and update PO files [skip ci]
b2fa28fc i18n: refresh POT and update PO files [skip ci]
6db1f8a1 i18n: refresh POT and update PO files [skip ci]
3612b09e changed watch to stream
4882813f fix: Remove runtime directory creation in /etc
f8829694 i18n: refresh POT and update PO files [skip ci]
93e2f7bd i18n: refresh POT and update PO files [skip ci]
97b7bdf8 i18n: refresh POT and update PO files [skip ci]
50fc6e58 i18n: refresh POT and update PO files [skip ci]
7feb8d65 i18n: refresh POT and update PO files [skip ci]
5fb4a706 i18n: refresh POT and update PO files [skip ci]
8aa16816 i18n: refresh POT and update PO files [skip ci]
427a22be i18n: refresh POT and update PO files [skip ci]
9156794b i18n: refresh POT and update PO files [skip ci]
3b42b0f5 build(deps-dev): bump ty from 0.0.12 to 0.0.13
5f1b7ff3 build(deps-dev): bump commitizen from 4.12.0 to 4.12.1
8d6fb225 i18n: refresh POT and update PO files [skip ci]
304779cc i18n: refresh POT and update PO files [skip ci]
060b5f21 i18n: refresh POT and update PO files [skip ci]
fefd72c9 i18n: refresh POT and update PO files [skip ci]
208d6b2b i18n: refresh POT and update PO files [skip ci]
8f282c1b i18n: refresh POT and update PO files [skip ci]
9e433600 i18n: refresh POT and update PO files [skip ci]
438565c2 build(deps): bump filelock from 3.19.1 to 3.20.3
214d07e3 build(deps): bump werkzeug from 3.1.3 to 3.1.5
7df1b689 build(deps): bump virtualenv from 20.34.0 to 20.36.1
aae50d12 build(deps): bump cbor2 from 5.7.0 to 5.8.0
90c8fbd6 build(deps-dev): bump wlc from 1.16.1 to 1.17.2
4543320b build(deps-dev): bump ty from 0.0.9 to 0.0.12
cd1f3102 build(deps-dev): bump commitizen from 4.10.1 to 4.12.0
649f8f94 build(deps-dev): bump the linting-tools group with 2 updates
997ecb46 i18n: refresh POT and update PO files [skip ci]
fae3c324 i18n: refresh POT and update PO files [skip ci]
b7e53bb9 i18n: refresh POT and update PO files [skip ci]
0d8e15c6 i18n: refresh POT and update PO files [skip ci]
a78c2efa i18n: refresh POT and update PO files [skip ci]
3e8fb708 build(deps): bump @alpinejs/collapse in /app/static
ab215a10 i18n: refresh POT and update PO files [skip ci]
d6d6831d i18n: refresh POT and update PO files [skip ci]
4def3935 i18n: refresh POT and update PO files [skip ci]
f8724705 i18n: refresh POT and update PO files [skip ci]
04ea8a37 i18n: refresh POT and update PO files [skip ci]
e885a983 i18n: refresh POT and update PO files [skip ci]
603b403c update translation due to context
632cf6a5 pt_BR full translation
c2e1741c i18n: refresh POT and update PO files [skip ci]
fa2dacda i18n: refresh POT and update PO files [skip ci]
ca900b1d build(deps-dev): bump ty from 0.0.1a32 to 0.0.7
efb09127 build(deps): bump alpinejs from 3.15.2 to 3.15.3 in /app/static
9a5d4b97 build(deps-dev): bump the ui-frameworks group
e54693a7 i18n: refresh POT and update PO files [skip ci]
a0b5a739 build(deps): bump tiny-markdown-editor in /app/static
a96a8939 build(deps): bump sqlalchemy in the flask-ecosystem group
5af76c93 build(deps-dev): bump playwright in the testing-tools group
0bd6f1cb i18n: refresh POT and update PO files [skip ci]
852e922b i18n: refresh POT and update PO files [skip ci]
a325b269 i18n: refresh POT and update PO files [skip ci]
00d697a7 i18n: refresh POT and update PO files [skip ci]
6aa528d1 i18n: refresh POT and update PO files [skip ci]
549ca4ea i18n: refresh POT and update PO files [skip ci]
ef783a29 Implement APScheduler shutdown on Gunicorn exit
4d2f4098 i18n: refresh POT and update PO files [skip ci]
42c6551f build(deps): bump cachetools from 6.2.2 to 6.2.4
db8a9b45 i18n: refresh POT and update PO files [skip ci]
8a74d2c8 i18n: refresh POT and update PO files [skip ci]
092109ba i18n: refresh POT and update PO files [skip ci]
729a02e3 i18n: refresh POT and update PO files [skip ci]
e7c08b28 i18n: refresh POT and update PO files [skip ci]
e8e24533 i18n: refresh POT and update PO files [skip ci]
753879ab i18n: refresh POT and update PO files [skip ci]
2c5ebf97 build(deps-dev): bump the linting-tools group across 1 directory with 2 updates
5ac8352b build(deps): bump tiny-markdown-editor in /app/static
99e2eb37 i18n: refresh POT and update PO files [skip ci]
f5808596 i18n: refresh POT and update PO files [skip ci]
6ae86863 i18n: refresh POT and update PO files [skip ci]
ea0d25ef i18n: refresh POT and update PO files [skip ci]
4e13d768 i18n: refresh POT and update PO files [skip ci]
4758b7f3 i18n: refresh POT and update PO files [skip ci]
0afacbbd i18n: refresh POT and update PO files [skip ci]
006898db build(deps): bump actions/cache from 4 to 5
ad3e3fd6 build(deps-dev): bump commitizen from 4.10.0 to 4.10.1
5fac6cdd i18n: refresh POT and update PO files [skip ci]
3d393538 i18n: refresh POT and update PO files [skip ci]
54235584 i18n: refresh POT and update PO files [skip ci]
85d840ce i18n: refresh POT and update PO files [skip ci]
70eedd3c i18n: refresh POT and update PO files [skip ci]
d5929c22 i18n: refresh POT and update PO files [skip ci]
f3770f9b chore: revert .gitignore to original state, using docs-internal locally
f3cb48bb fix(i18n): clean Italian translation formatting and fix 34 incorrect translations
30c75489 Update Italian translations and metadata
17b76d40 chore: ignore #operational directory
4b66e7d8 feat(i18n): complete Italian translation (100%)
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2026.2.0`
- Deploy to production
- Build Docker images with `:latest` and `v2026.2.0` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation