### PR TITLE
Release v2026.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2026.4.0",
+  "version": "2026.4.1",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2026.4.0"
+version = "2026.4.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -154,7 +154,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2026.4.0"
+version = "2026.4.1"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2026.4.0"
+version = "2026.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2026.4.1

## What's Changed

### 🐛 Bug Fixes
- use uv instead of broken pipx babel in verify-translations
- merge Weblate contributions and prevent future lock conflicts

### 🧹 Chores
- 

### 📝 Other Changes
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (Chinese (Simplified Han script))
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (French)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (Spanish)
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2026.4.1...v2026.4.1

## 📋 All Commits Included (71 commits)

<details>
<summary>Click to expand commit list</summary>

```
7a704c31 chore: release v2026.4.1
02336fc9 Update translation files
4762786d i18n: refresh POT template [skip ci]
e82884bf Update translation files
6cfae11e i18n: refresh POT template [skip ci]
99147b38 Update translation files
1ec03cf3 i18n: refresh POT template [skip ci]
6d3e0c5f Update translation files
5f8da54b i18n: refresh POT template [skip ci]
336a88a5 Update translation files
f518a9a4 i18n: refresh POT template [skip ci]
4440bdce Update translation files
84b66775 i18n: refresh POT template [skip ci]
4786c76b Update translation files
d7a3a2c0 i18n: refresh POT template [skip ci]
e2b43c6b Update translation files
ad2b2df6 Translated using Weblate (Chinese (Simplified Han script))
d997c667 i18n: refresh POT template [skip ci]
e50bfcd2 Update translation files
5c2bfb13 i18n: refresh POT template [skip ci]
6417d8f8 Update translation files
08bd2987 Translated using Weblate (French)
6bfb2d9a Translated using Weblate (Polish)
291123c8 Translated using Weblate (Polish)
1f2ee3fc Translated using Weblate (Polish)
131ca54e Translated using Weblate (Polish)
2fbdb0a9 Translated using Weblate (Polish)
32cecdc7 Translated using Weblate (Polish)
0179e3af i18n: refresh POT template [skip ci]
ae1bee40 Update translation files
55513453 i18n: refresh POT template [skip ci]
5ad78ac7 Update translation files
38bc0fd2 i18n: refresh POT template [skip ci]
c1ac22e1 Update translation files
9cd4550e i18n: refresh POT template [skip ci]
ace2c3df Update translation files
7094da30 i18n: refresh POT template [skip ci]
54b0230e Update translation files
64acf82c i18n: refresh POT template [skip ci]
3a32d7ce Update translation files
4d95f0c2 i18n: refresh POT template [skip ci]
e5531f06 Update translation files
f6227bc7 i18n: refresh POT template [skip ci]
5baefd6a Update translation files
5b95950c i18n: refresh POT template [skip ci]
c5b1a8b9 Update translation files
0bd306a3 i18n: refresh POT template [skip ci]
041a0a70 Update translation files
cd9ce9d8 i18n: refresh POT template [skip ci]
1a39e095 Update translation files
db8e9ea3 i18n: refresh POT template [skip ci]
9f1b3eb7 Update translation files
a04473d9 Translated using Weblate (Spanish)
e07097f2 i18n: refresh POT template [skip ci]
7cbb80fb Update translation files
b3527c79 i18n: refresh POT template [skip ci]
34a48d60 Update translation files
6fab7132 i18n: refresh POT template [skip ci]
50775263 Update translation files
90e41db4 i18n: refresh POT template [skip ci]
31053698 Update translation files
ff3b9232 i18n: refresh POT template [skip ci]
8e057b01 Update translation files
c88e0e04 i18n: refresh POT template [skip ci]
4c88fec0 Update translation files
ee327e62 i18n: refresh POT template [skip ci]
9a9f3f6e Update translation files
a674f579 i18n: refresh POT template [skip ci]
292500f2 Update translation files
59bc2293 fix(ci): use uv instead of broken pipx babel in verify-translations
0e04feee fix(i18n): merge Weblate contributions and prevent future lock conflicts
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2026.4.1`
- Deploy to production
- Build Docker images with `:latest` and `v2026.4.1` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation