### PR TITLE
refactor: Phase 1 invitation schema normalization

### DIFF
--- a/app/blueprints/api/api_routes.py
+++ b/app/blueprints/api/api_routes.py
@@ -656,19 +656,8 @@ class InvitationsListResource(Resource):
                 # Use server name resolver for display name logic
                 display_info = get_display_name_info(servers)
 
-                # Convert specific_libraries from string to list of integers
-                specific_libraries = []
-                if invitation.specific_libraries:
-                    try:
-                        # Parse comma-separated string to list of integers
-                        specific_libraries = [
-                            int(lib_id.strip())
-                            for lib_id in invitation.specific_libraries.split(",")
-                            if lib_id.strip().isdigit()
-                        ]
-                    except (ValueError, AttributeError):
-                        # If parsing fails, use empty list
-                        specific_libraries = []
+                # Get library IDs from the normalized relationship
+                specific_libraries = [lib.id for lib in invitation.libraries]
 
                 invitations_list.append(
                     {

--- a/app/blueprints/api/api_routes.py
+++ b/app/blueprints/api/api_routes.py
@@ -657,7 +657,13 @@ class InvitationsListResource(Resource):
                 display_info = get_display_name_info(servers)
 
                 # Get library IDs from the normalized relationship
-                specific_libraries = [lib.id for lib in invitation.libraries]
+                # Use external_id (e.g. Plex folder ID) to match the legacy
+                # CSV format that API consumers expect.
+                specific_libraries = [
+                    int(lib.external_id)
+                    for lib in invitation.libraries
+                    if lib.external_id and lib.external_id.isdigit()
+                ]
 
                 invitations_list.append(
                     {

--- a/app/models.py
+++ b/app/models.py
@@ -88,14 +88,16 @@ class Invitation(db.Model):
     used_at = db.Column(db.DateTime, nullable=True)
     created = db.Column(db.DateTime, default=lambda: datetime.now(UTC), nullable=False)
 
-    # DEPRECATED: Legacy single-user relationship for backward compatibility
-    # Will be removed in Phase 2 - use 'users' relationship instead
+    # CACHE: Tracks the first user who used this invitation.  The canonical
+    # many-to-many relationship is `users` (via invitation_users).  This FK is
+    # kept as a provenance/recovery pointer and for backward-compatible API
+    # responses — it is NOT scheduled for removal.
     used_by_id = db.Column(
         db.Integer, db.ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
     used_by = db.relationship("User", foreign_keys=[used_by_id])
 
-    # NEW: Many-to-many relationship to track all users who used this invitation
+    # Many-to-many relationship to track all users who used this invitation
     users = db.relationship(
         "User",
         secondary=invitation_users,
@@ -105,12 +107,15 @@ class Invitation(db.Model):
     expires = db.Column(db.DateTime, nullable=True)
     unlimited = db.Column(db.Boolean, nullable=True)
     duration = db.Column(db.String, nullable=True)
-    # DEPRECATED: Use invitation.libraries relationship instead.
+    # LEGACY: Superseded by invitation.libraries relationship.
     # Kept for migrate_libraries.py which reads this on old installs.
     specific_libraries = db.Column(db.String, nullable=True)
     plex_allow_sync = db.Column(db.Boolean, default=False, nullable=True)
     plex_home = db.Column(db.Boolean, default=False, nullable=True)
     plex_allow_channels = db.Column(db.Boolean, default=False, nullable=True)
+    # CACHE: Legacy single-server FK.  The canonical relationship is `servers`
+    # (via invitation_servers).  This column is kept as a fallback for API
+    # responses and old invitations created before multi-server support.
     server_id = db.Column(
         db.Integer, db.ForeignKey("media_server.id", ondelete="SET NULL"), nullable=True
     )
@@ -190,6 +195,10 @@ class User(db.Model, UserMixin):
     token = db.Column(db.String, nullable=False)
     username = db.Column(db.String, nullable=False)
     email = db.Column(db.String, nullable=True)
+    # PROVENANCE: The invitation code this user was created with.  Used as
+    # the correlation key to find the local User after remote provisioning,
+    # for identity linking, admin display, and data repair.  Do NOT remove
+    # until invitation_users is threaded end-to-end through user creation.
     code = db.Column(db.String, nullable=False)
     photo = db.Column(db.String, nullable=True)
     expires = db.Column(db.DateTime, nullable=True)

--- a/app/models.py
+++ b/app/models.py
@@ -80,12 +80,16 @@ class Invitation(db.Model):
     __tablename__ = "invitation"
     id = db.Column(db.Integer, primary_key=True)
     code = db.Column(db.String, nullable=False)
+    # CACHE: Derived from invitation_users / invitation_servers.
+    # The source of truth for "was this invite used" is the existence of rows
+    # in invitation_users.  These columns are kept in sync by mark_server_used()
+    # and exist for cheap query filters (Invitation.used.is_(True)).
     used = db.Column(db.Boolean, default=False, nullable=False)
     used_at = db.Column(db.DateTime, nullable=True)
     created = db.Column(db.DateTime, default=lambda: datetime.now(UTC), nullable=False)
 
     # DEPRECATED: Legacy single-user relationship for backward compatibility
-    # Will be removed in a future version - use 'users' relationship instead
+    # Will be removed in Phase 2 - use 'users' relationship instead
     used_by_id = db.Column(
         db.Integer, db.ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -101,6 +105,8 @@ class Invitation(db.Model):
     expires = db.Column(db.DateTime, nullable=True)
     unlimited = db.Column(db.Boolean, nullable=True)
     duration = db.Column(db.String, nullable=True)
+    # DEPRECATED: Use invitation.libraries relationship instead.
+    # Kept for migrate_libraries.py which reads this on old installs.
     specific_libraries = db.Column(db.String, nullable=True)
     plex_allow_sync = db.Column(db.Boolean, default=False, nullable=True)
     plex_home = db.Column(db.Boolean, default=False, nullable=True)
@@ -216,50 +222,12 @@ class User(db.Model, UserMixin):
         db.DateTime, default=lambda: datetime.now(UTC), nullable=True
     )
 
-    # Legacy metadata caching fields (will be phased out)
-    library_access_json = db.Column(db.Text, nullable=True)
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def get_library_access(self):
-        """Get deserialized library access data."""
-        import json
-
-        if not self.library_access_json:
-            return None
-        try:
-            return json.loads(self.library_access_json)
-        except (json.JSONDecodeError, TypeError):
-            return None
-
-    def set_library_access(self, library_access):
-        """Set library access data, serializing to JSON."""
-        import json
-
-        if library_access is None:
-            self.library_access_json = None
-        else:
-            # Convert UserLibraryAccess objects to dicts if needed
-            if (
-                isinstance(library_access, list)
-                and library_access
-                and hasattr(library_access[0], "__dict__")
-            ):
-                # Convert dataclass objects to dicts
-                library_access = [
-                    {
-                        "library_id": lib.library_id,
-                        "library_name": lib.library_name,
-                        "has_access": lib.has_access,
-                    }
-                    for lib in library_access
-                ]
-            self.library_access_json = json.dumps(library_access)
-
-    def has_cached_metadata(self):
+    def has_cached_metadata(self) -> bool:
         """Check if user has cached metadata available."""
-        return self.library_access_json is not None
+        return self.accessible_libraries is not None
 
     def get_accessible_libraries(self):
         """Get list of accessible library names."""

--- a/app/services/user_details.py
+++ b/app/services/user_details.py
@@ -155,18 +155,7 @@ class UserDetailsService:
         self, _server: MediaServer, account: User
     ) -> list[str]:
         """Extract library names from cached user data."""
-        library_access_data = account.get_library_access()
-        if not library_access_data:
-            return []
-
-        # Extract library names from cached JSON data
-        accessible_libraries = [
-            lib.get("library_name", "")
-            for lib in library_access_data
-            if isinstance(lib, dict) and lib.get("has_access", False)
-        ]
-
-        return [name for name in accessible_libraries if name]
+        return account.get_accessible_libraries()
 
     def _extract_libraries_from_details(
         self, server: MediaServer, account: User, details: MediaUserDetails


### PR DESCRIPTION
## Summary

- Remove `library_access_json` column and helpers from User model — `accessible_libraries` already stores the same data
- Replace `specific_libraries` CSV string parsing in the API with the normalized `invitation.libraries` relationship
- Relabel `Invitation.used`, `used_at`, `used_by_id`, `server_id`, and `User.code` as sanctioned cache/provenance columns with clear rationale for keeping each one

## Context

An adversarial review of the full normalization plan concluded that Phases 2 and 3 (removing `used_by_id`, `server_id`, `User.code`) should **not** proceed yet. These columns are load-bearing recovery/correlation mechanisms, not just schema smell — `User.code` literally saved us during the `invitation_user` data loss repair. Further removal is only warranted after:

1. A canonical acceptance model is defined
2. Invitation/user/server lookups are centralized behind service helpers
3. `invitation_id` is threaded end-to-end through user creation

## Test plan

- [x] Full test suite passes (486 passed, 0 failures)
- [ ] Verify API `/api/invitations` returns library IDs from relationship instead of CSV
- [ ] Verify user detail modal still shows accessible libraries correctly