### PR TITLE
Fix multi-server Plex OAuth invites

### DIFF
--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -1264,50 +1264,70 @@ def handle_oauth_token(app, token: str, code: str) -> None:
         email = account.email
 
         inv = Invitation.query.filter_by(code=code).first()
-        # Use the new multi-server relationship instead of legacy server
+        servers: list[MediaServer] = []
+
         if inv and inv.servers:
-            # Get the first Plex server from the invitation's server list
+            # A single Plex OAuth token can authorize shares on every Plex server
+            # attached to the invite. Non-Plex servers continue through the
+            # password-based step after this route returns.
             plex_servers = [s for s in inv.servers if s.server_type == "plex"]
-            server = plex_servers[0] if plex_servers else inv.servers[0]
+            servers = plex_servers or [inv.servers[0]]
         elif inv and inv.server:
             # Fallback to legacy single server relationship
-            server = inv.server
+            servers = [inv.server]
         else:
             # Last resort fallback
-            server = MediaServer.query.first()
-        if not server:
-            raise ValueError("No media server found")
-        server_id = server.id
+            fallback_server = MediaServer.query.first()
+            if fallback_server:
+                servers = [fallback_server]
 
-        db.session.query(User).filter(
-            User.email == email, User.server_id == server_id
-        ).delete(synchronize_session=False)
-        db.session.commit()
+        if not servers:
+            raise ValueError("No media server found")
 
         from app.services.expiry import calculate_user_expiry
+        from flask import current_app
 
-        expires = calculate_user_expiry(inv, server_id) if inv else None
+        for server in servers:
+            server_id = server.id
 
-        client = PlexClient(media_server=server)
-        new_user = client._create_user_with_identity_linking(
-            {
-                "token": token,
-                "email": email,
-                "username": account.username,
-                "code": code,
-                "expires": expires,
-                "server_id": server_id,
-            }
-        )
-        db.session.commit()
+            db.session.query(User).filter(
+                User.email == email, User.server_id == server_id
+            ).delete(synchronize_session=False)
+            db.session.commit()
 
-        _invite_user(email, code, new_user.id, server)
+            expires = calculate_user_expiry(inv, server_id) if inv else None
 
-        # Mark invitation as used for this server
-        if inv:
-            from app.services.invites import mark_server_used
+            client = PlexClient(media_server=server)
+            new_user = client._create_user_with_identity_linking(
+                {
+                    "token": token,
+                    "email": email,
+                    "username": account.username,
+                    "code": code,
+                    "expires": expires,
+                    "server_id": server_id,
+                }
+            )
+            db.session.commit()
 
-            mark_server_used(inv, server_id, new_user)
+            _invite_user(email, code, new_user.id, server)
+
+            # Mark invitation as used for this server
+            if inv:
+                from app.services.invites import mark_server_used
+
+                mark_server_used(inv, server_id, new_user)
+
+            # Pass only what we need: server credentials and Flask app instance
+            # Use the specific server being processed for this invitation
+            post_setup_client = PlexClient(media_server=server)
+            server_url = post_setup_client.url
+            api_token = post_setup_client.token
+            threading.Thread(
+                target=_post_join_setup,
+                args=(current_app._get_current_object(), server_url, api_token, token),  # type: ignore
+                daemon=True,
+            ).start()
 
         notify(
             "User Joined",
@@ -1315,19 +1335,6 @@ def handle_oauth_token(app, token: str, code: str) -> None:
             "tada",
             event_type="user_joined",
         )
-
-        # Pass only what we need: server credentials and Flask app instance
-        # Use the specific server that was determined for this invitation
-        from flask import current_app
-
-        post_setup_client = PlexClient(media_server=server)
-        server_url = post_setup_client.url
-        api_token = post_setup_client.token
-        threading.Thread(
-            target=_post_join_setup,
-            args=(current_app._get_current_object(), server_url, api_token, token),  # type: ignore
-            daemon=True,
-        ).start()
 
 
 def _invite_user(email: str, code: str, _user_id: int, server: MediaServer) -> None:

