### PR TITLE
feat(notifications): add generic webhook agent type

### DIFF
--- a/app/blueprints/notifications/routes.py
+++ b/app/blueprints/notifications/routes.py
@@ -16,9 +16,84 @@ from app.services.notifications import (  # your existing helpers
     _notifiarr,
     _ntfy,
     _telegram,
+    _webhook,
+    is_webhook_url_allowed,
 )
 
 notify_bp = Blueprint("notify", __name__, url_prefix="/settings/notifications")
+
+
+def _test_agent(form: dict) -> tuple[bool, str | None]:
+    """Send a test notification for a form-submitted agent config.
+
+    Returns (ok, error_message). A None error_message means the test failed
+    but there's no more specific reason to show the user beyond the generic
+    "could not connect" fallback.
+    """
+    url = form.get("url")
+    if not url:
+        return False, "URL is required."
+
+    t = form["type"]
+    if t == "discord":
+        return _discord("Wizarr test message", url, "Test Notification"), None
+    if t == "ntfy":
+        return (
+            _ntfy(
+                "Wizarr test message",
+                "Wizarr",
+                "tada",
+                url,
+                form["username"],
+                form["password"],
+            ),
+            None,
+        )
+    if t == "apprise":
+        return _apprise("Wizarr test message", "Wizarr", "tada", url), None
+    if t == "notifiarr":
+        raw = form.get("channel_id")
+        if not raw:
+            return False, "Channel ID is required for Notifiarr."
+        return (
+            _notifiarr(
+                "Connection established. You will now receive notifications in this channel.",
+                "Test successful!",
+                url,
+                int(raw),
+            ),
+            None,
+        )
+    if t == "telegram":
+        if not (form.get("telegram_bot_token") and form.get("telegram_chat_id")):
+            return False, "Telegram bot token and chat id are required."
+        return (
+            _telegram(
+                "Wizarr test message",
+                "Wizarr",
+                url,
+                form["telegram_bot_token"],
+                form["telegram_chat_id"],
+            ),
+            None,
+        )
+    if t == "webhook":
+        if not is_webhook_url_allowed(url):
+            return False, (
+                "Webhook URL must use https, or http on a loopback host "
+                "(localhost, 127.0.0.1, host.docker.internal)."
+            )
+        ok = _webhook(
+            url,
+            form.get("webhook_secret"),
+            "test",
+            "Wizarr test message",
+            "This is a test delivery from Wizarr.",
+            {"test": True},
+            bool(form.get("include_password")),
+        )
+        return ok, None
+    return False, "Unknown notification service."
 
 
 @notify_bp.route("/", methods=["GET"])
@@ -49,60 +124,16 @@ def create():
             "channel_id": request.form.get("channel_id") or None,
             "telegram_bot_token": request.form.get("telegram_bot_token") or None,
             "telegram_chat_id": request.form.get("telegram_chat_id") or None,
+            "webhook_secret": request.form.get("webhook_secret") or None,
+            "include_password": bool(request.form.get("include_password")),
             "notification_events": ",".join(events)
             if events
             else "user_joined,update_available",
         }
 
-        # test the connection
-        ok = False
-        if form["type"] == "discord":
-            url = form.get("url")
-            if url:
-                ok = _discord("Wizarr test message", url, "Test Notification")
-        elif form["type"] == "ntfy":
-            url = form.get("url")
-            if url:
-                ok = _ntfy(
-                    "Wizarr test message",
-                    "Wizarr",
-                    "tada",
-                    url,
-                    form["username"],
-                    form["password"],
-                )
-        elif form["type"] == "apprise":
-            url = form.get("url")
-            if url:
-                ok = _apprise("Wizarr test message", "Wizarr", "tada", url)
-        elif form["type"] == "notifiarr":
-            url = form.get("url")
-            channel_id_raw = form.get("channel_id")
-
-            if url and channel_id_raw:
-                channel_id = int(channel_id_raw)
-                ok = _notifiarr(
-                    "Connection established. You will now receive notifications in this channel.",
-                    "Test successful!",
-                    url,
-                    channel_id,
-                )
-        elif form["type"] == "telegram":
-            url = form.get("url")
-            telegram_bot_token = form.get("telegram_bot_token")
-            telegram_chat_id = form.get("telegram_chat_id")
-
-            if url and telegram_bot_token and telegram_chat_id:
-                ok = _telegram(
-                    "Wizarr test message",
-                    "Wizarr",
-                    url,
-                    telegram_bot_token,
-                    telegram_chat_id,
-                )
+        ok, error = _test_agent(form)
 
         if ok:
-            # from Notification.create(**form) to SQLAlchemy ORM
             agent = Notification(**form)
             db.session.add(agent)
             db.session.commit()
@@ -112,7 +143,7 @@ def create():
         resp = make_response(
             render_template(
                 "modals/create-notification-agent.html",
-                error="Could not connect – check URL / credentials.",
+                error=error or "Could not connect – check URL / credentials.",
             )
         )
         resp.headers["HX-Retarget"] = "#create-modal"
@@ -144,60 +175,16 @@ def edit(agent_id):
             "channel_id": request.form.get("channel_id") or None,
             "telegram_bot_token": request.form.get("telegram_bot_token") or None,
             "telegram_chat_id": request.form.get("telegram_chat_id") or None,
+            "webhook_secret": request.form.get("webhook_secret") or None,
+            "include_password": bool(request.form.get("include_password")),
             "notification_events": ",".join(events)
             if events
             else "user_joined,update_available",
         }
 
-        # test the connection
-        ok = False
-        if form["type"] == "discord":
-            url = form.get("url")
-            if url:
-                ok = _discord("Wizarr test message", url, "Test Notification")
-        elif form["type"] == "ntfy":
-            url = form.get("url")
-            if url:
-                ok = _ntfy(
-                    "Wizarr test message",
-                    "Wizarr",
-                    "tada",
-                    url,
-                    form["username"],
-                    form["password"],
-                )
-        elif form["type"] == "apprise":
-            url = form.get("url")
-            if url:
-                ok = _apprise("Wizarr test message", "Wizarr", "tada", url)
-        elif form["type"] == "notifiarr":
-            url = form.get("url")
-            channel_id_raw = form.get("channel_id")
-
-            if url and channel_id_raw:
-                channel_id = int(channel_id_raw)
-                ok = _notifiarr(
-                    "Connection established. You will now receive notifications in this channel.",
-                    "Test successful!",
-                    url,
-                    channel_id,
-                )
-        elif form["type"] == "telegram":
-            url = form.get("url")
-            telegram_bot_token = form.get("telegram_bot_token")
-            telegram_chat_id = form.get("telegram_chat_id")
-
-            if url and telegram_bot_token and telegram_chat_id:
-                ok = _telegram(
-                    "Wizarr test message",
-                    "Wizarr",
-                    url,
-                    telegram_bot_token,
-                    telegram_chat_id,
-                )
+        ok, error = _test_agent(form)
 
         if ok:
-            # Update the agent with new values
             agent.name = form["name"]
             agent.url = form["url"]
             agent.type = form["type"]
@@ -206,6 +193,8 @@ def edit(agent_id):
             agent.channel_id = form["channel_id"]
             agent.telegram_bot_token = form["telegram_bot_token"]
             agent.telegram_chat_id = form["telegram_chat_id"]
+            agent.webhook_secret = form["webhook_secret"]
+            agent.include_password = form["include_password"]
             agent.notification_events = form["notification_events"]
             db.session.commit()
             return redirect(url_for(".list_agents"))
@@ -215,7 +204,7 @@ def edit(agent_id):
             render_template(
                 "modals/edit-notification-agent.html",
                 agent=agent,
-                error="Could not connect – check URL / credentials.",
+                error=error or "Could not connect – check URL / credentials.",
             )
         )
         resp.headers["HX-Retarget"] = "#create-modal"

--- a/app/models.py
+++ b/app/models.py
@@ -372,6 +372,11 @@ class Notification(db.Model):
     channel_id = db.Column(db.Integer, nullable=True)
     telegram_bot_token = db.Column(db.String, nullable=True)
     telegram_chat_id = db.Column(db.String, nullable=True)
+    # For type="webhook": HMAC-SHA256 shared secret used to sign outgoing payloads.
+    webhook_secret = db.Column(db.String, nullable=True)
+    # For type="webhook": whether to include the plaintext password in user_joined
+    # payloads. Opt-in per-agent; default off.
+    include_password = db.Column(db.Boolean, nullable=False, default=False)
     notification_events = db.Column(
         db.String, nullable=False, default="user_joined,update_available"
     )

--- a/app/services/media/client_base.py
+++ b/app/services/media/client_base.py
@@ -533,6 +533,20 @@ class MediaClient(ABC):
                     f"User {username} has joined your server! 🎉",
                     tags="tada",
                     event_type="user_joined",
+                    context={
+                        "user": {
+                            "username": username,
+                            "email": email,
+                            "server_id": getattr(self.server, "id", None),
+                            "server_type": getattr(self.server, "server_type", None),
+                            "server_name": getattr(self.server, "name", None),
+                        },
+                        "invite": {"code": code},
+                        # Webhook agents with include_password=False will have
+                        # this stripped before transmission; agents with it on
+                        # receive plaintext (sent only over https or loopback).
+                        "password": password,
+                    },
                 )
             except Exception as e:
                 logging.warning(f"Failed to send join notification: {e}")

--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -1314,6 +1314,17 @@ def handle_oauth_token(app, token: str, code: str) -> None:
             f"User {account.username} has joined your server!",
             "tada",
             event_type="user_joined",
+            context={
+                "user": {
+                    "username": account.username,
+                    "email": email,
+                    "server_id": server_id,
+                    "server_type": "plex",
+                    "server_name": getattr(server, "name", None),
+                },
+                "invite": {"code": code},
+                # Plex signup is OAuth-based; no plaintext password exists.
+            },
         )
 
         # Pass only what we need: server credentials and Flask app instance

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -1,14 +1,43 @@
 import base64
+import hashlib
+import hmac
+import ipaddress
 import json
 import logging
+from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlparse
 
 import apprise
 import requests
 
 from app.models import Notification
 
