### PR TITLE
fix: use playback position instead of file duration for watch time

### DIFF
--- a/app/activity/monitoring/collectors/emby.py
+++ b/app/activity/monitoring/collectors/emby.py
@@ -104,6 +104,33 @@ class EmbyCollector(BaseCollector):
     def _emit_session_event(self, session_data: dict[str, Any], event_type: str):
         """Convert session data to ActivityEvent and emit."""
         try:
+            # For session_end events, use position_ms (last known playback position)
+            # as the watched duration rather than duration_ms (total file runtime from
+            # RunTimeTicks). This avoids overestimating watch time when a user stops
+            # partway through a title. Fall back to duration_ms only when position_ms
+            # is unavailable or zero.
+            position_ms: int | None = session_data.get("position_ms")
+            raw_duration_ms: int | None = session_data.get("duration_ms")
+
+            if event_type == "session_end":
+                if position_ms:
+                    duration_ms = position_ms
+                    self.logger.debug(
+                        "session_end_duration_from_position",
+                        session_id=session_data.get("session_id"),
+                        position_ms=position_ms,
+                        file_runtime_ms=raw_duration_ms,
+                    )
+                else:
+                    duration_ms = raw_duration_ms
+                    self.logger.debug(
+                        "session_end_duration_fallback_to_runtime",
+                        session_id=session_data.get("session_id"),
+                        duration_ms=raw_duration_ms,
+                    )
+            else:
+                duration_ms = raw_duration_ms
+
             event = ActivityEvent(
                 event_type=event_type,
                 server_id=self.server.id,
@@ -117,8 +144,8 @@ class EmbyCollector(BaseCollector):
                 series_name=session_data.get("series_name"),
                 season_number=session_data.get("season_number"),
                 episode_number=session_data.get("episode_number"),
-                duration_ms=session_data.get("duration_ms"),
-                position_ms=session_data.get("position_ms"),
+                duration_ms=duration_ms,
+                position_ms=position_ms,
                 device_name=session_data.get("device_name"),
                 client_name=session_data.get("client"),
                 ip_address=session_data.get("ip_address"),

--- a/app/activity/monitoring/collectors/jellyfin.py
+++ b/app/activity/monitoring/collectors/jellyfin.py
@@ -103,6 +103,33 @@ class JellyfinCollector(BaseCollector):
     def _emit_session_event(self, session_data: dict[str, Any], event_type: str):
         """Convert session data to ActivityEvent and emit."""
         try:
+            # For session_end events, use position_ms (last known playback position)
+            # as the watched duration rather than duration_ms (total file runtime from
+            # RunTimeTicks). This avoids overestimating watch time when a user stops
+            # partway through a title. Fall back to duration_ms only when position_ms
+            # is unavailable or zero.
+            position_ms: int | None = session_data.get("position_ms")
+            raw_duration_ms: int | None = session_data.get("duration_ms")
+
+            if event_type == "session_end":
+                if position_ms:
+                    duration_ms = position_ms
+                    self.logger.debug(
+                        "session_end_duration_from_position",
+                        session_id=session_data.get("session_id"),
+                        position_ms=position_ms,
+                        file_runtime_ms=raw_duration_ms,
+                    )
+                else:
+                    duration_ms = raw_duration_ms
+                    self.logger.debug(
+                        "session_end_duration_fallback_to_runtime",
+                        session_id=session_data.get("session_id"),
+                        duration_ms=raw_duration_ms,
+                    )
+            else:
+                duration_ms = raw_duration_ms
+
             event = ActivityEvent(
                 event_type=event_type,
                 server_id=self.server.id,
@@ -116,8 +143,8 @@ class JellyfinCollector(BaseCollector):
                 series_name=session_data.get("series_name"),
                 season_number=session_data.get("season_number"),
                 episode_number=session_data.get("episode_number"),
-                duration_ms=session_data.get("duration_ms"),
-                position_ms=session_data.get("position_ms"),
+                duration_ms=duration_ms,
+                position_ms=position_ms,
                 device_name=session_data.get("device_name"),
                 client_name=session_data.get("client"),
                 ip_address=session_data.get("ip_address"),

--- a/app/services/historical/importers/jellyfin_importer.py
+++ b/app/services/historical/importers/jellyfin_importer.py
@@ -217,8 +217,27 @@ class JellyfinHistoricalImporter:
         if viewed_at < cutoff:
             return "exhausted"
 
-        duration_ms = ticks_to_ms(item.get("RunTimeTicks"))
+        runtime_ms = ticks_to_ms(item.get("RunTimeTicks"))
         position_ms = ticks_to_ms(user_data.get("PlaybackPositionTicks"))
+        fully_played: bool = bool(user_data.get("Played", False))
+
+        # Use the actual playback position for partially-watched items so that
+        # watch time reflects how much the user actually watched rather than the
+        # total file duration.  For fully-played items the runtime is a safe
+        # proxy (position resets to 0 on Jellyfin/Emby once marked played).
+        if fully_played:
+            duration_ms = runtime_ms
+        else:
+            duration_ms = position_ms if position_ms else runtime_ms
+
+        logger.debug(
+            "jellyfin_item_duration_resolved",
+            media_title=item.get("Name"),
+            fully_played=fully_played,
+            runtime_ms=runtime_ms,
+            position_ms=position_ms,
+            resolved_duration_ms=duration_ms,
+        )
 
         started_at = viewed_at
         if duration_ms and duration_ms > 0:
@@ -238,6 +257,13 @@ class JellyfinHistoricalImporter:
             f"{media_id}_{user_id}_{int(viewed_at.timestamp())}"
         )
 
+        if fully_played:
+            duration_source = "runtime_ticks"
+        elif position_ms:
+            duration_source = "playback_position_ticks"
+        else:
+            duration_source = "runtime_ticks_fallback"
+
         metadata = {
             "imported_from": f"{self.media_server.server_type}_history",
             "historical_viewed_at": viewed_at.isoformat(),
@@ -245,7 +271,7 @@ class JellyfinHistoricalImporter:
             "historical_play_count": user_data.get("PlayCount"),
             "historical_position_ms": position_ms or None,
             "media_source_id": media_id,
-            "historical_duration_source": "runtime_ticks" if duration_ms else None,
+            "historical_duration_source": duration_source,
             "historical_user_id": str(user_id),
         }
 


### PR DESCRIPTION
## Summary

Fixes #1121 — watch time/duration is severely overestimated for Jellyfin and Emby users who stop partway through a title.

- **Root cause**: `RunTimeTicks` (total file runtime) was being stored as the session's `duration_ms`. A user watching 30 min of a 2-hour movie was recorded as having watched 2 hours.
- **Jellyfin collector** (`app/activity/monitoring/collectors/jellyfin.py`): On `session_end`, `duration_ms` is now taken from `position_ms` (the last known playback position). Falls back to `raw_duration_ms` only when `position_ms` is unavailable or zero.
- **Emby collector** (`app/activity/monitoring/collectors/emby.py`): Identical fix — Emby and Jellyfin share the same Sessions API shape.
- **Jellyfin historical importer** (`app/services/historical/importers/jellyfin_importer.py`): For items where `UserData.Played == false` (partially watched), `PlaybackPositionTicks` is used instead of `RunTimeTicks`. Fully-played items keep `RunTimeTicks` as their proxy since Jellyfin/Emby reset position to 0 on full playback.
- The `historical_duration_source` metadata field is updated to accurately reflect which source was used (`runtime_ticks`, `playback_position_ticks`, or `runtime_ticks_fallback`).

Plex was already correct and is unchanged (it uses elapsed wall-clock time minus paused time via `SessionManager`).

## Test plan

- [ ] Start a Jellyfin or Emby session, play ~20 min of a 2-hour movie, then stop — confirm the recorded `duration_ms` is ~20 min, not 2 hours
- [ ] Repeat with an Emby server
- [ ] Trigger a historical import; verify partially-watched items use `PlaybackPositionTicks` and fully-watched items use `RunTimeTicks`
- [ ] Confirm `historical_duration_source` metadata values are correct in each case
- [ ] Verify Plex behaviour is unchanged