### PR TITLE
Release v2026.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2026.3.0",
+  "version": "2026.3.1",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2026.3.0"
+version = "2026.3.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -154,7 +154,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2026.3.0"
+version = "2026.3.1"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2026.3.0"
+version = "2026.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2026.3.1

## What's Changed

### 🚀 Features
- add LDAP authentication and invitation integration

### 🐛 Bug Fixes
- clean up _alembic_tmp_ debris from prior failed migration runs
- make LDAP migration idempotent for crash recovery
- disable FK enforcement during LDAP migration batch_alter_table
- resolve double scrollbar on LDAP settings and add experimental label
- use batch_alter_table for SQLite-compatible column addition
- correct Jinja2 syntax in passkey registration template (#1126)
- resolve all test failures, linting errors, and type errors
- security, architecture, and code quality improvements
- use playback position instead of file duration for watch time (#1121)
- correct Emby library ID mapping and prevent silent folder fallback (#1195)
- update existing Plex share on re-invite instead of failing (#1168)
- add missing created_at column to User model (#1182)
- handle legacy admin user when creating API keys (#1174)
- preserve per-server expiry dates in user grouping (#1163)
- address security, correctness, and code quality issues
- remove corrupt 0-byte session cache files instead of logging forever

### 🔧 Build System / Dependencies
- bump cryptography from 46.0.5 to 46.0.6
- bump the ui-frameworks group
- bump requests from 2.32.5 to 2.33.0
- bump tiny-markdown-editor in /app/static
- bump inapp-spy from 5.0.8 to 5.0.9 in /app/static
- bump picomatch from 4.0.3 to 4.0.4 in /app/static
- bump cbor2 from 5.8.0 to 5.9.0
- bump sqlalchemy in the flask-ecosystem group
- bump ruff in the linting-tools group
- bump pyasn1 from 0.6.2 to 0.6.3
- bump pyopenssl from 25.3.0 to 26.0.0
- bump docker/setup-qemu-action from 3 to 4
- bump docker/login-action from 3 to 4
- bump python-dotenv from 1.2.1 to 1.2.2
- bump commitizen from 4.13.8 to 4.13.9
- bump ty from 0.0.18 to 0.0.19

### 💄 Styling
- reformat templates with djlint
- fix djlint formatting in template

### 🧹 Chores
- 
- 

### 📝 Other Changes
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Update contrast for light mode mobile next button
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- i18n: refresh POT and update PO files [skip ci]
- Add Telegram notification support


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2026.3.1...v2026.3.1

## 📋 All Commits Included (72 commits)

<details>
<summary>Click to expand commit list</summary>

```
3a1f3993 chore: release v2026.3.1
c57d2903 fix: clean up _alembic_tmp_ debris from prior failed migration runs
7b316a46 fix: make LDAP migration idempotent for crash recovery
48848657 fix: disable FK enforcement during LDAP migration batch_alter_table
c61e183c chore: release v2026.3.0
9b8c0248 fix: resolve double scrollbar on LDAP settings and add experimental label
8817e0a3 fix: use batch_alter_table for SQLite-compatible column addition
7b70be9d fix: correct Jinja2 syntax in passkey registration template (#1126)
ef8ad209 style: reformat templates with djlint
396e940b style: fix djlint formatting in template
73c29458 fix: resolve all test failures, linting errors, and type errors
67247546 fix(ldap): security, architecture, and code quality improvements
65ed356d fix: use playback position instead of file duration for watch time (#1121)
e9f3c245 fix: correct Emby library ID mapping and prevent silent folder fallback (#1195)
751bfb67 fix: update existing Plex share on re-invite instead of failing (#1168)
41ca8856 fix: add missing created_at column to User model (#1182)
09b79b5e fix: handle legacy admin user when creating API keys (#1174)
9f3d66e4 fix: preserve per-server expiry dates in user grouping (#1163)
498886c0 fix(ldap): address security, correctness, and code quality issues
e5360491 fix: remove corrupt 0-byte session cache files instead of logging forever
d2dc88a6 i18n: refresh POT and update PO files [skip ci]
8f019d6f build(deps): bump cryptography from 46.0.5 to 46.0.6
c8a457fc i18n: refresh POT and update PO files [skip ci]
e8c89c26 build(deps-dev): bump the ui-frameworks group
435c4259 i18n: refresh POT and update PO files [skip ci]
7814af2b build(deps): bump requests from 2.32.5 to 2.33.0
acec57ed Update contrast for light mode mobile next button
9ece2974 build(deps): bump tiny-markdown-editor in /app/static
70a05eb2 build(deps): bump inapp-spy from 5.0.8 to 5.0.9 in /app/static
1d100aff build(deps): bump picomatch from 4.0.3 to 4.0.4 in /app/static
b2f1ab0e i18n: refresh POT and update PO files [skip ci]
cf0a8941 i18n: refresh POT and update PO files [skip ci]
f8264d36 i18n: refresh POT and update PO files [skip ci]
97d4dad0 build(deps): bump cbor2 from 5.8.0 to 5.9.0
931d1818 build(deps): bump sqlalchemy in the flask-ecosystem group
221d7855 build(deps-dev): bump ruff in the linting-tools group
61781887 i18n: refresh POT and update PO files [skip ci]
8aa09355 i18n: refresh POT and update PO files [skip ci]
0fb738a9 i18n: refresh POT and update PO files [skip ci]
6ca2cd2a i18n: refresh POT and update PO files [skip ci]
7d69ecec i18n: refresh POT and update PO files [skip ci]
e45c9a5b i18n: refresh POT and update PO files [skip ci]
ed2b45f5 build(deps): bump pyasn1 from 0.6.2 to 0.6.3
7f8fb43b i18n: refresh POT and update PO files [skip ci]
c20d54ab build(deps): bump pyopenssl from 25.3.0 to 26.0.0
6da9e6d6 i18n: refresh POT and update PO files [skip ci]
3bb38ac9 i18n: refresh POT and update PO files [skip ci]
37f3a610 i18n: refresh POT and update PO files [skip ci]
b377416b i18n: refresh POT and update PO files [skip ci]
0a821893 i18n: refresh POT and update PO files [skip ci]
95aada04 i18n: refresh POT and update PO files [skip ci]
7f5f7b88 i18n: refresh POT and update PO files [skip ci]
ed766272 build(deps): bump docker/setup-qemu-action from 3 to 4
753ffe2e build(deps): bump docker/login-action from 3 to 4
99e3673d i18n: refresh POT and update PO files [skip ci]
f9645b4b i18n: refresh POT and update PO files [skip ci]
2d34f9e4 i18n: refresh POT and update PO files [skip ci]
8df9764b i18n: refresh POT and update PO files [skip ci]
ede5dc34 i18n: refresh POT and update PO files [skip ci]
3bbfa440 i18n: refresh POT and update PO files [skip ci]
4351823a i18n: refresh POT and update PO files [skip ci]
0f0b5bd1 build(deps): bump python-dotenv from 1.2.1 to 1.2.2
c777e048 build(deps-dev): bump commitizen from 4.13.8 to 4.13.9
a84af520 build(deps-dev): bump ty from 0.0.18 to 0.0.19
7a0cd431 i18n: refresh POT and update PO files [skip ci]
8d131fd8 i18n: refresh POT and update PO files [skip ci]
258dfc41 i18n: refresh POT and update PO files [skip ci]
8c7db9cf i18n: refresh POT and update PO files [skip ci]
2289a503 i18n: refresh POT and update PO files [skip ci]
f0b1aff9 i18n: refresh POT and update PO files [skip ci]
7f64f558 Add Telegram notification support
5bb51e0c feat(ldap): add LDAP authentication and invitation integration
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2026.3.1`
- Deploy to production
- Build Docker images with `:latest` and `v2026.3.1` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation