### PR TITLE
Release v2026.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2026.4.0",
+  "version": "2026.5.0",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2026.4.0"
+version = "2026.5.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -154,7 +154,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2026.4.0"
+version = "2026.5.0"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1674,7 +1674,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2026.4.0"
+version = "2026.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2026.5.0

## What's Changed

### 🐛 Bug Fixes
- align static asset cache-busting in Plex login template
- implement deterministic build lifecycle and dynamic cache busting
- resolve external Bowser dependency and casing fallback
- improve Service Worker update strategy and cache management
- resolve persistent Service Worker cache-first WSOD lock-in
- resolve White Screen of Death (WSOD) by serving external assets from clean vendor directories
- use uv instead of broken pipx babel in verify-translations
- merge Weblate contributions and prevent future lock conflicts

### 💄 Styling
- use dynamic url_for query parameters and optimize context processor imports

### 🧹 Chores
- 
- 

### 📝 Other Changes
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (French)
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (Catalan)
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (Catalan)
- Translated using Weblate (Spanish)
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (French)
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (French)
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (French)
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (Chinese (Simplified Han script))
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (French)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- Translated using Weblate (Polish)
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- Translated using Weblate (Spanish)
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files
- i18n: refresh POT template [skip ci]
- Update translation files


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2026.5.0...v2026.5.0

## 📋 All Commits Included (148 commits)

<details>
<summary>Click to expand commit list</summary>

