### PR TITLE
Update contrast for light mode mobile next button

### DIFF
--- a/app/static/src/style.css
+++ b/app/static/src/style.css
@@ -312,6 +312,15 @@ Make sure disabled buttons don't get the pointer cursor.
     pointer-events: all; /* Re-enable clicks on buttons */
   }
 
+  /* Light mode: solid primary-colour button so it pops against any light background */
+  html:not(.dark) .wizard-btn-mobile {
+    background: var(--color-primary);
+    color: white;
+    box-shadow:
+      0 4px 12px rgba(0, 0, 0, 0.2),
+      0 2px 4px rgba(0, 0, 0, 0.12);
+  }
+
   .dark .wizard-btn-mobile {
     background: color-mix(in srgb, rgb(187 187 188) 12%, transparent);
     box-shadow:


### PR DESCRIPTION
Closes #1190 


Tested locally

### Before
<img width="331" height="488" alt="2026-03-26T11:30:47,057345046-04:00" src="https://github.com/user-attachments/assets/3de809ba-390a-4a8b-8154-6e2ae158e608" />


### After
<img width="316" height="446" alt="2026-03-26T12:23:10,457041945-04:00" src="https://github.com/user-attachments/assets/e0222bbe-d847-424e-a676-5bc939db6098" />



And dark mode is unchanged