-__all__ = ["notify"]
+__all__ = ["notify", "is_webhook_url_allowed"]
+
+
+def is_webhook_url_allowed(url: str) -> bool:
+    """Return True iff url uses https, or uses http with a loopback host.
+
+    Webhook agents can carry sensitive payloads (plaintext passwords when the
+    agent opts in), so we refuse plaintext http over the network. Loopback is
+    permitted for local docker / host-side integrations.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme == "https":
+        return True
+    if parsed.scheme != "http":
+        return False
+    host = (parsed.hostname or "").lower()
+    if host in ("localhost", "host.docker.internal"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _send(url: str, data, headers: dict) -> bool:
@@ -131,6 +160,49 @@ def _telegram(
     return _send(url, data, headers)
 
 
+def _webhook(
+    url: str,
+    secret: str | None,
+    event_type: str,
+    title: str,
+    message: str,
+    context: dict[str, Any] | None,
+    include_password: bool,
+) -> bool:
+    """POST a structured JSON payload to an external webhook.
+
+    Payload schema is versioned via the "event" field so new events can be
+    added without breaking existing consumers. If include_password is False,
+    the "password" field is stripped before sending regardless of what the
+    caller supplied in context.
+    """
+    if not is_webhook_url_allowed(url):
+        logging.error(
+            "Webhook URL rejected (must be https or loopback http): %s", url
+        )
+        return False
+
+    safe_context = dict(context or {})
+    if not include_password:
+        safe_context.pop("password", None)
+
+    payload = {
+        "event": event_type,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "title": title,
+        "message": message,
+        **safe_context,
+    }
+    body = json.dumps(payload, separators=(",", ":")).encode()
+
+    headers = {"Content-Type": "application/json"}
+    if secret:
+        sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        headers["X-Wizarr-Signature"] = f"sha256={sig}"
+
+    return _send(url, body, headers)
+
+
 def notify(
     title: str,
     message: str,
@@ -138,8 +210,16 @@ def notify(
     event_type: str = "user_joined",
     previous_version: str | None = None,
     new_version: str | None = None,
+    context: dict[str, Any] | None = None,
 ):
-    """Broadcast to every configured agent that is subscribed to the event type."""
+    """Broadcast to every configured agent that is subscribed to the event type.
+
+    `context` carries structured data for webhook-style agents. It is ignored
+    by human-facing agents (Discord, ntfy, etc.) that only render a title and
+    message. When an agent is type="webhook", context is merged into the JSON
+    payload; if the agent has include_password=False, the plaintext password
+    is stripped before sending.
+    """
     for agent in Notification.query.all():
         # Check if agent is subscribed to this event type
         subscribed_events = (
@@ -163,4 +243,14 @@ def notify(
                 agent.url,
                 agent.telegram_bot_token,
                 agent.telegram_chat_id,
+            )
+        elif agent.type == "webhook":
+            _webhook(
+                agent.url,
+                agent.webhook_secret,
+                event_type,
+                title,
+                message,
+                context,
+                bool(agent.include_password),
             )

--- a/app/templates/modals/create-notification-agent.html
+++ b/app/templates/modals/create-notification-agent.html
@@ -65,7 +65,38 @@
                 <option value="notifiarr">Notifiarr</option>
                 <option value="ntfy">Ntfy</option>
                 <option value="telegram">Telegram</option>
+                <option value="webhook">Webhook</option>
               </select>
+            </div>
+            <div id="webhookSection"
+                 class="notificationAgentInfo"
+                 style="display: none">
+              <label for="webhook_secret"
+                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                {{ _("Shared Secret (HMAC-SHA256)") }}
+              </label>
+              <input type="password"
+                     name="webhook_secret"
+                     id="webhook_secret"
+                     placeholder="{{ _('Optional but recommended') }}"
+                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white">
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {{ _("Requests will be signed with header X-Wizarr-Signature: sha256=&lt;hex&gt;.") }}
+              </p>
+              <div class="flex items-start mt-3">
+                <input type="checkbox"
+                       name="include_password"
+                       id="include_password"
+                       value="1"
+                       class="w-4 h-4 mt-1 text-primary bg-gray-100 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600">
+                <label for="include_password"
+                       class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300">
+                  {{ _("Include plaintext password in user_joined payloads") }}
+                  <span class="block text-xs font-normal text-gray-500 dark:text-gray-400">
+                    {{ _("Off by default. Only enable for trusted, private endpoints (https or loopback only).") }}
+                  </span>
+                </label>
+              </div>
             </div>
             <div id="notifiarrSection"
                  class="notificationAgentInfo"
@@ -190,6 +221,8 @@
             notifiarrSection.style.display = 'block';
         } else if (value === "telegram") {
             telegramSection.style.display = 'block';
+        } else if (value === "webhook") {
+            webhookSection.style.display = 'block';
         }
 
         // Trigger required channel_id
@@ -213,6 +246,8 @@
 
         if (value === 'apprise') {
             urlEle.placeholder = "e.g. apprise://hostname/token";
+        } else if (value === 'webhook') {
+            urlEle.placeholder = "https://example.com/hook  or  http://127.0.0.1:5059/hook";
         } else {
             urlEle.placeholder = "e.g. https://example.com";
         }

--- a/app/templates/modals/edit-notification-agent.html
+++ b/app/templates/modals/edit-notification-agent.html
@@ -45,7 +45,45 @@
                         {% if agent.type == 'notifiarr' %}selected{% endif %}>Notifiarr</option>
                 <option value="ntfy" {% if agent.type == 'ntfy' %}selected{% endif %}>Ntfy</option>
                 <option value="telegram" {% if agent.type == 'telegram' %}selected{% endif %}>Telegram</option>
+                <option value="webhook" {% if agent.type == 'webhook' %}selected{% endif %}>Webhook</option>
               </select>
+            </div>
+            <div id="webhookSection"
+                 class="notificationAgentInfo"
+                 style="display:
+                        {% if agent.type == 'webhook' %}
+                          block
+                        {% else %}
+                          none
+                        {% endif %}">
+              <label for="webhook_secret"
+                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                {{ _("Shared Secret (HMAC-SHA256)") }}
+              </label>
+              <input type="password"
+                     name="webhook_secret"
+                     id="webhook_secret"
+                     value="{{ agent.webhook_secret or '' }}"
+                     placeholder="{{ _('Optional but recommended') }}"
+                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white">
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {{ _("Requests will be signed with header X-Wizarr-Signature: sha256=&lt;hex&gt;.") }}
+              </p>
+              <div class="flex items-start mt-3">
+                <input type="checkbox"
+                       name="include_password"
+                       id="include_password"
+                       value="1"
+                       {% if agent.include_password %}checked{% endif %}
+                       class="w-4 h-4 mt-1 text-primary bg-gray-100 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600">
+                <label for="include_password"
+                       class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300">
+                  {{ _("Include plaintext password in user_joined payloads") }}
+                  <span class="block text-xs font-normal text-gray-500 dark:text-gray-400">
+                    {{ _("Off by default. Only enable for trusted, private endpoints (https or loopback only).") }}
+                  </span>
+                </label>
+              </div>
             </div>
             <div id="notifiarrSection"
                  class="notificationAgentInfo"
@@ -192,6 +230,8 @@
             notifiarrSection.style.display = 'block';
         } else if (value === "telegram") {
             telegramSection.style.display = 'block';
+        } else if (value === "webhook") {
+            webhookSection.style.display = 'block';
         }
 
         if (value === 'notifiarr') {
@@ -212,6 +252,8 @@
 
         if (value === 'apprise') {
             urlEle.placeholder = "e.g. apprise://hostname/token";
+        } else if (value === 'webhook') {
+            urlEle.placeholder = "https://example.com/hook  or  http://127.0.0.1:5059/hook";
         } else {
             urlEle.placeholder = "e.g. https://example.com";
         }

--- a/migrations/versions/20260423_add_webhook_agent_fields.py
+++ b/migrations/versions/20260423_add_webhook_agent_fields.py
@@ -1,0 +1,34 @@
+"""Add webhook agent fields to notification table
+
+Revision ID: 20260423_webhook_agent
+Revises: 20260401_repair
+Create Date: 2026-04-23
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260423_webhook_agent"
+down_revision = "20260401_repair"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("notification", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("webhook_secret", sa.String(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "include_password",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("notification", schema=None) as batch_op:
+        batch_op.drop_column("include_password")
+        batch_op.drop_column("webhook_secret")

--- a/tests/test_webhook_notifications.py
+++ b/tests/test_webhook_notifications.py
@@ -1,0 +1,131 @@
+"""Unit tests for the generic webhook notification agent.
+
+These tests cover the parts of app/services/notifications.py that don't
+require a Flask app or DB: URL validation and payload signing/shape. The
+Notification model dispatch is covered by the existing app-level tests once
+the migration has been applied.
+"""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import patch
+
+from app.services.notifications import _webhook, is_webhook_url_allowed
+
+
+class TestIsWebhookUrlAllowed:
+    def test_https_allowed(self):
+        assert is_webhook_url_allowed("https://example.com/hook")
+
+    def test_http_loopback_allowed(self):
+        assert is_webhook_url_allowed("http://127.0.0.1:5059/hook")
+        assert is_webhook_url_allowed("http://localhost:5059/hook")
+        assert is_webhook_url_allowed("http://host.docker.internal:5059/hook")
+        assert is_webhook_url_allowed("http://[::1]/hook")
+
+    def test_http_non_loopback_rejected(self):
+        assert not is_webhook_url_allowed("http://example.com/hook")
+        assert not is_webhook_url_allowed("http://10.0.0.5/hook")
+
+    def test_unsupported_schemes_rejected(self):
+        assert not is_webhook_url_allowed("ftp://example.com/hook")
+        assert not is_webhook_url_allowed("not-a-url")
+
+
+class TestWebhookDispatch:
+    def _captured_post(self):
+        """Return a mock replacing requests.post that records its call."""
+        calls = []
+
+        class _Resp:
+            status_code = 200
+            text = ""
+
+        def fake_post(url, data=None, headers=None, timeout=None):
+            calls.append({"url": url, "data": data, "headers": headers})
+            return _Resp()
+
+        return calls, fake_post
+
+    def test_signs_body_with_hmac_sha256(self):
+        calls, fake_post = self._captured_post()
+        secret = "s3cret"
+        with patch("app.services.notifications.requests.post", fake_post):
+            ok = _webhook(
+                url="https://example.com/hook",
+                secret=secret,
+                event_type="user_joined",
+                title="New User",
+                message="bob joined",
+                context={"user": {"username": "bob"}},
+                include_password=False,
+            )
+        assert ok
+        assert len(calls) == 1
+        body = calls[0]["data"]
+        expected_sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        assert calls[0]["headers"]["X-Wizarr-Signature"] == f"sha256={expected_sig}"
+
+    def test_password_omitted_when_opt_out(self):
+        calls, fake_post = self._captured_post()
+        with patch("app.services.notifications.requests.post", fake_post):
+            _webhook(
+                url="https://example.com/hook",
+                secret=None,
+                event_type="user_joined",
+                title="",
+                message="",
+                context={"user": {"username": "bob"}, "password": "hunter2"},
+                include_password=False,
+            )
+        payload = json.loads(calls[0]["data"])
+        assert "password" not in payload
+        assert payload["user"]["username"] == "bob"
+
+    def test_password_included_when_opt_in(self):
+        calls, fake_post = self._captured_post()
+        with patch("app.services.notifications.requests.post", fake_post):
+            _webhook(
+                url="https://example.com/hook",
+                secret=None,
+                event_type="user_joined",
+                title="",
+                message="",
+                context={"user": {"username": "bob"}, "password": "hunter2"},
+                include_password=True,
+            )
+        payload = json.loads(calls[0]["data"])
+        assert payload["password"] == "hunter2"
+
+    def test_http_non_loopback_refused_before_send(self):
+        calls, fake_post = self._captured_post()
+        with patch("app.services.notifications.requests.post", fake_post):
+            ok = _webhook(
+                url="http://evil.example.com/hook",
+                secret="s",
+                event_type="user_joined",
+                title="",
+                message="",
+                context={"password": "hunter2"},
+                include_password=True,
+            )
+        assert not ok
+        assert calls == []  # nothing was sent
+
+    def test_payload_has_event_and_timestamp(self):
+        calls, fake_post = self._captured_post()
+        with patch("app.services.notifications.requests.post", fake_post):
+            _webhook(
+                url="https://example.com/hook",
+                secret=None,
+                event_type="user_joined",
+                title="New User",
+                message="bob joined",
+                context={},
+                include_password=False,
+            )
+        payload = json.loads(calls[0]["data"])
+        assert payload["event"] == "user_joined"
+        assert "timestamp" in payload
+        assert payload["title"] == "New User"


### PR DESCRIPTION
Adds a new notification agent type, "webhook", that delivers structured JSON payloads to an external URL on the same events as other agents. Motivated by the need to automatically provision ancillary services (Jellyseerr, Calibre-Web, ...) from a single Wizarr invite completion, using the plaintext password the user just set.

Schema:
  * notification.webhook_secret    — optional HMAC-SHA256 shared secret
  * notification.include_password  — opt-in per-agent toggle for
                                     whether user_joined payloads
                                     include the plaintext password

Transport:
  * Each request carries X-Wizarr-Signature: sha256=<hex> when a secret is set.
  * URL is validated at save time and refused at send time if it is plaintext http to a non-loopback host, so a misconfigured agent cannot leak passwords over the open network.

Call sites:
  * client_base.join() and plex.handle_oauth_token now pass a structured `context` dict (user, invite, password) to notify(). Existing agent types (Discord, ntfy, Apprise, Notifiarr, Telegram) ignore `context` unchanged.

Payload shape (versioned via `event`):
  {
    "event": "user_joined", "timestamp": "...", "title": "...", "message": "...", "user": {"username", "email", "server_id", ...}, "invite": {"code": "..."},
    "password": "..."   // only when agent.include_password=True
  }

Tests cover URL validation, HMAC signing, and the
include_password opt-in behavior.