### PR TITLE
fix: override `PUID/PGID=0` to prevent entrypoint loop

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,13 @@ DEFAULT_GID='1000'
 PUID="${PUID:-$DEFAULT_UID}"
 PGID="${PGID:-$DEFAULT_GID}"
 
+# Prevent running as root
+if [ "$PUID" = "0" ] || [ "$PGID" = "0" ]; then
+  echo "[entrypoint] ⚠️  WARNING: PUID/PGID cannot be 0 (root). Using defaults instead..."
+  PUID="$DEFAULT_UID"
+  PGID="$DEFAULT_GID"
+fi
+
 if [ "$(id -u)" = "0" ]; then
   echo "[entrypoint] 👤 Wanted UID=$PUID  GID=$PGID"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,14 +9,7 @@ DEFAULT_GID='1000'
 PUID="${PUID:-$DEFAULT_UID}"
 PGID="${PGID:-$DEFAULT_GID}"
 
-# Prevent running as root
-if [ "$PUID" = "0" ] || [ "$PGID" = "0" ]; then
-  echo "[entrypoint] ⚠️  WARNING: PUID/PGID cannot be 0 (root). Using defaults instead..."
-  PUID="$DEFAULT_UID"
-  PGID="$DEFAULT_GID"
-fi
-
-if [ "$(id -u)" = "0" ]; then
+if [ "$(id -u)" != "$PUID" ] || [ "$(id -g)" != "$PGID" ]; then
   echo "[entrypoint] 👤 Wanted UID=$PUID  GID=$PGID"
 
   # Figure out which *names* already map to those numeric IDs


### PR DESCRIPTION
fixes #1249