### PR TITLE
fix: add missing created_at column to User model

### DIFF
--- a/app/blueprints/api/api_routes.py
+++ b/app/blueprints/api/api_routes.py
@@ -371,8 +371,8 @@ class UsersListResource(Resource):
                             "expires": user.expires.isoformat()
                             if user.expires
                             else None,
-                            "created": user.created.isoformat()
-                            if hasattr(user, "created") and user.created
+                            "created_at": user.created_at.isoformat()
+                            if hasattr(user, "created_at") and user.created_at
                             else None,
                         }
                     )

--- a/app/blueprints/api/models.py
+++ b/app/blueprints/api/models.py
@@ -46,7 +46,7 @@ user_model = api.model(
             description="Type of media server (plex, jellyfin, etc.)"
         ),
         "expires": fields.DateTime(description="Expiration date (ISO format)"),
-        "created": fields.DateTime(description="Creation date (ISO format)"),
+        "created_at": fields.DateTime(description="Creation date (ISO format)"),
     },
 )
 

--- a/app/models.py
+++ b/app/models.py
@@ -206,6 +206,10 @@ class User(db.Model, UserMixin):
         db.Text, nullable=True
     )  # JSON array of library names
 
+    created_at = db.Column(
+        db.DateTime, default=lambda: datetime.now(UTC), nullable=True
+    )
+
     # Legacy metadata caching fields (will be phased out)
     library_access_json = db.Column(db.Text, nullable=True)
 

--- a/migrations/versions/4a39bd26329d_20260329_add_user_created_at.py
+++ b/migrations/versions/4a39bd26329d_20260329_add_user_created_at.py
@@ -1,0 +1,32 @@
+"""20260329_add_user_created_at
+
+Revision ID: 4a39bd26329d
+Revises: e6155a91eb50
+Create Date: 2026-03-29 16:10:14.582887
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4a39bd26329d"
+down_revision = "e6155a91eb50"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "user",
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.text("(datetime('now'))"),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("user", "created_at")


### PR DESCRIPTION
## Summary

Fixes #1182 — the \"Joined/Create date\" for users was always `null` because:

- The `User` model had no `created_at` column (every other model did)
- `api_routes.py` referenced the non-existent attribute `user.created`
- The OpenAPI spec declared the field as `created` instead of `created_at`

Changes made:
- Add `created_at = db.Column(db.DateTime, ...)` to the `User` model in `app/models.py`
- Add Alembic migration `4a39bd26329d_20260329_add_user_created_at.py` that backfills existing rows using `server_default=sa.text("(datetime('now'))")`
- Update `app/blueprints/api/api_routes.py` serialization from `user.created` → `user.created_at`
- Update `app/blueprints/api/models.py` OpenAPI field from `created` → `created_at`

## Test plan

- [ ] Apply migration on a database with existing users and verify `created_at` is backfilled
- [ ] Create a new user via the invitation wizard and confirm `GET /api/v1/users` returns a non-null `created_at`
- [ ] Confirm the admin users table displays the joined date correctly