### PR TITLE
Fix multi-server Emby/Jellyfin invite permissions

### DIFF
--- a/app/blueprints/public/routes.py
+++ b/app/blueprints/public/routes.py
@@ -24,6 +24,48 @@ from app.services.media.plex import PlexInvitationError, handle_oauth_token
 public_bp = Blueprint("public", __name__)
 
 
+def _media_permission_flags(invitation: Invitation, server: MediaServer) -> dict:
+    return {
+        "allow_downloads": bool(getattr(invitation, "allow_downloads", False))
+        or bool(getattr(server, "allow_downloads", False)),
+        "allow_live_tv": bool(getattr(invitation, "allow_live_tv", False))
+        or bool(getattr(server, "allow_live_tv", False)),
+        "allow_mobile_uploads": bool(
+            getattr(invitation, "allow_mobile_uploads", False)
+        )
+        or bool(getattr(server, "allow_mobile_uploads", False)),
+    }
+
+
+def _apply_safe_media_user_policy(
+    client, user_id: str, invitation: Invitation, server: MediaServer
+) -> dict:
+    permissions = _media_permission_flags(invitation, server)
+    current_policy = client.get(f"/Users/{user_id}").json().get("Policy", {})
+    current_policy.update(
+        {
+            "IsAdministrator": False,
+            "EnableContentDeletion": False,
+            "EnableContentDeletionFromFolders": [],
+            "EnableContentDownloading": permissions["allow_downloads"],
+            "EnableLiveTvAccess": permissions["allow_live_tv"],
+            "EnableLiveTvManagement": False,
+            "AllowCameraUpload": permissions["allow_mobile_uploads"],
+            "EnablePublicSharing": False,
+            "AllowSharingPersonalItems": False,
+            "EnableSubtitleManagement": False,
+            "EnableRemoteControlOfOtherUsers": False,
+        }
+    )
+
+    max_sessions = getattr(invitation, "max_active_sessions", None)
+    if server.server_type == "jellyfin" and max_sessions is not None:
+        current_policy["MaxActiveSessions"] = max_sessions
+
+    client.set_policy(user_id, current_policy)
+    return permissions
+
+
 # ─── Landing “/” ──────────────────────────────────────────────────────────────
 @public_bp.route("/")
 def root():
@@ -372,8 +414,12 @@ def password_prompt(code):
             client = get_client_for_media_server(srv)
 
             try:
+                permissions = _media_permission_flags(invitation, srv)
                 if srv.server_type in ("jellyfin", "emby"):
                     uid = client.create_user(username, pw)
+                    permissions = _apply_safe_media_user_policy(
+                        client, uid, invitation, srv
+                    )
                 elif srv.server_type in ("audiobookshelf", "romm"):
                     uid = client.create_user(username, pw, email=email)
                 else:
@@ -393,6 +439,10 @@ def password_prompt(code):
                 new_user.server_id = srv.id
                 new_user.expires = user_expires  # Set expiry based on invitation duration (server-specific)
                 new_user.is_ldap_user = is_ldap_user
+                new_user.is_admin = False
+                new_user.allow_downloads = permissions["allow_downloads"]
+                new_user.allow_live_tv = permissions["allow_live_tv"]
+                new_user.allow_camera_upload = permissions["allow_mobile_uploads"]
                 db.session.add(new_user)
                 db.session.commit()
 

--- a/tests/test_multiserver_media_policy.py
+++ b/tests/test_multiserver_media_policy.py
@@ -1,0 +1,105 @@
+from unittest.mock import patch
+
+from app.extensions import db
+from app.models import AdminAccount, Invitation, MediaServer, Settings
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class PolicyCapturingClient:
+    def __init__(self):
+        self.user_id = "emby-user-1"
+        self.policy_updates = []
+
+    def create_user(self, username, password):
+        return self.user_id
+
+    def get(self, endpoint):
+        assert endpoint == f"/Users/{self.user_id}"
+        return _Response(
+            {
+                "Policy": {
+                    "IsAdministrator": True,
+                    "EnableContentDeletion": True,
+                    "EnableContentDownloading": True,
+                    "EnableLiveTvAccess": True,
+                    "EnableLiveTvManagement": True,
+                    "AllowCameraUpload": True,
+                    "EnablePublicSharing": True,
+                    "AllowSharingPersonalItems": True,
+                    "EnableSubtitleManagement": True,
+                    "EnableRemoteControlOfOtherUsers": True,
+                }
+            }
+        )
+
+    def set_policy(self, user_id, policy):
+        assert user_id == self.user_id
+        self.policy_updates.append(policy)
+
+
+def _complete_setup():
+    admin = AdminAccount(username="admin")
+    admin.set_password("password")
+    db.session.add(admin)
+    db.session.add(Settings(key="admin_username", value="admin"))
+
+
+def test_password_prompt_applies_safe_emby_policy(client, session):
+    _complete_setup()
+    server = MediaServer(
+        name="Emby",
+        server_type="emby",
+        url="http://emby.local",
+        api_key="emby-key",
+        allow_downloads=False,
+        allow_live_tv=False,
+        allow_mobile_uploads=False,
+    )
+    invitation = Invitation(
+        code="EMBYPOLICY",
+        used=False,
+        unlimited=True,
+        allow_downloads=False,
+        allow_live_tv=False,
+        allow_mobile_uploads=False,
+    )
+    invitation.servers = [server]
+    db.session.add_all([server, invitation])
+    db.session.commit()
+
+    media_client = PolicyCapturingClient()
+
+    with patch(
+        "app.services.media.service.get_client_for_media_server",
+        return_value=media_client,
+    ):
+        response = client.post(
+            "/j/EMBYPOLICY/password",
+            data={
+                "username": "viewer",
+                "email": "viewer@example.com",
+                "password": "password123",
+                "confirm": "password123",
+            },
+        )
+
+    assert response.status_code == 302
+    assert len(media_client.policy_updates) == 1
+    policy = media_client.policy_updates[0]
+    assert policy["IsAdministrator"] is False
+    assert policy["EnableContentDeletion"] is False
+    assert policy["EnableContentDownloading"] is False
+    assert policy["EnableLiveTvAccess"] is False
+    assert policy["EnableLiveTvManagement"] is False
+    assert policy["AllowCameraUpload"] is False
+    assert policy["EnablePublicSharing"] is False
+    assert policy["AllowSharingPersonalItems"] is False
+    assert policy["EnableSubtitleManagement"] is False
+    assert policy["EnableRemoteControlOfOtherUsers"] is False


### PR DESCRIPTION
## Summary

- Applies explicit safe Jellyfin/Emby policy after multi-server password-flow user creation.
- Preserves invite/server toggles for downloads, live TV, mobile uploads, and Jellyfin max active sessions.
- Stores matching permission metadata on the local Wizarr user row.
- Adds a regression test for the `/j/<code>/password` multi-server path.

Fixes #1293.

## Root cause

The multi-server password route called `client.create_user(...)` directly for Jellyfin/Emby servers and then recorded the local user without applying the normal invite/server permission policy. Depending on server defaults, the new account could inherit broad permissions such as admin-like management flags, downloads, live TV, public sharing, or camera upload.

## Validation

- `.venv/bin/python -m pytest tests/test_multiserver_media_policy.py tests/test_invitation_comprehensive.py -q`
- `git diff --check HEAD~1..HEAD`

`uv run ruff check app/blueprints/public/routes.py` could not complete locally because `uv` timed out downloading `setuptools==82.0.1` from PyPI.