### PR TITLE
fix: update existing Plex share on re-invite instead of failing

### DIFF
--- a/app/blueprints/public/routes.py
+++ b/app/blueprints/public/routes.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import requests
+import structlog
 from flask import (
     Blueprint,
     Response,
@@ -13,6 +14,7 @@ from flask import (
     session,
     url_for,
 )
+from flask_babel import gettext as _
 
 from app.extensions import db, limiter
 from app.models import Invitation, MediaServer, Settings, User
@@ -123,7 +125,11 @@ def join():
             try:
                 handle_oauth_token(current_app, token, code)
             except PlexInvitationError as e:
-                # Show user-friendly error message from Plex API
+                structlog.get_logger().error(
+                    "Plex invitation failed",
+                    code=code,
+                    error=e.message,
+                )
                 name_setting = Settings.query.filter_by(key="server_name").first()
                 server_name = name_setting.value if name_setting else None
 
@@ -131,14 +137,16 @@ def join():
                     "user-plex-login.html",
                     server_name=server_name,
                     code=code,
-                    code_error=f"Plex invitation failed: {e.message}",
+                    code_error=_(
+                        "There was an issue setting up your access. Please contact your server admin."
+                    ),
                 )
             except Exception as e:
-                # Handle any other unexpected errors
-                import logging
-
-                logging.error(f"Unexpected error during Plex OAuth: {e}")
-
+                structlog.get_logger().error(
+                    "Unexpected error during Plex OAuth",
+                    code=code,
+                    error=str(e),
+                )
                 name_setting = Settings.query.filter_by(key="server_name").first()
                 server_name = name_setting.value if name_setting else None
 
@@ -146,7 +154,9 @@ def join():
                     "user-plex-login.html",
                     server_name=server_name,
                     code=code,
-                    code_error="An unexpected error occurred during invitation. Please try again or contact support.",
+                    code_error=_(
+                        "There was an issue setting up your access. Please contact your server admin."
+                    ),
                 )
 
         # Determine if there are additional servers attached to the invite

--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -1350,9 +1350,23 @@ def _invite_user(email: str, code: str, _user_id: int, server: MediaServer) -> N
             client.invite_home(email, libs, allow_sync, allow_tv, allow_camera_upload)
         else:
             client.invite_friend(email, libs, allow_sync, allow_tv, allow_camera_upload)
-    except PlexInvitationError:
-        # Re-raise PlexInvitationError to preserve the user-friendly message
-        raise
+    except PlexInvitationError as e:
+        if "already sharing" in e.message.lower():
+            # User already has a share — update libraries and permissions instead
+            structlog.get_logger().info(
+                "User already has share, updating libraries and permissions",
+                email=email,
+            )
+            permissions = {
+                "allow_downloads": allow_sync,
+                "allow_live_tv": allow_tv,
+                "allow_camera_upload": allow_camera_upload,
+            }
+            client.update_user_libraries(email, libs if libs else None)
+            client.update_user_permissions(email, permissions)
+        else:
+            # Re-raise PlexInvitationError to preserve the user-friendly message
+            raise
     except Exception as e:
         # Handle any other unexpected errors
         error_message = extract_plex_error_message(e)


### PR DESCRIPTION
## Summary

Fixes #1168.

- When a user who already has a Plex share uses a new invite link, `_invite_user()` now catches the "already sharing" `PlexInvitationError` and calls `update_user_libraries()` + `update_user_permissions()` to bring the share in line with the new invitation's settings, rather than propagating the error.
- The `/join` route now shows a generic, translatable user-facing message (`_("There was an issue setting up your access. Please contact your server admin.")`) for all `PlexInvitationError` and unexpected `Exception` cases, while logging the technical detail via `structlog` for admin visibility.
- Removed an inline `import logging` inside an exception handler in `routes.py` — the top-level `structlog` import is now used consistently throughout the file.

## Test plan

- [ ] Invite a Plex user who already has an existing share; confirm the wizard completes without error and the share reflects the new invitation's library/permission settings.
- [ ] Invite a brand-new Plex user; confirm the normal invite path is unaffected.
- [ ] Trigger a non-"already sharing" `PlexInvitationError` (e.g. bad email); confirm the error is re-raised and the user sees the generic contact-admin message.
- [ ] Confirm the technical error details appear in the server logs via structlog.