### PR TITLE
fix: preserve per-server expiry dates in user grouping

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -1093,7 +1093,7 @@ def _group_users_for_display(user_list):
 
     cards = []
     for lst in groups.values():
-        primary = min(lst, key=lambda x: (x.username or ""))
+        primary = min(lst, key=lambda x: x.username or "")
         photo = next((a.photo for a in lst if a.photo), None)
         expire_dates = [a.expires for a in lst if a.expires]
         expires = min(expire_dates) if expire_dates else None
@@ -1116,7 +1116,7 @@ def _group_users_for_display(user_list):
 
         primary.accounts = lst
         primary.photo = photo or primary.photo
-        primary.expires = expires
+        primary.earliest_expires = expires
         primary.code = code
         primary.allowSync = allow_sync
         primary.invited_date = invited_date

--- a/app/templates/tables/user_card.html
+++ b/app/templates/tables/user_card.html
@@ -109,8 +109,8 @@
                     </path>
                   </svg>
                   <span>
-                    {% if user.expires %}
-                      {{ _("Expires") }}: {{ user.expires|human_date }}
+                    {% if user.earliest_expires %}
+                      {{ _("Expires") }}: {{ user.earliest_expires|human_date }}
                     {% else %}
                       {{ _("Expires") }}: {{ _("Never") }}
                     {% endif %}


### PR DESCRIPTION
## Summary

Fixes #1163.

- `_group_users_for_display()` was overwriting `primary.expires` with `min(expire_dates)`, destroying each account's individual expiry value before the template could inspect them.
- The template's `expiry_values|unique|list|length > 1` check always saw identical values (the mutated minimum) so `has_mixed_expiry` was always `False`.
- Fix: store the computed minimum in `primary.earliest_expires` instead, leaving `primary.expires` (and every `acct.expires` in `primary.accounts`) untouched.
- The `else` branch in `user_card.html` now reads `user.earliest_expires` for the uniform-expiry display.

## Test plan

- [ ] Users with different expiry dates across servers display per-server expiry dates (mixed-expiry branch renders)
- [ ] Users with a single server or identical expiry dates across servers display one expiry date (uniform branch renders `earliest_expires`)
- [ ] Users with no expiry show "Never" in both branches