### PR TITLE
fix: remove corrupt 0-byte session cache files instead of logging forever

### DIFF
--- a/app/utils/session_cache.py
+++ b/app/utils/session_cache.py
@@ -1,8 +1,14 @@
 """
-Robust session cache wrapper that handles stale file handle errors gracefully.
+Robust session cache wrapper that handles corrupt and stale session files gracefully.
+
+Addresses:
+- 0-byte cache files left by interrupted container restarts (GitHub #1180)
+- Stale file handle errors (errno 116) from network storage / container restarts
 """
 
+import contextlib
 import logging
+import struct
 from pathlib import Path
 
 from cachelib.file import FileSystemCache
@@ -10,8 +16,8 @@ from cachelib.file import FileSystemCache
 
 class RobustFileSystemCache(FileSystemCache):
     """
-    A FileSystemCache wrapper that handles OSError errno 116 (stale file handle)
-    by recreating the cache directory and continuing operation.
+    A FileSystemCache wrapper that automatically removes corrupt or stale
+    session files instead of logging warnings indefinitely.
     """
 
     def __init__(self, cache_dir, **kwargs):
@@ -81,38 +87,79 @@ class RobustFileSystemCache(FileSystemCache):
             # Consider delete successful for stale files (they're gone anyway)
             return True
 
-    def _cleanup_stale_files(self):
-        """Clean up any stale session files at startup."""
+    def _remove_expired(self, now: float) -> None:
+        """Remove expired cache files, deleting corrupt/empty files instead of
+        logging warnings forever (fixes GitHub #1180)."""
+        for fname in self._list_dir():
+            try:
+                with self._safe_stream_open(fname, "rb") as f:
+                    header = f.read(4)
+                if len(header) < 4:
+                    # Corrupt or empty file — remove it silently
+                    Path(fname).unlink()
+                    self._update_count(delta=-1)
+                    continue
+                expires = struct.unpack("I", header)[0]
+                if expires != 0 and expires < now:
+                    Path(fname).unlink()
+                    self._update_count(delta=-1)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                if e.errno == 116:  # Stale file handle
+                    self._try_remove(fname)
+                else:
+                    logging.warning(
+                        "Exception raised while handling cache file '%s'",
+                        fname,
+                        exc_info=True,
+                    )
+            except (EOFError, struct.error):
+                # Corrupt file — remove it
+                self._try_remove(fname)
+
+    @staticmethod
+    def _try_remove(fname: str) -> None:
+        """Best-effort removal of a cache file."""
+        with contextlib.suppress(OSError):
+            Path(fname).unlink()
+
+    def _cleanup_stale_files(self) -> None:
+        """Clean up stale or corrupt session files at startup."""
         try:
             session_dir = Path(self.cache_dir)
             if not session_dir.exists():
                 return
 
-            stale_files = []
+            bad_files: list[Path] = []
             for cache_file in session_dir.glob("*"):
-                if cache_file.is_file():
-                    try:
-                        # Try to access file stats to detect stale handles
-                        cache_file.stat()
-                        # Try to open/read the file briefly
-                        with cache_file.open("rb") as f:
-                            f.read(1)
-                    except OSError as e:
-                        if e.errno == 116:  # Stale file handle
-                            stale_files.append(cache_file)
+                if not cache_file.is_file():
+                    continue
+                try:
+                    # Empty files are corrupt — the header is a 4-byte struct
+                    if cache_file.stat().st_size < 4:
+                        bad_files.append(cache_file)
+                        continue
+                    with cache_file.open("rb") as f:
+                        f.read(4)
+                except OSError as e:
+                    if e.errno == 116:  # Stale file handle
+                        bad_files.append(cache_file)
 
-            if stale_files:
+            if bad_files:
                 logging.info(
-                    f"Found {len(stale_files)} stale session files at startup, cleaning up..."
+                    "Found %d corrupt/stale session files at startup, cleaning up...",
+                    len(bad_files),
                 )
-                for stale_file in stale_files:
+                for bad_file in bad_files:
                     try:
-                        stale_file.unlink()
-                        logging.debug(f"Removed stale session file: {stale_file}")
+                        bad_file.unlink()
                     except OSError as cleanup_error:
                         logging.warning(
-                            f"Could not cleanup stale session file {stale_file}: {cleanup_error}"
+                            "Could not cleanup session file %s: %s",
+                            bad_file,
+                            cleanup_error,
                         )
 
         except Exception as e:
-            logging.warning(f"Session cache startup cleanup failed: {e}")
+            logging.warning("Session cache startup cleanup failed: %s", e)

--- a/tests/test_session_cache.py
+++ b/tests/test_session_cache.py
@@ -1,0 +1,80 @@
+"""Tests for RobustFileSystemCache — corrupt/empty file handling (GitHub #1180)."""
+
+import struct
+import time
+
+import pytest
+
+from app.utils.session_cache import RobustFileSystemCache
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    d = tmp_path / "sessions"
+    d.mkdir()
+    return d
+
+
+class TestStartupCleanup:
+    """_cleanup_stale_files removes corrupt files at init."""
+
+    def test_removes_empty_files(self, cache_dir):
+        # Create a 0-byte file (the exact scenario from #1180)
+        (cache_dir / "empty_session").write_bytes(b"")
+
+        cache = RobustFileSystemCache(str(cache_dir))
+        assert not (cache_dir / "empty_session").exists()
+        # Cache should still work after cleanup
+        cache.set("key", "value")
+        assert cache.get("key") == "value"
+
+    def test_removes_truncated_files(self, cache_dir):
+        # File with fewer than 4 bytes (truncated header)
+        (cache_dir / "truncated").write_bytes(b"\x00\x01")
+
+        RobustFileSystemCache(str(cache_dir))
+        assert not (cache_dir / "truncated").exists()
+
+    def test_keeps_valid_files(self, cache_dir):
+        # Create a valid cache file (4-byte header + pickled data)
+        expires = int(time.time()) + 3600  # 1 hour from now
+        header = struct.pack("I", expires)
+        (cache_dir / "valid_session").write_bytes(header + b"some_data")
+
+        RobustFileSystemCache(str(cache_dir))
+        assert (cache_dir / "valid_session").exists()
+
+
+class TestRemoveExpired:
+    """_remove_expired deletes corrupt files instead of logging forever."""
+
+    def test_removes_empty_file_during_expiry_check(self, cache_dir):
+        cache = RobustFileSystemCache(str(cache_dir))
+
+        # Sneak in a 0-byte file after init
+        (cache_dir / "empty_after_init").write_bytes(b"")
+
+        # Trigger expiry check
+        cache._remove_expired(time.time())
+
+        assert not (cache_dir / "empty_after_init").exists()
+
+    def test_removes_truncated_file_during_expiry_check(self, cache_dir):
+        cache = RobustFileSystemCache(str(cache_dir))
+
+        (cache_dir / "short_header").write_bytes(b"\x00")
+
+        cache._remove_expired(time.time())
+
+        assert not (cache_dir / "short_header").exists()
+
+    def test_normal_expiry_still_works(self, cache_dir):
+        cache = RobustFileSystemCache(str(cache_dir), default_timeout=1)
+        cache.set("ephemeral", "data")
+        assert cache.get("ephemeral") == "data"
+
+        # Wait for expiry
+        time.sleep(1.5)
+        cache._remove_expired(time.time())
+
+        assert cache.get("ephemeral") is None


### PR DESCRIPTION
## Summary

- Overrides cachelib's `_remove_expired` to delete empty/truncated session files instead of logging warnings indefinitely
- Updates startup cleanup to detect files with `st_size < 4` (corrupt header) in addition to stale file handles
- Adds 6 tests covering empty files, truncated files, valid file preservation, and normal expiry

## Root Cause

When a container restart interrupts writes to the session cache directory, it leaves behind 0-byte files. cachelib's `_remove_expired` tries to `struct.unpack("I", f.read(4))` on these empty files, catches the `struct.error`, logs a warning, but **never removes the file** — causing infinite log spam.

## Test plan

- [x] `test_removes_empty_files` — 0-byte files are cleaned at startup
- [x] `test_removes_truncated_files` — partial header files are cleaned at startup
- [x] `test_keeps_valid_files` — valid session files are preserved
- [x] `test_removes_empty_file_during_expiry_check` — 0-byte files created after startup are cleaned during expiry
- [x] `test_removes_truncated_file_during_expiry_check` — truncated files created after startup are cleaned during expiry
- [x] `test_normal_expiry_still_works` — standard cache expiry behavior is unchanged

Fixes #1180