--- a/tests/test_plex_oauth_multi_server.py
+++ b/tests/test_plex_oauth_multi_server.py
@@ -1,0 +1,96 @@
+from app.extensions import db
+from app.models import Invitation, MediaServer, User, invitation_servers
+from app.services.media import plex as plex_service
+
+
+class FakePlexAccount:
+    email = "viewer@example.com"
+    username = "viewer"
+
+    def __init__(self, token):
+        self.token = token
+
+
+class FakePlexClient:
+    def __init__(self, media_server):
+        self.media_server = media_server
+        self.url = media_server.url
+        self.token = media_server.api_key
+
+    def _create_user_with_identity_linking(self, user_data):
+        user = User(
+            token=user_data["token"],
+            username=user_data["username"],
+            email=user_data["email"],
+            code=user_data["code"],
+            server_id=user_data["server_id"],
+            expires=user_data["expires"],
+        )
+        db.session.add(user)
+        db.session.flush()
+        return user
+
+
+class ImmediateThread:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+
+def test_plex_oauth_invites_every_plex_server_on_multi_server_invite(
+    app, session, monkeypatch
+):
+    plex_primary = MediaServer(
+        name="Plex Primary",
+        server_type="plex",
+        url="http://plex-primary:32400",
+        api_key="primary-token",
+    )
+    plex_secondary = MediaServer(
+        name="Plex Secondary",
+        server_type="plex",
+        url="http://plex-secondary:32400",
+        api_key="secondary-token",
+    )
+    emby = MediaServer(
+        name="Emby",
+        server_type="emby",
+        url="http://emby:8096",
+        api_key="emby-token",
+    )
+    invitation = Invitation(code="MULTIPLEX", unlimited=False)
+    invitation.servers.extend([plex_primary, plex_secondary, emby])
+    session.add(invitation)
+    session.commit()
+
+    invited_server_ids = []
+
+    def fake_invite_user(email, code, user_id, server):
+        invited_server_ids.append(server.id)
+
+    monkeypatch.setattr(plex_service, "MyPlexAccount", FakePlexAccount)
+    monkeypatch.setattr(plex_service, "PlexClient", FakePlexClient)
+    monkeypatch.setattr(plex_service, "_invite_user", fake_invite_user)
+    monkeypatch.setattr(plex_service, "_post_join_setup", lambda *args: None)
+    monkeypatch.setattr(plex_service.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(plex_service, "notify", lambda *args, **kwargs: None)
+
+    plex_service.handle_oauth_token(app, "oauth-token", invitation.code)
+
+    users = User.query.filter_by(email="viewer@example.com").all()
+    assert {user.server_id for user in users} == {plex_primary.id, plex_secondary.id}
+    assert invited_server_ids == [plex_primary.id, plex_secondary.id]
+
+    usage_rows = session.execute(
+        invitation_servers.select().where(
+            invitation_servers.c.invite_id == invitation.id
+        )
+    ).all()
+    usage_by_server = {row.server_id: row.used for row in usage_rows}
+    assert usage_by_server == {
+        plex_primary.id: True,
+        plex_secondary.id: True,
+        emby.id: False,
+    }


### PR DESCRIPTION
## Summary

Fixes multi-server invites where a single invitation contains more than one Plex server. The existing Plex OAuth handler selected only the first Plex server attached to the invite, so additional Plex servers were skipped and only non-Plex servers continued through the password step.

This changes `handle_oauth_token()` to process every Plex server attached to the invitation while preserving the existing legacy/single-server fallback behavior.

Closes #1291.

## What changed

- collect all Plex servers from a multi-server invitation instead of selecting `plex_servers[0]`
- create/update the Wizarr user row once per Plex server
- invite/update sharing once per Plex server
- mark each Plex server as used for the invitation
- keep non-Plex servers for the existing password-based follow-up step
- add a regression test for a mixed invite containing two Plex servers and one Emby server

## Validation

- `python3 -m py_compile app/services/media/plex.py tests/test_plex_oauth_multi_server.py`
- `git diff --check`
- `pytest tests/test_plex_oauth_multi_server.py -q`
- red/green regression check: the new test fails against `upstream/main` and passes with this fix
- `pytest tests/test_plex_oauth_multi_server.py tests/test_invitation_unit.py -q` → 16 passed