```
5e0281a7 chore: release v2026.5.0
89b17adc Update translation files
ec06e068 i18n: refresh POT template [skip ci]
d91f4dc4 chore(deps): bulk-bump python and npm deps from open dependabot PRs (#1279)
5dcb4ab3 Update translation files
f4ff6136 Translated using Weblate (French)
3dd4568e i18n: refresh POT template [skip ci]
22cf10ee Update translation files
c5d183d3 i18n: refresh POT template [skip ci]
bbac16bd Update translation files
618ac07b i18n: refresh POT template [skip ci]
9e5f1813 Update translation files
7b33c15a i18n: refresh POT template [skip ci]
eaab5fd0 Update translation files
ae2ebf25 i18n: refresh POT template [skip ci]
365d1d57 fix(frontend): align static asset cache-busting in Plex login template
4b0eca0d style(flask): use dynamic url_for query parameters and optimize context processor imports
a33d79dd fix(assets): implement deterministic build lifecycle and dynamic cache busting
492d96c3 fix(assets): resolve external Bowser dependency and casing fallback
123a9671 fix(pwa): improve Service Worker update strategy and cache management
7a0f5fdc fix(pwa): resolve persistent Service Worker cache-first WSOD lock-in
a378d766 fix: resolve White Screen of Death (WSOD) by serving external assets from clean vendor directories
1bdd5b3b Update translation files
be00073b i18n: refresh POT template [skip ci]
79da708a Update translation files
6d20f4df i18n: refresh POT template [skip ci]
00fb9ca6 Update translation files
71173735 i18n: refresh POT template [skip ci]
902ea4a1 Update translation files
1682b60c i18n: refresh POT template [skip ci]
8eb84e4f Update translation files
019d29ad i18n: refresh POT template [skip ci]
d135cb2c Update translation files
97b00f19 i18n: refresh POT template [skip ci]
3b5dab8c Update translation files
4a532dad i18n: refresh POT template [skip ci]
088dc9d9 Update translation files
26caa394 i18n: refresh POT template [skip ci]
418a1110 Update translation files
1db7ea16 i18n: refresh POT template [skip ci]
c5fe4493 Update translation files
049e0940 i18n: refresh POT template [skip ci]
2db9cc24 Update translation files
f0b185b4 i18n: refresh POT template [skip ci]
2e226a99 Update translation files
9c2b32d6 Translated using Weblate (Catalan)
89b1ede6 i18n: refresh POT template [skip ci]
dd18d47e Update translation files
9fa2d7ae Translated using Weblate (Catalan)
d9c87fa4 Translated using Weblate (Spanish)
5abca75c i18n: refresh POT template [skip ci]
01b25b4f Update translation files
d6c14593 i18n: refresh POT template [skip ci]
c8a454c6 Update translation files
9f9f3d23 i18n: refresh POT template [skip ci]
f9a1b2e4 Update translation files
6717fec5 i18n: refresh POT template [skip ci]
8fab2b07 Update translation files
6de4788a i18n: refresh POT template [skip ci]
a451fd19 Update translation files
0e79179c i18n: refresh POT template [skip ci]
e7adff12 Update translation files
a4195086 i18n: refresh POT template [skip ci]
ea5c0ff2 Update translation files
73054332 i18n: refresh POT template [skip ci]
40f2aa0d Update translation files
7916cd19 i18n: refresh POT template [skip ci]
c32ad216 Update translation files
d7aeef27 Translated using Weblate (French)
f91e30d1 i18n: refresh POT template [skip ci]
6fc575ce Update translation files
0664067d Translated using Weblate (French)
4631dfba i18n: refresh POT template [skip ci]
54e0e948 Update translation files
621d96f7 Translated using Weblate (French)
3539dfdc i18n: refresh POT template [skip ci]
cc788611 Update translation files
249534c9 i18n: refresh POT template [skip ci]
02336fc9 Update translation files
4762786d i18n: refresh POT template [skip ci]
e82884bf Update translation files
6cfae11e i18n: refresh POT template [skip ci]
99147b38 Update translation files
1ec03cf3 i18n: refresh POT template [skip ci]
6d3e0c5f Update translation files
5f8da54b i18n: refresh POT template [skip ci]
336a88a5 Update translation files
f518a9a4 i18n: refresh POT template [skip ci]
4440bdce Update translation files
84b66775 i18n: refresh POT template [skip ci]
4786c76b Update translation files
d7a3a2c0 i18n: refresh POT template [skip ci]
e2b43c6b Update translation files
ad2b2df6 Translated using Weblate (Chinese (Simplified Han script))
d997c667 i18n: refresh POT template [skip ci]
e50bfcd2 Update translation files
5c2bfb13 i18n: refresh POT template [skip ci]
6417d8f8 Update translation files
08bd2987 Translated using Weblate (French)
6bfb2d9a Translated using Weblate (Polish)
291123c8 Translated using Weblate (Polish)
1f2ee3fc Translated using Weblate (Polish)
131ca54e Translated using Weblate (Polish)
2fbdb0a9 Translated using Weblate (Polish)
32cecdc7 Translated using Weblate (Polish)
0179e3af i18n: refresh POT template [skip ci]
ae1bee40 Update translation files
55513453 i18n: refresh POT template [skip ci]
5ad78ac7 Update translation files
38bc0fd2 i18n: refresh POT template [skip ci]
c1ac22e1 Update translation files
9cd4550e i18n: refresh POT template [skip ci]
ace2c3df Update translation files
7094da30 i18n: refresh POT template [skip ci]
54b0230e Update translation files
64acf82c i18n: refresh POT template [skip ci]
3a32d7ce Update translation files
4d95f0c2 i18n: refresh POT template [skip ci]
e5531f06 Update translation files
f6227bc7 i18n: refresh POT template [skip ci]
5baefd6a Update translation files
5b95950c i18n: refresh POT template [skip ci]
c5b1a8b9 Update translation files
0bd306a3 i18n: refresh POT template [skip ci]
041a0a70 Update translation files
cd9ce9d8 i18n: refresh POT template [skip ci]
1a39e095 Update translation files
db8e9ea3 i18n: refresh POT template [skip ci]
9f1b3eb7 Update translation files
a04473d9 Translated using Weblate (Spanish)
e07097f2 i18n: refresh POT template [skip ci]
7cbb80fb Update translation files
b3527c79 i18n: refresh POT template [skip ci]
34a48d60 Update translation files
6fab7132 i18n: refresh POT template [skip ci]
50775263 Update translation files
90e41db4 i18n: refresh POT template [skip ci]
31053698 Update translation files
ff3b9232 i18n: refresh POT template [skip ci]
8e057b01 Update translation files
c88e0e04 i18n: refresh POT template [skip ci]
4c88fec0 Update translation files
ee327e62 i18n: refresh POT template [skip ci]
9a9f3f6e Update translation files
a674f579 i18n: refresh POT template [skip ci]
292500f2 Update translation files
59bc2293 fix(ci): use uv instead of broken pipx babel in verify-translations
0e04feee fix(i18n): merge Weblate contributions and prevent future lock conflicts
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2026.5.0`
- Deploy to production
- Build Docker images with `:latest` and `v2026.5.0` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation