### PR TITLE
fix: correct Emby library ID mapping and prevent silent folder fallback (#1195)

### DIFF
--- a/app/services/media/emby.py
+++ b/app/services/media/emby.py
@@ -3,6 +3,7 @@ import re
 from typing import TYPE_CHECKING
 
 import requests
+import structlog
 from sqlalchemy import or_
 
 from app.extensions import db
@@ -17,18 +18,24 @@ if TYPE_CHECKING:
 # Reuse the same email regex as jellyfin
 EMAIL_RE = re.compile(r"[^@]+@[^@]+\.[^@]+")
 
+log = structlog.get_logger(__name__)
+
 
 @register_media_client("emby")
 class EmbyClient(JellyfinClient):
     """Wrapper around the Emby REST API using credentials from Settings."""
 
     def libraries(self) -> dict[str, str]:
-        """Return mapping of library GUIDs to names."""
+        """Return mapping of library Id to names.
+
+        Uses ``Id`` (not ``Guid``) so that ``Library.external_id`` stores the
+        value that Emby's ``EnabledFolders`` policy field actually expects.
+        """
         try:
             items = self.get("/Library/MediaFolders").json()["Items"]
-            return {item["Guid"]: item["Name"] for item in items}
+            return {item["Id"]: item["Name"] for item in items}
         except Exception as exc:
-            logging.warning("Emby: failed to fetch libraries – %s", exc)
+            log.warning("emby.libraries.failed", error=str(exc))
             return {}
 
     def scan_libraries(
@@ -41,7 +48,7 @@ class EmbyClient(JellyfinClient):
             token: Optional API token override
 
         Returns:
-            dict: Library name -> library GUID mapping
+            dict: Library name -> library Id mapping (uses ``Id``, not ``Guid``)
         """
         try:
             if url and token:
@@ -56,9 +63,9 @@ class EmbyClient(JellyfinClient):
             else:
                 items = self.get("/Library/MediaFolders").json()["Items"]
 
-            return {item["Name"]: item["Guid"] for item in items}
+            return {item["Name"]: item["Id"] for item in items}
         except Exception as exc:
-            logging.warning("Emby: failed to scan libraries – %s", exc)
+            log.warning("emby.scan_libraries.failed", error=str(exc))
             return {}
 
     def statistics(self):
@@ -185,31 +192,59 @@ class EmbyClient(JellyfinClient):
         """Return placeholder password for local DB."""
         return "emby-user"
 
-    def _set_specific_folders(self, user_id: str, names: list[str]):
-        """Set library access for a user and ensure playback permissions."""
-        items = self.get("/Library/MediaFolders").json()["Items"]
-        mapping = {i["Name"]: i["Guid"] for i in items}
+    def _set_specific_folders(self, user_id: str, names: list[str]) -> None:
+        """Set library access for a user and ensure playback permissions.
 
-        # Debug logging
-        logging.info(f"EMBY: _set_specific_folders called with names: {names}")
-        logging.info(f"EMBY: mapping: {mapping}")
+        Builds a mapping of ``{Name: Id, Id: Id}`` so that lookups succeed
+        whether ``names`` contains library names or already-resolved Ids.
+        """
+        items = self.get("/Library/MediaFolders").json()["Items"]
+        # Primary mapping: Name -> Id
+        mapping: dict[str, str] = {i["Name"]: i["Id"] for i in items}
+        # Also allow Id passthrough and Guid -> Id for backwards compatibility
+        mapping.update({i["Id"]: i["Id"] for i in items})
+        mapping.update({i["Guid"]: i["Id"] for i in items if "Guid" in i})
+
+        log.debug("emby._set_specific_folders", user_id=user_id, requested=names)
 
         folder_ids = [self._folder_name_to_id(n, mapping) for n in names]
         folder_ids = [fid for fid in folder_ids if fid]
 
-        logging.info(f"EMBY: folder_ids after mapping: {folder_ids}")
+        if names and not folder_ids:
+            log.warning(
+                "emby._set_specific_folders.no_libraries_resolved",
+                user_id=user_id,
+                requested=names,
+                hint="No requested libraries could be mapped to an Emby folder Id. "
+                "Re-scan libraries on the server settings page to refresh external IDs.",
+            )
+            # Restrict to nothing rather than silently granting everything.
+            policy_patch = {
+                "EnableAllFolders": False,
+                "EnabledFolders": [],
+                "EnableMediaPlayback": True,
+                "EnableAudioPlaybackTranscoding": True,
+                "EnableVideoPlaybackTranscoding": True,
+                "EnablePlaybackRemuxing": True,
+                "EnableRemoteAccess": True,
+            }
+        else:
+            policy_patch = {
+                "EnableAllFolders": not folder_ids,
+                "EnabledFolders": folder_ids,
+                "EnableMediaPlayback": True,
+                "EnableAudioPlaybackTranscoding": True,
+                "EnableVideoPlaybackTranscoding": True,
+                "EnablePlaybackRemuxing": True,
+                "EnableRemoteAccess": True,
+            }
 
-        policy_patch = {
-            "EnableAllFolders": not folder_ids,
-            "EnabledFolders": folder_ids,
-            "EnableMediaPlayback": True,
-            "EnableAudioPlaybackTranscoding": True,
-            "EnableVideoPlaybackTranscoding": True,
-            "EnablePlaybackRemuxing": True,
-            "EnableRemoteAccess": True,
-        }
-
-        logging.info(f"EMBY: Setting policy patch for user {user_id}: {policy_patch}")
+        log.debug(
+            "emby._set_specific_folders.applying",
+            user_id=user_id,
+            enable_all=policy_patch["EnableAllFolders"],
+            folder_ids=folder_ids,
+        )
 
         current = self.get(f"/Users/{user_id}").json()["Policy"]
         current.update(policy_patch)

--- a/app/services/media/jellyfin.py
+++ b/app/services/media/jellyfin.py
@@ -464,44 +464,46 @@ class JellyfinClient(RestApiMixin):
             return name
         return cache.get(name)
 
-    def _set_specific_folders(self, user_id: str, names: list[str]):
-        mapping = {
-            item["Name"]: item["Id"]
-            for item in self.get("/Library/MediaFolders").json()["Items"]
-        }
-
-        # Also map IDs directly for convenience
+    def _set_specific_folders(self, user_id: str, names: list[str]) -> None:
+        log = structlog.get_logger(__name__)
+        items = self.get("/Library/MediaFolders").json()["Items"]
+        mapping = {item["Name"]: item["Id"] for item in items}
+        # Also map IDs directly so callers may pass either a name or an Id.
         mapping.update({v: v for v in mapping.values()})
+
+        log.debug("jellyfin._set_specific_folders", user_id=user_id, requested=names)
 
         folder_ids = [self._folder_name_to_id(n, mapping) for n in names]
         folder_ids = [fid for fid in folder_ids if fid]
 
-        # Debug logging
-        import logging
+        if names and not folder_ids:
+            log.warning(
+                "jellyfin._set_specific_folders.no_libraries_resolved",
+                user_id=user_id,
+                requested=names,
+                hint="No requested libraries could be mapped to a Jellyfin folder Id. "
+                "Re-scan libraries on the server settings page to refresh external IDs.",
+            )
+            # Restrict to nothing rather than silently granting access to all libraries.
+            policy_patch = {
+                "EnableAllFolders": False,
+                "EnabledFolders": [],
+            }
+        else:
+            policy_patch = {
+                "EnableAllFolders": not folder_ids,
+                "EnabledFolders": folder_ids,
+            }
 
-        logging.info(f"JELLYFIN: _set_specific_folders called with names: {names}")
-        logging.info(f"JELLYFIN: mapping: {mapping}")
-        logging.info(f"JELLYFIN: folder_ids after mapping: {folder_ids}")
-
-        policy_patch = {
-            "EnableAllFolders": not folder_ids,
-            "EnabledFolders": folder_ids,
-        }
-
-        logging.info(
-            f"JELLYFIN: Setting policy patch for user {user_id}: {policy_patch}"
+        log.debug(
+            "jellyfin._set_specific_folders.applying",
+            user_id=user_id,
+            enable_all=policy_patch["EnableAllFolders"],
+            folder_ids=folder_ids,
         )
 
         current = self.get(f"/Users/{user_id}").json()["Policy"]
-        logging.info(
-            f"JELLYFIN: Current policy before update: EnableAllFolders={current.get('EnableAllFolders')}, EnabledFolders={current.get('EnabledFolders')}"
-        )
-
         current.update(policy_patch)
-        logging.info(
-            f"JELLYFIN: Final policy to be set: EnableAllFolders={current.get('EnableAllFolders')}, EnabledFolders={current.get('EnabledFolders')}"
-        )
-
         self.set_policy(user_id, current)
 
     # --- public sign-up ---------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1195 — Emby users could not see any library after being invited because library access was being silently granted to **all** libraries instead of the selected ones.

- **Root cause 1 (critical):** `EmbyClient.libraries()` was returning `{Guid: Name}`, so `Library.external_id` stored the Guid. But `_set_specific_folders()` was building a `{Name: Guid}` mapping and passing Guids to Emby's `EnabledFolders` policy field, which expects the `Id`. Every lookup resolved to nothing, producing an empty list.
- **Root cause 2 (moderate):** When `_set_specific_folders()` produced an empty `folder_ids` list it set `EnableAllFolders: True`, silently granting the user access to every library regardless of what the admin configured.

### Changes

**`app/services/media/emby.py`**
- `libraries()` now returns `{Id: Name}` so `Library.external_id` stores the value that `EnabledFolders` expects.
- `scan_libraries()` now returns `{Name: Id}` (was `{Name: Guid}`) for consistency.
- `_set_specific_folders()` override builds a three-way mapping `{Name: Id, Id: Id, Guid: Id}`, providing backwards compatibility for existing `Library` records that still hold a Guid. Replaces inline debug `logging.info()` calls with structured `structlog` events.

**`app/services/media/jellyfin.py`**
- `_set_specific_folders()`: when `names` is non-empty but all lookups fail, logs a `WARNING` via structlog and sets `EnableAllFolders: False` with an empty `EnabledFolders` list — restricting access to nothing rather than granting everything. Removes the ad-hoc `import logging` inside the function body and replaces debug calls with structlog.

## Test plan

- [ ] Invite a new user on an Emby server with specific libraries selected — verify only those libraries are accessible after joining.
- [ ] Invite a new user on an Emby server with no libraries selected (all) — verify all libraries are accessible.
- [ ] Invite a new user on a Jellyfin server with specific libraries — verify behaviour is unchanged.
- [ ] Verify that a server with stale `Library.external_id` Guid values (pre-fix records) still resolves correctly after re-scanning libraries.
- [ ] Confirm that if library resolution fails entirely, the warning is logged and the user ends up with no library access (not full access).