### PR TITLE
Adding subpath support behind reverse proxy

### DIFF
--- a/SUBPATH_SUPPORT.md
+++ b/SUBPATH_SUPPORT.md
@@ -1,0 +1,135 @@
+# Subpath Support for Wizarr
+
+This document describes the changes made to support running Wizarr under a custom path (e.g., `midominio.com/wizarr`) behind a reverse proxy.
+
+## The Problem
+
+When running Wizarr behind a reverse proxy like nginx with a location block like:
+
+```nginx
+location /wizarr {
+    proxy_pass http://localhost:5698/;
+}
+```
+
+The application would show 404 errors because:
+1. All blueprints were registered with hardcoded `/` prefixes
+2. Static files were served from `/static` without considering the subpath
+3. URL generation with `url_for()` didn't account for the custom path
+
+## The Solution
+
+### 1. Configurable `APPLICATION_ROOT` (app/config.py)
+
+Added a new environment variable `APPLICATION_ROOT` that allows you to specify the base path:
+
+```bash
+APPLICATION_ROOT=/wizarr
+```
+
+If not set, it defaults to `/` (root path).
+
+### 2. Dynamic Blueprint Registration (app/__init__.py)
+
+Modified the blueprint registration to prepend the `APPLICATION_ROOT` to each blueprint's `url_prefix`:
+
+```python
+# Example: if APPLICATION_ROOT=/wizarr
+# /setup becomes /wizarr/setup
+# /api becomes /wizarr/api
+# etc.
+```
+
+### 3. Static Files Path (app/__init__.py)
+
+Configured Flask to serve static files from the correct path:
+
+```python
+static_url_path=f"{app_root}/static"
+```
+
+### 4. Reverse Proxy Middleware (app/middleware.py)
+
+Added a `ReverseProxyFix` middleware that:
+- Reads `X-Forwarded-Prefix` header (sent by nginx/traefik)
+- Sets `SCRIPT_NAME` for correct URL generation
+- Handles `X-Forwarded-Proto` for HTTPS detection
+- Handles `X-Forwarded-Host` for correct host detection
+
+### 5. Onboarding Path Handling (app/middleware.py)
+
+Updated the `require_onboarding()` function to handle paths correctly when running under a subpath.
+
+## Usage
+
+### Environment Variables
+
+Set these in your Docker compose or environment:
+
+```bash
+# Required: the path where Wizarr is served
+APPLICATION_ROOT=/wizarr
+
+# Optional: if using HTTPS behind proxy
+PREFERRED_URL_SCHEME=https
+```
+
+### Nginx Configuration
+
+```nginx
+location /wizarr {
+    proxy_pass http://localhost:5698;
+    proxy_set_header X-Forwarded-Prefix /wizarr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host:$server_port;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+}
+```
+
+### Docker Compose Example
+
+```yaml
+services:
+  wizarr:
+    image: ghcr.io/wizarrrr/wizarr:latest
+    container_name: wizarr
+    environment:
+      - APPLICATION_ROOT=/wizarr
+      - PREFERRED_URL_SCHEME=https
+    volumes:
+      - ./config/wizarr:/config
+```
+
+### Traefik Configuration
+
+If using Traefik, you can use `X-Forwarded-Prefix` middleware:
+
+```yaml
+labels:
+  - "traefik.http.middlewares.wizarr-strip.stripprefix.prefixes=/wizarr"
+  - "traefik.http.routers.wizarr.middlewares=wizarr-strip"
+```
+
+## Notes
+
+- The `APPLICATION_ROOT` is used as a fallback if `X-Forwarded-Prefix` header is not present
+- Static files are automatically served from the correct path
+- All internal redirects and `url_for()` calls now generate correct URLs
+- No changes are needed to templates or JavaScript files
+
+## Testing
+
+To test the subpath setup:
+
+1. Set `APPLICATION_ROOT=/wizarr` environment variable
+2. Start the application
+3. Access via `http://localhost:5698/wizarr/` directly, or
+4. Configure your reverse proxy and access via `https://midominio.com/wizarr`
+
+## Files Modified
+
+- `app/config.py` - Added `APPLICATION_ROOT` configuration
+- `app/__init__.py` - Dynamic blueprint registration and static path configuration
+- `app/middleware.py` - Added `ReverseProxyFix` middleware and updated path handling

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -29,8 +29,11 @@ def create_app(config_object=DevelopmentConfig):
     # Step 2: Create Flask application
     if show_startup:
         logger.step("Creating Flask application", "🌐")
-    app = Flask(__name__)
+    # SCRIPT_NAME supplies APPLICATION_ROOT, including for the static endpoint.
+    app = Flask(__name__, static_url_path="/static")
     app.config.from_object(config_object)
+    # Configure app to handle reverse proxy subpath
+    app.config["PREFERRED_URL_SCHEME"] = os.getenv("PREFERRED_URL_SCHEME", "http")
 
     # Step 3: Initialize extensions
     if show_startup:
@@ -84,6 +87,11 @@ def create_app(config_object=DevelopmentConfig):
 
     register_filters(app)
     app.before_request(require_onboarding)
+
+    # Wrap app with reverse proxy middleware for subpath support
+    from .middleware import ReverseProxyFix
+
+    app.wsgi_app = ReverseProxyFix(app.wsgi_app, app)
 
     # Step 6: Initialize wizard steps
     if show_startup:

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -177,10 +177,13 @@ def invite():
                 ldap_enabled=ldap_enabled,
             ), 400
 
-        current_url = request.headers.get("HX-Current-URL")
+        current_url = request.headers.get("HX-Current-URL", request.url)
         parsed_url = urlparse(current_url)
-        host_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-        link = f"{host_url}/j/{invite.code}"
+        if parsed_url.scheme in {"http", "https"} and parsed_url.netloc:
+            origin = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        else:
+            origin = request.host_url.rstrip("/")
+        link = f"{origin}{url_for('public.invite', code=invite.code)}"
 
         invitations = Invitation.query.order_by(Invitation.created.desc()).all()
         return render_template(

--- a/app/blueprints/api/api_routes.py
+++ b/app/blueprints/api/api_routes.py
@@ -173,8 +173,7 @@ def _generate_invitation_url(code):
 
     except Exception as e:
         logger.warning("Failed to generate invitation URL: %s", str(e))
-        # Fallback to basic format
-        return f"/j/{code}"
+        return f"{request.script_root}/j/{code}"
 
 
 def _calculate_invitation_status(invitation):

--- a/app/blueprints/auth/routes.py
+++ b/app/blueprints/auth/routes.py
@@ -17,7 +17,7 @@ auth_bp = Blueprint("auth", __name__)
 def login():
     if os.getenv("DISABLE_BUILTIN_AUTH", "").lower() == "true":
         login_user(AdminUser(), remember=bool(request.form.get("remember")))
-        return redirect("/")
+        return redirect(url_for("admin.dashboard"))
 
     # Pre-compute shared template context
     from app.models import LDAPConfiguration, WebAuthnCredential
@@ -48,7 +48,7 @@ def login():
 
         success, message = handle_ldap_login(username, password)
         if success:
-            return redirect("/")
+            return redirect(url_for("admin.dashboard"))
 
         return render_template(
             "login.html",
@@ -77,7 +77,7 @@ def login():
             )
         # No passkeys, allow direct login
         login_user(account, remember=bool(request.form.get("remember")))
-        return redirect("/")
+        return redirect(url_for("admin.dashboard"))
 
     # fetch the stored admin credentials
     admin_username = (
@@ -94,7 +94,7 @@ def login():
     ):
         # Legacy single-admin (Settings table)
         login_user(AdminUser(), remember=bool(request.form.get("remember")))
-        return redirect("/")
+        return redirect(url_for("admin.dashboard"))
 
     # Get IP address: prefer Cloudflare's header, then X-Forwarded-For, then remote_addr
     client_ip = (
@@ -156,7 +156,7 @@ def complete_2fa():
     session.pop("pending_2fa_remember", None)
 
     login_user(account, remember=remember)
-    return redirect("/")
+    return redirect(url_for("admin.dashboard"))
 
 
 # ── Logout ────────────────────────────────────────────────────────────

--- a/app/blueprints/public/routes.py
+++ b/app/blueprints/public/routes.py
@@ -30,8 +30,8 @@ def root():
     # check if admin_username exists
     admin_setting = Settings.query.filter_by(key="admin_username").first()
     if not admin_setting:
-        return redirect("/setup/")  # installation wizard
-    return redirect("/admin")
+        return redirect(url_for("setup.onboarding"))
+    return redirect(url_for("admin.dashboard"))
 
 
 # ─── Favicon ─────────────────────────────────────────────────────────────────

--- a/app/blueprints/wizard/routes.py
+++ b/app/blueprints/wizard/routes.py
@@ -78,7 +78,7 @@ def restrict_wizard():
             request.referrer and "/j/" in request.referrer
         ):
             return None
-        return redirect("/")
+        return redirect(url_for("admin.dashboard"))
     return None
 
 
@@ -419,6 +419,9 @@ def _serve_wizard(
         gradient_start=colors["gradient_start"],
         gradient_end=colors["gradient_end"],
         shadow_color=colors["shadow_color"],
+        server_url=server_ctx.get("server_url", ""),
+        external_url=server_ctx.get("external_url", ""),
+        server_name=server_ctx.get("server_name", ""),
     )
 
     # Add custom headers for client-side updates (HTMX requests only)
@@ -1080,6 +1083,9 @@ def combo(category: str, idx: int = 0):
         gradient_start=colors["gradient_start"],
         gradient_end=colors["gradient_end"],
         shadow_color=colors["shadow_color"],
+        server_url=server_ctx.get("server_url", ""),
+        external_url=server_ctx.get("external_url", ""),
+        server_name=server_ctx.get("server_name", ""),
     )
 
     # Add custom headers for client-side updates (HTMX requests only)
@@ -1297,6 +1303,9 @@ def bundle_view(idx: int):
         gradient_start=colors["gradient_start"],
         gradient_end=colors["gradient_end"],
         shadow_color=colors["shadow_color"],
+        server_url=server_ctx.get("server_url", ""),
+        external_url=server_ctx.get("external_url", ""),
+        server_name=server_ctx.get("server_name", ""),
     )
 
     # Add custom headers for client-side updates (HTMX requests only)
@@ -1436,6 +1445,7 @@ def bundle_preview(bundle_id: int, idx: int):
 
     # Get server-specific color scheme for theming
     colors = _get_server_colors(current_server_type)
+    server_ctx = _get_server_context(current_server_type or "")
 
     response = render_template(
         page,
@@ -1454,6 +1464,9 @@ def bundle_preview(bundle_id: int, idx: int):
         gradient_end=colors["gradient_end"],
         shadow_color=colors["shadow_color"],
         is_bundle_preview=True,  # Flag to help template generate correct URLs
+        server_url=server_ctx.get("server_url", ""),
+        external_url=server_ctx.get("external_url", ""),
+        server_name=server_ctx.get("server_name", ""),
     )
 
     # Add custom headers for client-side updates (HTMX requests only)

--- a/app/blueprints/wizard_admin/routes.py
+++ b/app/blueprints/wizard_admin/routes.py
@@ -217,7 +217,17 @@ def create_step():
         page_tmpl = "settings/wizard/form.html"
 
     tmpl = modal_tmpl if request.headers.get("HX-Request") else page_tmpl
-    return render_template(tmpl, form=form, action="create", bundle_id=bundle_id)
+    form_action = url_for(
+        "wizard_admin.create_step",
+        **({"simple": 1, "bundle_id": bundle_id} if simple else {}),
+    )
+    return render_template(
+        tmpl,
+        form=form,
+        action="create",
+        bundle_id=bundle_id,
+        form_action=form_action,
+    )
 
 
 @wizard_admin_bp.route("/create-preset", methods=["GET", "POST"])
@@ -342,7 +352,13 @@ def edit_step(step_id: int):
         "settings/wizard/simple_form.html" if simple else "settings/wizard/form.html"
     )
     tmpl = modal_tmpl if request.headers.get("HX-Request") else page_tmpl
-    return render_template(tmpl, form=form, action="edit", step=step)
+    return render_template(
+        tmpl,
+        form=form,
+        action="edit",
+        step=step,
+        form_action=url_for("wizard_admin.edit_step", step_id=step.id),
+    )
 
 
 @wizard_admin_bp.route("/<int:step_id>/delete", methods=["POST"])

--- a/app/config.py
+++ b/app/config.py
@@ -76,6 +76,11 @@ class BaseConfig:
     # Flask
     TEMPLATES_AUTO_RELOAD = True
     SECRET_KEY = get_or_create_secret("SECRET_KEY", generate_secret_key)
+    # Support running under a custom path (e.g., /wizarr via reverse proxy)
+    APPLICATION_ROOT = os.getenv("APPLICATION_ROOT", "/")
+    # Ensure trailing slash for consistency
+    if APPLICATION_ROOT != "/" and not APPLICATION_ROOT.endswith("/"):
+        APPLICATION_ROOT += "/"
     # Sessions
     SESSION_TYPE = "cachelib"  # Changed from 'filesystem' to 'cachelib'
     SESSION_CACHELIB = SESSION_CACHELIB  # Reference the module-level cache

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,16 +1,22 @@
-# app/middleware.py
 from flask import current_app, redirect, request, url_for
 
 from app.models import Settings
 
 
 def require_onboarding():
-    if (
-        request.path.startswith("/setup")
-        or request.path.startswith("/static")
-        or request.path.startswith("/settings")
-        or request.path.startswith("/api")
-    ):
+    # Get the current path
+    # Note: PATH_INFO has the prefix stripped by ReverseProxyFix middleware
+    # but request.path includes SCRIPT_NAME, so we need to get the actual path
+    path = request.path
+
+    # Get SCRIPT_NAME (set by middleware if APPLICATION_ROOT is configured)
+    script_name = request.script_root or ""
+
+    # Remove SCRIPT_NAME prefix to get the actual route path
+    if script_name and path.startswith(script_name):
+        path = path[len(script_name) :] or "/"
+
+    if path.startswith(("/setup", "/static", "/settings", "/api")):
         return None
 
     # Skip onboarding check during testing
@@ -24,3 +30,58 @@ def require_onboarding():
     return None
     # Allow access to the application even if no MediaServer has been configured yet.
     # Users can add servers later via the Settings page.
+
+
+class ReverseProxyFix:
+    """Middleware to handle reverse proxy headers for subpath support.
+
+    Handles both smart proxies (with X-Forwarded-Prefix header) and
+    dumb proxies (that strip the prefix but don't send the header).
+    """
+
+    def __init__(self, wsgi_app, flask_app):
+        self.wsgi_app = wsgi_app
+        self.flask_app = flask_app  # Reference to Flask app for config access
+
+    def __call__(self, environ, start_response):
+        app_root = self.flask_app.config.get("APPLICATION_ROOT", "/")
+        path_info = environ.get("PATH_INFO", "/")
+
+        # Special case: /health endpoint should always work for Docker healthcheck
+        # even without the prefix (internal health checks bypass the proxy)
+        is_health_check = path_info in {"/health", "/health/"}
+        # Check if request is from localhost (internal/Docker healthcheck)
+        remote_addr = environ.get("REMOTE_ADDR", "")
+        # Handle multiple IPs in X-Forwarded-For
+        x_forwarded_for = environ.get("HTTP_X_FORWARDED_FOR", "")
+        client_ip = (
+            x_forwarded_for.split(",")[0].strip() if x_forwarded_for else remote_addr
+        )
+        local_addresses = {"127.0.0.1", "::1", "localhost"}
+        is_local = client_ip in local_addresses or remote_addr in local_addresses
+
+        # Determine the effective prefix
+        forwarded_prefix = environ.get("HTTP_X_FORWARDED_PREFIX", "").rstrip("/")
+        configured_prefix = app_root.rstrip("/")
+        effective_prefix = forwarded_prefix or configured_prefix
+
+        # Skip prefix handling only for local health checks
+        if not (is_health_check and is_local) and effective_prefix:
+            # Always set SCRIPT_NAME so url_for() generates correct URLs with prefix
+            environ["SCRIPT_NAME"] = effective_prefix
+
+            # Proxies may preserve or strip the prefix. Normalize either form.
+            if path_info.startswith(effective_prefix):
+                environ["PATH_INFO"] = path_info[len(effective_prefix) :] or "/"
+
+        # Handle X-Forwarded-Proto for HTTPS detection
+        forwarded_proto = environ.get("HTTP_X_FORWARDED_PROTO", "")
+        if forwarded_proto:
+            environ["wsgi.url_scheme"] = forwarded_proto
+
+        # Handle X-Forwarded-Host
+        forwarded_host = environ.get("HTTP_X_FORWARDED_HOST", "")
+        if forwarded_host:
+            environ["HTTP_HOST"] = forwarded_host
+
+        return self.wsgi_app(environ, start_response)

--- a/app/services/invitation_flow/workflows.py
+++ b/app/services/invitation_flow/workflows.py
@@ -214,7 +214,7 @@ class InvitationWorkflow(ABC):
             status = ProcessingStatus.PARTIAL_SUCCESS
             message = f"Accounts created on {len(successful)} of {len(successful) + len(failed)} servers"
 
-        redirect_url = "/wizard/"
+        redirect_url = url_for("wizard.start")
         if bundle_id:
             redirect_url = url_for("wizard.bundle_view", idx=0)
 

--- a/app/services/invitation_manager.py
+++ b/app/services/invitation_manager.py
@@ -201,7 +201,8 @@ class InvitationManager:
             str: Redirect URL
         """
         session["wizard_access"] = code
-        return "/wizard/"
+        from flask import url_for
+        return url_for("wizard.start")
 
 
 class LibraryScanner:

--- a/app/services/media/client_base.py
+++ b/app/services/media/client_base.py
@@ -130,12 +130,13 @@ class MediaClient(ABC):
         from urllib.parse import quote_plus
 
         from app.services.image_proxy import ImageProxyService
+        from flask import url_for
 
         # Generate opaque token for this URL
         token = ImageProxyService.generate_token(image_url, server_id=self.server_id)
 
-        # Return proxy URL with token
-        return f"/image-proxy?token={quote_plus(token)}"
+        # Return proxy URL with token (respects APPLICATION_ROOT)
+        return url_for("public.image_proxy", token=quote_plus(token), _external=False)
 
     def _create_user_with_identity_linking(self, user_kwargs: dict) -> User:
         """Create a User record with intelligent identity linking based on invitation type.

--- a/app/static/js/pwa-registration.js
+++ b/app/static/js/pwa-registration.js
@@ -1,12 +1,16 @@
 // PWA Service Worker Registration - Prevent double execution
 (function() {
   'use strict';
-  
+
   // Guard against double execution
   if (window.wizarrPWALoaded) {
     return;
   }
   window.wizarrPWALoaded = true;
+
+  // Resolve the worker relative to this script so subpath deployments work.
+  var registrationScript = document.currentScript;
+  var serviceWorkerUrl = new URL('../sw.js', registrationScript.src);
 
   // Service Worker Registration
   if ('serviceWorker' in navigator) {
@@ -14,7 +18,7 @@
       // updateViaCache: 'none' ensures the browser always fetches sw.js from the
       // server instead of the HTTP cache, so service worker updates are detected
       // immediately after deployment.
-      navigator.serviceWorker.register('/static/sw.js', { updateViaCache: 'none' })
+      navigator.serviceWorker.register(serviceWorkerUrl, { updateViaCache: 'none' })
         .then(function(registration) {
           console.log('ServiceWorker registration successful with scope: ', registration.scope);
 
@@ -43,7 +47,7 @@
     console.log('beforeinstallprompt event fired');
     e.preventDefault();
     deferredPrompt = e;
-    
+
     // Show install button/banner if needed
     showInstallPromotion();
   });

--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -2,61 +2,61 @@
   "name": "Wizarr",
   "short_name": "Wizarr",
   "description": "A simple invitation management system for your media servers",
-  "start_url": "/",
+  "start_url": "../",
   "display": "standalone",
   "background_color": "#1f2937",
   "theme_color": "#3b82f6",
   "orientation": "portrait-primary",
-  "scope": "/",
+  "scope": "../",
   "icons": [
     {
-      "src": "/static/img/pwa-icons/icon-72x72.png",
+      "src": "img/pwa-icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/static/img/pwa-icons/icon-96x96.png",
+      "src": "img/pwa-icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/static/img/pwa-icons/icon-128x128.png",
+      "src": "img/pwa-icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/static/img/pwa-icons/icon-144x144.png",
+      "src": "img/pwa-icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/static/img/pwa-icons/icon-152x152.png",
+      "src": "img/pwa-icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/static/img/pwa-icons/icon-192x192.png",
+      "src": "img/pwa-icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/static/img/pwa-icons/icon-384x384.png",
+      "src": "img/pwa-icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/static/img/pwa-icons/icon-512x512.png",
+      "src": "img/pwa-icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable any"
     }
   ],
   "categories": ["productivity", "utilities"]
-} 
+}

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,14 +1,14 @@
 const CACHE_NAME = 'wizarr-v2';
 const urlsToCache = [
-  '/static/css/main.css',
-  '/static/js/dark-mode-switch.js',
-  '/static/favicon.ico',
-  '/static/wizarr-logo.png',
-  '/static/js/vendor/htmx.min.js',
-  '/static/js/vendor/alpine.min.js',
-  '/static/js/vendor/flowbite.min.js',
-  '/static/js/vendor/alpine-collapse.min.js'
-];
+  'css/main.css',
+  'js/dark-mode-switch.js',
+  'favicon.ico',
+  'wizarr-logo.png',
+  'js/vendor/htmx.min.js',
+  'js/vendor/alpine.min.js',
+  'js/vendor/flowbite.min.js',
+  'js/vendor/alpine-collapse.min.js'
+].map((path) => new URL(path, self.location.href).href);
 
 // Install event - cache resources and activate immediately
 self.addEventListener('install', (event) => {
@@ -94,4 +94,4 @@ self.addEventListener('sync', (event) => {
 
 self.addEventListener('push', (event) => {
   console.log('Push event:', event);
-}); 
+});

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -25,9 +25,14 @@
           <div class="flex flex-col md:flex-row md:items-center gap-4 md:gap-8 text-sm font-medium">
             <!-- Main Navigation -->
             <ul class="flex flex-col md:flex-row md:items-center gap-2 md:gap-4 md:space-y-0 space-y-2">
-              {% set activity_url = url_for('activity.activity_dashboard') %}
-              {% set tabs = [('/home', '#', 'Home'), ('/invites', '#invites', 'Invitations'), ('/users', '#users', 'Users'), (activity_url, '#activity', 'Activity'), ('/settings', '#settings', 'Settings')] %}
-              {% for href, hash, label in tabs %}
+              {% set tabs = [
+                            ('home', url_for('admin.home'), '#', 'Home'),
+                            ('invites', url_for('admin.invites'), '#invites', 'Invitations'),
+                            ('users', url_for('admin.users'), '#users', 'Users'),
+                            ('activity', url_for('activity.activity_dashboard'), '#activity', 'Activity'),
+                            ('settings', url_for('settings.page'), '#settings', 'Settings')
+                          ] %}
+              {% for key, href, hash, label in tabs %}
                 <li>
                   <button hx-get="{{ href }}"
                           preload="mouseover"
@@ -40,22 +45,22 @@
                     {{ _(label) }}
                   </button>
                   <!-- Page-specific prefetches -->
-                  {% if href == "/home" %}
-                    <div hx-get="/now-playing-cards"
+                  {% if key == "home" %}
+                    <div hx-get="{{ url_for('admin.now_playing_cards') }}"
                          hx-trigger="hover once"
                          hx-swap="none"
                          style="display: none"></div>
-                  {% elif href == "/invites" %}
-                    <div hx-post="/invite/table"
+                  {% elif key == "invites" %}
+                    <div hx-post="{{ url_for('admin.invite_table') }}"
                          hx-trigger="hover once"
                          hx-swap="none"
                          style="display: none"></div>
-                  {% elif href == "/users" %}
-                    <div hx-get="/users/table"
+                  {% elif key == "users" %}
+                    <div hx-get="{{ url_for('admin.users_table') }}"
                          hx-trigger="hover once"
                          hx-swap="none"
                          style="display: none"></div>
-                  {% elif href == activity_url %}
+                  {% elif key == "activity" %}
                     <div hx-get="{{ url_for('activity.activity_grid') }}"
                          hx-trigger="hover once"
                          hx-swap="none"
@@ -64,17 +69,12 @@
                          hx-trigger="hover once"
                          hx-swap="none"
                          style="display: none"></div>
-                  {% elif href == "/plus" %}
-                    <div hx-get="/plus/overview"
+                  {% elif key == "settings" %}
+                    <div hx-get="{{ url_for('settings.general_settings') }}"
                          hx-trigger="hover once"
                          hx-swap="none"
                          style="display: none"></div>
-                  {% elif href == "/settings" %}
-                    <div hx-get="/settings/general"
-                         hx-trigger="hover once"
-                         hx-swap="none"
-                         style="display: none"></div>
-                    <div hx-get="/settings/api-keys"
+                    <div hx-get="{{ url_for('api_keys.list_api_keys') }}"
                          hx-trigger="hover once"
                          hx-swap="none"
                          style="display: none"></div>
@@ -120,7 +120,7 @@
                      class="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 z-50">
                   <div class="py-1">
                     <a href="#profile"
-                       hx-get="/profile"
+                       hx-get="{{ url_for('admin.user_profile') }}"
                        hx-target="#content"
                        hx-swap="innerHTML"
                        hx-push-url="#profile"
@@ -182,7 +182,7 @@
         </a>
         <div class="flex items-center gap-2">
           <!-- User Profile for mobile -->
-          <button hx-get="/profile"
+          <button hx-get="{{ url_for('admin.user_profile') }}"
                   hx-trigger="click"
                   hx-target="#content"
                   hx-swap="innerHTML"
@@ -222,13 +222,12 @@
     <!-- Mobile Bottom Navigation -->
     <nav class="md:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 z-50">
       <div class="grid grid-cols-5 h-16">
-        {% set activity_url = url_for('activity.activity_dashboard') %}
         {% set mobile_tabs = [
-                  ('/home', '#', 'Home', 'm4 12 8-8 8 8M6 10.5V19a1 1 0 0 0 1 1h3v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h3a1 1 0 0 0 1-1v-8.5'),
-                  ('/invites', '#invites', 'Invitations', 'm3.5 5.5 7.893 6.036a1 1 0 0 0 1.214 0L20.5 5.5M4 19h16a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Z'),
-                  ('/users', '#users', 'Users', 'M16 19h4a1 1 0 0 0 1-1v-1a3 3 0 0 0-3-3h-2m-2.236-4a3 3 0 1 0 0-4M3 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z'),
-                  (activity_url, '#activity', 'Activity', 'M5 3a1 1 0 0 1 1 1v12a1 1 0 1 1-2 0V4a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v9a1 1 0 1 1-2 0V8a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1Z'),
-                  ('/settings', '#settings', 'Settings', 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 0 1 6 0z')
+                  (url_for('admin.home'), '#', 'Home', 'm4 12 8-8 8 8M6 10.5V19a1 1 0 0 0 1 1h3v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h3a1 1 0 0 0 1-1v-8.5'),
+                  (url_for('admin.invites'), '#invites', 'Invitations', 'm3.5 5.5 7.893 6.036a1 1 0 0 0 1.214 0L20.5 5.5M4 19h16a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Z'),
+                  (url_for('admin.users'), '#users', 'Users', 'M16 19h4a1 1 0 0 0 1-1v-1a3 3 0 0 0-3-3h-2m-2.236-4a3 3 0 1 0 0-4M3 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z'),
+                  (url_for('activity.activity_dashboard'), '#activity', 'Activity', 'M5 3a1 1 0 0 1 1 1v12a1 1 0 1 1-2 0V4a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v9a1 1 0 1 1-2 0V8a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1Z'),
+                  (url_for('settings.page'), '#settings', 'Settings', 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 0 1 6 0z')
                 ] %}
         {% for href, hash, label, icon_path in mobile_tabs %}
           <button hx-get="{{ href }}"
@@ -249,18 +248,24 @@
         {% endfor %}
       </div>
     </nav>
-    {% set preload_hashes = ["#invites", "#users", "#activity", "#settings", "#profile"] %}
-    {% set preload_pages = ["invites", "users", "activity", "settings", "profile"] %}
-    <div hx-get="/home"
+    {% set preload_pages = [
+              ("#invites", url_for('admin.invites')),
+              ("#users", url_for('admin.users')),
+              ("#activity", url_for('activity.activity_dashboard')),
+              ("#settings", url_for('settings.page')),
+              ("#profile", url_for('admin.user_profile'))
+            ] %}
+    {% set preload_hashes = preload_pages | map(attribute=0) | list %}
+    <div hx-get="{{ url_for('admin.home') }}"
          hx-target="#content"
          hx-swap="innerHTML"
          hx-trigger="load[!{{ preload_hashes | tojson }}.includes(window.location.hash)]"
          style="display:none"></div>
-    {% for page in preload_pages %}
-      <div hx-get="/{{ page }}"
+    {% for hash, page_url in preload_pages %}
+      <div hx-get="{{ page_url }}"
            hx-target="#content"
            hx-swap="innerHTML"
-           hx-trigger="load[window.location.hash === '#{{ page }}']"
+           hx-trigger="load[window.location.hash === '{{ hash }}']"
            style="display:none"></div>
     {% endfor %}
     <!-- Support Banner (Flask/Jinja) -->

--- a/app/templates/admin/accepted_invites_card.html
+++ b/app/templates/admin/accepted_invites_card.html
@@ -53,13 +53,13 @@
       {% if total_pages and total_pages > 1 %}
         <div class="flex items-center gap-2">
           <button class="px-2 py-1 rounded border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 disabled:opacity-40 disabled:cursor-not-allowed"
-                  hx-get="/accepted-invites-card?page={{ page - 1 }}"
+                  hx-get="{{ url_for('admin.accepted_invites_card', page=page - 1) }}"
                   hx-target="#latestInvitesContainer"
                   hx-swap="innerHTML"
                   {% if page <= 1 %}disabled{% endif %}>{{ _("Prev") }}</button>
           <span>{{ _("Page") }} {{ page }} / {{ total_pages }}</span>
           <button class="px-2 py-1 rounded border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 disabled:opacity-40 disabled:cursor-not-allowed"
-                  hx-get="/accepted-invites-card?page={{ page + 1 }}"
+                  hx-get="{{ url_for('admin.accepted_invites_card', page=page + 1) }}"
                   hx-target="#latestInvitesContainer"
                   hx-swap="innerHTML"
                   {% if page >= total_pages %}disabled{% endif %}>{{ _("Next") }}</button>
@@ -112,13 +112,13 @@
       {% if total_pages and total_pages > 1 %}
         <div class="flex items-center gap-2">
           <button class="px-2 py-1 rounded border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 disabled:opacity-40 disabled:cursor-not-allowed"
-                  hx-get="/accepted-invites-card?page={{ page - 1 }}"
+                  hx-get="{{ url_for('admin.accepted_invites_card', page=page - 1) }}"
                   hx-target="#latestInvitesContainer"
                   hx-swap="innerHTML"
                   {% if page <= 1 %}disabled{% endif %}>Prev</button>
           <span>Page {{ page }} / {{ total_pages }}</span>
           <button class="px-2 py-1 rounded border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 disabled:opacity-40 disabled:cursor-not-allowed"
-                  hx-get="/accepted-invites-card?page={{ page + 1 }}"
+                  hx-get="{{ url_for('admin.accepted_invites_card', page=page + 1) }}"
                   hx-target="#latestInvitesContainer"
                   hx-swap="innerHTML"
                   {% if page >= total_pages %}disabled{% endif %}>Next</button>

--- a/app/templates/admin/home.html
+++ b/app/templates/admin/home.html
@@ -35,7 +35,7 @@
         </div>
         <div id="nowPlayingContent"
              class="relative z-20"
-             hx-get="/now-playing-cards"
+             hx-get="{{ url_for('admin.now_playing_cards') }}"
              hx-trigger="load, every 10s"
              hx-swap="innerHTML settle:0ms">
           <!-- Now playing cards container -->
@@ -53,7 +53,7 @@
         <!-- Latest Accepted Invites Card -->
         <div id="latestInvitesContainer"
              class="min-h-[400px]"
-             hx-get="/accepted-invites-card"
+             hx-get="{{ url_for('admin.accepted_invites_card') }}"
              hx-trigger="load, every 30s"
              hx-swap="innerHTML">
           <!-- Loading placeholder -->
@@ -64,7 +64,7 @@
         <!-- Server Health Card -->
         <div id="serverHealthContainer"
              class="min-h-[400px]"
-             hx-get="/server-health-card"
+             hx-get="{{ url_for('admin.server_health_card') }}"
              hx-trigger="load, every 45s"
              hx-swap="innerHTML">
           <!-- Loading placeholder -->
@@ -82,7 +82,7 @@
       // Modal functions
       function openInviteModal() {
           // Load invite form into the modal container
-          htmx.ajax('GET', '/invite', {
+          htmx.ajax('GET', '{{ url_for("admin.invite") }}', {
               target: '#invite-modal',
               swap: 'innerHTML'
           });

--- a/app/templates/admin/invites.html
+++ b/app/templates/admin/invites.html
@@ -16,7 +16,7 @@
       <select id="invite_server_filter"
               name="server"
               class="w-full sm:w-56 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-              hx-post="/invite/table"
+              hx-post="{{ url_for('admin.invite_table') }}"
               hx-target="#invite_table"
               hx-swap="outerHTML"
               hx-include="#invite_server_filter">
@@ -24,7 +24,7 @@
         {% for s in servers %}<option value="{{ s.id }}">{{ s.name }} ({{ s.server_type }})</option>{% endfor %}
       </select>
     </div>
-    <div hx-post="/invite/table"
+    <div hx-post="{{ url_for('admin.invite_table') }}"
          hx-trigger="load"
          hx-target="#invite_table"
          hx-swap="outerHTML settle:0ms"
@@ -40,7 +40,7 @@
     // Modal functions
     function openInviteModal() {
         // Load invite form into the modal container
-        htmx.ajax('GET', '/invite', {
+        htmx.ajax('GET', {{ url_for('admin.invite') | tojson }}, {
             target: '#invite-modal',
             swap: 'innerHTML'
         });
@@ -58,11 +58,12 @@
     });
 
     function tableCopyLink(invite_code) {
-        var url = window.location.origin;
+        const invitePath = {{ url_for('public.invite', code='INVITE_CODE') | tojson }}
+            .replace('INVITE_CODE', encodeURIComponent(invite_code));
         var icon = document.getElementById("icon_" + invite_code);
 
         // Copy the invite link using the fallback-enabled function
-        copyToClipboard(url + "/j/" + invite_code, (success) => {
+        copyToClipboard(window.location.origin + invitePath, (success) => {
             if (success) {
                 // Add class="text-green-500" to icon
                 icon.classList.add("text-green-500");

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -154,7 +154,7 @@
         <select id="server_filter"
                 name="server"
                 class="w-full sm:w-56 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                hx-get="/users/table"
+                hx-get="{{ url_for('admin.users_table') }}"
                 hx-target="#user_table"
                 hx-swap="outerHTML"
                 hx-include="#server_filter,#search_query,#order_sel">
@@ -166,7 +166,7 @@
                type="text"
                placeholder="Search users…"
                class="flex-1 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-               hx-get="/users/table"
+               hx-get="{{ url_for('admin.users_table') }}"
                hx-trigger="keyup changed delay:300ms"
                hx-target="#user_table"
                hx-swap="outerHTML"
@@ -174,7 +174,7 @@
         <select id="order_sel"
                 name="order"
                 class="w-full sm:w-56 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                hx-get="/users/table"
+                hx-get="{{ url_for('admin.users_table') }}"
                 hx-target="#user_table"
                 hx-swap="outerHTML"
                 hx-include="#server_filter,#search_query,#order_sel">
@@ -185,19 +185,19 @@
         </select>
       </div>
       <div id="link-bar" class="hidden flex gap-2">
-        <button hx-post="/users/link"
+        <button hx-post="{{ url_for('admin.link_accounts') }}"
                 hx-include=".link-check:checked"
                 hx-swap="none"
                 class="text-white bg-primary hover:bg-primary_hover focus:ring-4 focus:outline-none focus:ring-primary_hover font-medium rounded-lg text-sm px-3 py-2">
           {{ _("Link") }}
         </button>
-        <button hx-post="/users/unlink"
+        <button hx-post="{{ url_for('admin.unlink_account') }}"
                 hx-include=".link-check:checked"
                 hx-swap="none"
                 class="text-white bg-secondary hover:bg-secondary_hover focus:ring-4 focus:outline-none focus:ring-secondary_hover font-medium rounded-lg text-sm px-3 py-2">
           {{ _("Unlink") }}
         </button>
-        <button hx-post="/users/bulk-delete"
+        <button hx-post="{{ url_for('admin.bulk_delete_users') }}"
                 hx-include=".link-check:checked"
                 hx-swap="none"
                 class="text-white bg-red-600 hover:bg-red-700 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-3 py-2">
@@ -205,14 +205,14 @@
         </button>
       </div>
     </div>
-    <div hx-get="/users/table"
+    <div hx-get="{{ url_for('admin.users_table') }}"
          hx-trigger="load"
          hx-target="#user_table"
          hx-swap="outerHTML settle:0ms"
          hx-include="#server_filter,#search_query,#order_sel"
          class="p-4 mb-6 overflow-x-auto">
       <!-- Hidden element to trigger user sync polling -->
-      <div hx-get="/hx/users/sync"
+      <div hx-get="{{ url_for('admin.sync_users') }}"
            hx-trigger="load delay:2s"
            hx-include="#server_filter"
            hx-swap="none"></div>
@@ -276,7 +276,7 @@
             </div>
           </div>
         </div>
-        <div hx-get="/expired-users/table"
+        <div hx-get="{{ url_for('admin.expired_users_table') }}"
              hx-trigger="load"
              hx-target="#expired_users_table"
              hx-swap="outerHTML"
@@ -354,7 +354,7 @@
                 if (searchQuery) params.set('q', searchQuery);
                 if (orderSel) params.set('order', orderSel);
 
-                const url = '/users/table?' + params.toString();
+                const url = {{ url_for('admin.users_table') | tojson }} + '?' + params.toString();
                 console.log('Making HTMX request to:', url);
 
                 // Make HTMX request to refresh the user table with current filters

--- a/app/templates/components/admin_passkeys.html
+++ b/app/templates/components/admin_passkeys.html
@@ -82,7 +82,8 @@
 <script>
     function deletePasskey(passkeyId) {
         if (confirm('{{ _("Are you sure you want to delete this passkey?") }}')) {
-            fetch(`/webauthn/credentials/${passkeyId}`, {
+            const credentialsUrl = {{ url_for('webauthn.list_credentials') | tojson }};
+            fetch(`${credentialsUrl}/${passkeyId}`, {
                     method: 'DELETE',
                     headers: {
                         'Content-Type': 'application/json',
@@ -105,7 +106,8 @@
 
     function resetAllPasskeys(adminId, username) {
         if (confirm(`{{ _("Are you sure you want to reset ALL passkeys for {}?").format('${username}') }} {{ _("This action cannot be undone.") }}`)) {
-            fetch(`/settings/admins/${adminId}/reset-passkeys`, {
+            const adminsUrl = {{ url_for('admin_accounts.list_admins') | tojson }};
+            fetch(`${adminsUrl}/${adminId}/reset-passkeys`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/app/templates/components/passkey_add_form.html
+++ b/app/templates/components/passkey_add_form.html
@@ -2,7 +2,7 @@
      style="z-index: 9999">
   <div class="bg-white dark:bg-gray-800 rounded-lg p-6 m-4 max-w-md w-full">
     <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-4">{{ _("Add New Passkey") }}</h3>
-    <form hx-post="/webauthn/register-start"
+    <form hx-post="{{ url_for('webauthn.register_start_htmx') }}"
           hx-target="#passkey-modal-container"
           hx-swap="innerHTML">
       <div class="mb-4">
@@ -17,7 +17,7 @@
       </div>
       <div class="flex justify-end space-x-3">
         <button type="button"
-                hx-get="/webauthn/close-modal"
+                hx-get="{{ url_for('webauthn.close_modal') }}"
                 hx-target="#passkey-modal-container"
                 hx-swap="innerHTML"
                 class="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">

--- a/app/templates/components/passkey_error.html
+++ b/app/templates/components/passkey_error.html
@@ -13,7 +13,7 @@
     </div>
     <p class="text-gray-600 dark:text-gray-400 mb-6">{{ error }}</p>
     <div class="flex justify-end">
-      <button hx-get="/webauthn/close-modal"
+      <button hx-get="{{ url_for('webauthn.close_modal') }}"
               hx-target="#passkey-modal-container"
               hx-swap="innerHTML"
               class="px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded-md">{{ _("Close") }}</button>

--- a/app/templates/components/passkey_list.html
+++ b/app/templates/components/passkey_list.html
@@ -24,7 +24,7 @@
             </p>
           </div>
         </div>
-        <button hx-delete="/webauthn/credentials/{{ passkey.id }}"
+        <button hx-delete="{{ url_for('webauthn.delete_credential', credential_id=passkey.id) }}"
                 hx-target="#passkey-list"
                 hx-swap="innerHTML"
                 hx-confirm="Are you sure you want to delete this passkey?"

--- a/app/templates/components/passkey_management.html
+++ b/app/templates/components/passkey_management.html
@@ -17,7 +17,7 @@
         {{ _("Passkeys") }}
       </h2>
     </div>
-    <button hx-get="/webauthn/add-form"
+    <button hx-get="{{ url_for('webauthn.show_add_form') }}"
             hx-target="#passkey-modal-container"
             hx-swap="innerHTML"
             :disabled="!isHttps"
@@ -44,7 +44,7 @@
      :class="!isHttps && 'opacity-50'">{{ _("Manage your passkeys for passwordless authentication.") }}</p>
   <div id="passkey-list"
        :class="!isHttps && 'opacity-50 pointer-events-none'"
-       hx-get="/webauthn/list"
+       hx-get="{{ url_for('webauthn.list_passkeys_htmx') }}"
        hx-trigger="load"
        hx-swap="innerHTML">
     <!-- Passkeys will be loaded here -->

--- a/app/templates/components/passkey_register.html
+++ b/app/templates/components/passkey_register.html
@@ -12,7 +12,7 @@
       </p>
     </div>
     <div class="mt-6 flex justify-center">
-      <button hx-get="/webauthn/close-modal"
+      <button hx-get="{{ url_for('webauthn.close_modal') }}"
               hx-target="#passkey-modal-container"
               hx-swap="innerHTML"
               class="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md">
@@ -84,7 +84,7 @@
                     }
                 };
 
-                return fetch('/webauthn/register/complete', {
+                return fetch({{ url_for('webauthn.register_complete') | tojson }}, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
@@ -100,15 +100,15 @@
             })
             .then(result => {
                 if (result.verified) {
-                    htmx.ajax('GET', '/webauthn/close-modal', '#passkey-modal-container');
-                    htmx.ajax('GET', '/webauthn/list', '#passkey-list');
+                    htmx.ajax('GET', {{ url_for('webauthn.close_modal') | tojson }}, '#passkey-modal-container');
+                    htmx.ajax('GET', {{ url_for('webauthn.list_passkeys_htmx') | tojson }}, '#passkey-list');
                 } else {
-                    htmx.ajax('GET', '/webauthn/add-form', '#passkey-modal-container');
+                    htmx.ajax('GET', {{ url_for('webauthn.show_add_form') | tojson }}, '#passkey-modal-container');
                     alert('{{ _("Failed to register passkey") }}: ' + (result.error || 'Unknown error'));
                 }
             })
             .catch(error => {
-                htmx.ajax('GET', '/webauthn/add-form', '#passkey-modal-container');
+                htmx.ajax('GET', {{ url_for('webauthn.show_add_form') | tojson }}, '#passkey-modal-container');
                 alert('{{ _("Failed to complete passkey registration") }}: ' + error.message);
             });
     })();

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -177,7 +177,7 @@
             // Handle back to login button
             if (backToLoginBtn) {
                 backToLoginBtn.addEventListener('click', function() {
-                    window.location.href = '/login';
+                    window.location.href = {{ url_for('auth.login') | tojson }};
                 });
             }
 
@@ -190,7 +190,7 @@
             `;
 
                     // Begin authentication (usernameless)
-                    const beginResponse = await fetch('/webauthn/authenticate/begin', {
+                    const beginResponse = await fetch({{ url_for('webauthn.authenticate_begin') | tojson }}, {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json'
@@ -224,7 +224,7 @@
                     const credentialId = uint8ArrayToBase64url(new Uint8Array(credential.rawId));
 
                     // Complete authentication
-                    const completeResponse = await fetch('/webauthn/authenticate/complete', {
+                    const completeResponse = await fetch({{ url_for('webauthn.authenticate_complete') | tojson }}, {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json'
@@ -257,7 +257,7 @@
                                     }
                                 });
                                 if (completeLoginResponse.ok) {
-                                    window.location.href = '/';
+                                    window.location.href = {{ url_for('public.root') | tojson }};
                                 } else {
                                     throw new Error('{{ _("Failed to complete 2FA login") }}');
                                 }

--- a/app/templates/modals/invite.html
+++ b/app/templates/modals/invite.html
@@ -35,7 +35,7 @@
                    role="alert">{{ error_message }}</div>
             {% endif %}
             <form class="space-y-4 md:space-y-6"
-                  hx-post="/invite"
+                  hx-post="{{ url_for('admin.invite') }}"
                   hx-target="#inviteModalContent"
                   hx-swap="innerHTML"
                   onsubmit="return validateServerSelection()">
@@ -350,7 +350,7 @@
                                   class="text-white bg-primary hover:bg-primary_hover focus:ring-4 focus:outline-none focus:ring-primary_hover font-medium rounded-lg text-xs px-3 py-2 inline-flex items-center"
                                   data-dropdown-toggle="libMenu{{ s.id }}"
                                   data-dropdown-placement="bottom"
-                                  hx-post="/invite/scan-libraries"
+                                  hx-post="{{ url_for('admin.invite_scan_libraries') }}"
                                   hx-vals='{"server_ids":"{{ s.id }}"}'
                                   hx-target="#libMenu{{ s.id }} .dropdown-content"
                                   hx-swap="innerHTML"
@@ -508,7 +508,7 @@
 
     function createAnother() {
         // Reload the invite form
-        htmx.ajax('GET', '/invite', {
+        htmx.ajax('GET', {{ url_for('admin.invite') | tojson }}, {
             target: '#inviteModalContent',
             swap: 'innerHTML'
         });
@@ -525,7 +525,7 @@
             const link = document.getElementById('link');
             if (link) {
                 // Refresh the invitations table on the main page
-                htmx.ajax('POST', '/invite/table', {
+                htmx.ajax('POST', {{ url_for('admin.invite_table') | tojson }}, {
                     target: '#invite_table',
                     swap: 'outerHTML',
                     values: {

--- a/app/templates/modals/wizard-simple-step-form.html
+++ b/app/templates/modals/wizard-simple-step-form.html
@@ -14,7 +14,7 @@
           </div>
           <form class="space-y-4"
                 method="post"
-                hx-post="{{ request.path }}{{ '?' + request.query_string.decode("utf-8") if request.query_string else '' }}"
+                hx-post="{{ form_action }}"
                 hx-target="#tab-body"
                 hx-swap="innerHTML">
             {{ form.hidden_tag() }}

--- a/app/templates/modals/wizard-step-form.html
+++ b/app/templates/modals/wizard-step-form.html
@@ -15,7 +15,7 @@
           </div>
           <form class="space-y-4"
                 method="post"
-                hx-post="{{ request.path }}"
+                hx-post="{{ form_action }}"
                 hx-target="#tab-body"
                 hx-swap="innerHTML">
             {{ form.hidden_tag() }}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -32,7 +32,7 @@
           <h2 class="text-xl font-semibold text-gray-900 dark:text-white">{{ _("Password") }}</h2>
         </div>
         <p class="text-gray-600 dark:text-gray-400 mb-4">{{ _("Change your account password for security.") }}</p>
-        <form hx-post="/profile/change-password"
+        <form hx-post="{{ url_for('admin.change_password') }}"
               hx-target="#password-result"
               hx-swap="innerHTML"
               class="space-y-4">

--- a/app/templates/settings/index.html
+++ b/app/templates/settings/index.html
@@ -144,7 +144,7 @@
           {% if is_plus_enabled %}
             <li class="md:me-2">
               <button class="tab-btn w-full inline-flex items-center justify-center px-4 py-3 rounded-lg md:rounded-t-lg md:rounded-b-none bg-gray-700 md:bg-transparent border-0 md:border-b-2 border-transparent text-gray-300 hover:bg-gray-600 md:hover:bg-transparent hover:text-gray-100 md:hover:text-gray-600 md:hover:border-gray-300 md:dark:hover:text-gray-300 dark:bg-gray-800 md:dark:bg-transparent dark:hover:bg-gray-700 md:dark:hover:bg-transparent group transition-colors"
-                      hx-get="/plus/audit/"
+                      hx-get="{{ request.script_root }}/plus/audit/"
                       hx-target="#tab-body"
                       hx-swap="innerHTML"
                       hx-trigger="click"

--- a/app/templates/tables/invite_card.html
+++ b/app/templates/tables/invite_card.html
@@ -180,7 +180,7 @@
                 </button>
                 <!-- Delete invitation button -->
                 <button class="h-8 w-8 p-0 inline-flex items-center justify-center text-white bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 rounded-md transition-colors"
-                        hx-post="/invite/table?delete={{ invite.code }}"
+                        hx-post="{{ url_for('admin.invite_table', delete=invite.code) }}"
                         hx-trigger="click"
                         hx-target="#invite_table"
                         hx-swap="outerHTML swap:0.5s"
@@ -211,7 +211,9 @@
 </div>
 <script>
     function tableCopyLink(invite_code) {
-        const url = window.location.origin + "/j/" + invite_code;
+        const invitePath = {{ url_for('public.invite', code='INVITE_CODE') | tojson }}
+            .replace('INVITE_CODE', encodeURIComponent(invite_code));
+        const url = window.location.origin + invitePath;
         copyToClipboard(url, (success) => {
             if (!success) {
                 console.error("Copy failed for invite:", invite_code);

--- a/app/templates/tables/user_card.html
+++ b/app/templates/tables/user_card.html
@@ -210,7 +210,7 @@
               <div class="flex items-center space-x-2">
                 <!-- View details -->
                 <button class="h-8 w-8 p-0 inline-flex items-center justify-center text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 rounded-md hover:bg-gray-100/50 dark:hover:bg-gray-700/50 transition-colors"
-                        hx-get="/user/{{ user.id }}/details"
+                        hx-get="{{ url_for('admin.user_details_modal', db_id=user.id) }}"
                         hx-target="#modal-user"
                         hx-swap="innerHTML"
                         title="{{ _('View details') }}">
@@ -228,7 +228,7 @@
                 </button>
                 <!-- Edit user -->
                 <button class="h-8 w-8 p-0 inline-flex items-center justify-center text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 rounded-md hover:bg-gray-100/50 dark:hover:bg-gray-700/50 transition-colors"
-                        hx-get="/user/{{ user.id }}"
+                        hx-get="{{ url_for('admin.user_detail', db_id=user.id) }}"
                         hx-target="#modal-user"
                         hx-swap="innerHTML"
                         title="{{ _('Edit user') }}">

--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -279,7 +279,7 @@
       // Load movie posters for flowing grid background with progressive loading
       async function loadCinemaPosters() {
           try {
-              const response = await fetch('/cinema-posters');
+              const response = await fetch({{ url_for('public.cinema_posters') | tojson }});
               const posterUrls = await response.json();
 
               if (posterUrls && posterUrls.length > 0) {

--- a/app/templates/wizard/_content.html
+++ b/app/templates/wizard/_content.html
@@ -10,4 +10,17 @@
   <div class="prose prose-slate dark:prose-invert text-gray-800 dark:text-gray-200 max-w-none prose-sm md:prose-base">
     {{ body_html|safe }}
   </div>
+  {% if server_url and idx == max_idx %}
+    <div class="mt-6 flex justify-center">
+      <a href="{{ external_url or server_url }}"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="inline-flex items-center justify-center px-6 py-3 text-base font-medium text-white bg-primary hover:bg-primary_hover focus:ring-4 focus:outline-none focus:ring-primary_hover rounded-lg transition-colors">
+        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+        </svg>
+        {{ _("Open %(server_name)s", server_name=server_name or server_type|capitalize) }}
+      </a>
+    </div>
+  {% endif %}
 </div>

--- a/app/templates/wizard/steps.html
+++ b/app/templates/wizard/steps.html
@@ -11,6 +11,13 @@
      data-phase="{{ phase|default('') }}"
      data-step-phase="{{ (step_phase or '') }}"
      {% if is_bundle_preview %}data-bundle-id="{{ bundle_id }}"{% endif %}
+     data-post-wizard-url="{{ url_for('wizard.post_wizard', idx=0) }}"
+     data-pre-wizard-url="{{ url_for('wizard.pre_wizard', idx=0) }}"
+     data-combo-url-pre="{{ url_for('wizard.combo', category='pre_invite', idx=0) }}"
+     data-combo-url-post="{{ url_for('wizard.combo', category='post_invite', idx=0) }}"
+     data-bundle-url="{{ url_for('wizard.bundle_view', idx=0) }}"
+     data-bundle-preview-url="{{ url_for('wizard.bundle_preview', bundle_id=0, idx=0) }}"
+     data-generic-step-url="{{ url_for('wizard.step', server='SERVER', idx=0) }}"
      data-completion-url="{{ completion_url or '' }}"
      data-completion-label="{{ completion_label or '' }}"
      data-next-label="{{ _('Next') }}"
@@ -528,24 +535,36 @@
                 const targetIdx = isPrev ? idx - 1 : idx + 1;
 
                 // Generate URL based on phase and server type
+                // Uses data-attributes with url_for paths to support APPLICATION_ROOT subpaths
                 let newUrl;
                 const bundleId = this.wrapper.dataset.bundleId;
+                const getBase = (url) => url ? url.replace(/\/[^\/]+$/, '') : '';
                 if (serverType === 'combo') {
                     // Combo wizard uses path-based category routing
                     const category = phase === 'pre' ? 'pre_invite' : 'post_invite';
-                    newUrl = `/wizard/combo/${category}/${targetIdx}`;
+                    const comboUrl = phase === 'pre' ? this.wrapper.dataset.comboUrlPre : this.wrapper.dataset.comboUrlPost;
+                    newUrl = `${getBase(comboUrl)}/${targetIdx}`;
                 } else if (serverType === 'bundle' && bundleId) {
                     // Bundle preview mode (admin)
-                    newUrl = `/wizard/bundle-preview/${bundleId}/${targetIdx}`;
+                    const url = this.wrapper.dataset.bundlePreviewUrl;
+                    if (url) {
+                        const parts = url.split('/');
+                        parts[parts.length - 2] = bundleId;
+                        parts[parts.length - 1] = targetIdx;
+                        newUrl = parts.join('/');
+                    } else {
+                        newUrl = `${getBase('')}/bundle-preview/${bundleId}/${targetIdx}`;
+                    }
                 } else if (serverType === 'bundle') {
                     // Runtime bundle mode (user flow)
-                    newUrl = `/wizard/bundle/${targetIdx}`;
+                    newUrl = `${getBase(this.wrapper.dataset.bundleUrl)}/${targetIdx}`;
                 } else if (phase === 'pre') {
-                    newUrl = `/wizard/pre-wizard/${targetIdx}`;
+                    newUrl = `${getBase(this.wrapper.dataset.preWizardUrl)}/${targetIdx}`;
                 } else if (phase === 'post') {
-                    newUrl = `/wizard/post-wizard/${targetIdx}`;
+                    newUrl = `${getBase(this.wrapper.dataset.postWizardUrl)}/${targetIdx}`;
                 } else {
-                    newUrl = `/wizard/${serverType}/${targetIdx}`;
+                    const url = this.wrapper.dataset.genericStepUrl;
+                    newUrl = `${getBase(url ? url.replace('SERVER', serverType) : '')}/${targetIdx}`;
                 }
 
                 // Update visibility and state

--- a/tests/test_subpath_support.py
+++ b/tests/test_subpath_support.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from app.extensions import db
-from app.models import AdminAccount, Invitation, MediaServer, Settings
+from app.models import AdminAccount, Invitation, MediaServer, Settings, WizardStep
 
 
 @pytest.fixture
@@ -160,3 +160,46 @@ def test_auth_and_profile_templates_use_prefixed_routes(
     assert 'hx-post="/wizarr/profile/change-password"' in profile.text
     assert 'hx-get="/wizarr/webauthn/add-form"' in profile.text
     assert 'hx-get="/wizarr/webauthn/list"' in profile.text
+
+
+def test_wizard_edit_button_and_form_use_prefixed_route(
+    subpath_app, client, session
+):
+    admin = AdminAccount(username="admin")
+    admin.set_password("Password1")
+    server = MediaServer(
+        name="Test Jellyfin",
+        server_type="jellyfin",
+        url="http://jellyfin.local",
+        api_key="test-key",
+    )
+    step = WizardStep(
+        server_type="jellyfin",
+        category="post_invite",
+        position=0,
+        title="Welcome",
+        markdown="# Welcome",
+    )
+    db.session.add_all([admin, server, step])
+    db.session.commit()
+
+    client.post(
+        "/wizarr/login",
+        data={"username": "admin", "password": "Password1"},
+    )
+
+    steps = client.get(
+        "/wizarr/settings/wizard/",
+        headers={"HX-Request": "true"},
+    )
+    edit_url = f"/wizarr/settings/wizard/{step.id}/edit"
+
+    assert steps.status_code == 200
+    assert f'hx-get="{edit_url}"' in steps.text
+    assert f'hx-get="/settings/wizard/{step.id}/edit"' not in steps.text
+
+    edit_form = client.get(edit_url, headers={"HX-Request": "true"})
+
+    assert edit_form.status_code == 200
+    assert f'hx-post="{edit_url}"' in edit_form.text
+    assert f'hx-post="/settings/wizard/{step.id}/edit"' not in edit_form.text

--- a/tests/test_subpath_support.py
+++ b/tests/test_subpath_support.py
@@ -1,0 +1,162 @@
+from unittest.mock import patch
+
+import pytest
+
+from app.extensions import db
+from app.models import AdminAccount, Invitation, MediaServer, Settings
+
+
+@pytest.fixture
+def subpath_app(app):
+    original_root = app.config["APPLICATION_ROOT"]
+    app.config["APPLICATION_ROOT"] = "/wizarr"
+    yield app
+    app.config["APPLICATION_ROOT"] = original_root
+
+
+def test_root_redirects_to_prefixed_setup(subpath_app, client, session):
+
+    response = client.get("/wizarr/")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/wizarr/setup/"
+
+
+def test_root_redirects_to_prefixed_admin(subpath_app, client, session):
+    db.session.add(Settings(key="admin_username", value="admin"))
+    db.session.commit()
+
+    response = client.get("/wizarr/")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/wizarr/admin"
+
+
+def test_setup_redirects_to_prefixed_admin(subpath_app, client, session):
+    response = client.post(
+        "/wizarr/setup/",
+        headers={"X-Forwarded-Prefix": "/"},
+        data={
+            "username": "admin",
+            "password": "Password1",
+            "confirm": "Password1",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/wizarr/admin"
+
+    dashboard = client.get("/wizarr/admin")
+    html = dashboard.get_data(as_text=True)
+
+    assert dashboard.status_code == 200
+    assert 'href="/wizarr/static/css/main.css' in html
+    assert 'hx-get="/wizarr/home"' in html
+    assert "/wizarr/wizarr/static" not in html
+    assert 'hx-get="/home"' not in html
+
+    home = client.get("/wizarr/home", headers={"HX-Request": "true"})
+    home_html = home.get_data(as_text=True)
+
+    assert home.status_code == 200
+    assert 'hx-get="/wizarr/now-playing-cards"' in home_html
+    assert 'hx-get="/wizarr/accepted-invites-card"' in home_html
+    assert 'hx-get="/wizarr/server-health-card"' in home_html
+    assert "htmx.ajax('GET', '/wizarr/invite'" in home_html
+
+    invites = client.get("/wizarr/invites", headers={"HX-Request": "true"})
+    invites_html = invites.get_data(as_text=True)
+
+    assert invites.status_code == 200
+    assert 'hx-post="/wizarr/invite/table"' in invites_html
+    assert "htmx.ajax('GET', \"/wizarr/invite\"" in invites_html
+    assert '"/wizarr/j/INVITE_CODE"' in invites_html
+    assert 'hx-post="/invite/table"' not in invites_html
+
+    users = client.get("/wizarr/users", headers={"HX-Request": "true"})
+    users_html = users.get_data(as_text=True)
+
+    assert users.status_code == 200
+    assert 'hx-get="/wizarr/users/table"' in users_html
+    assert 'hx-get="/wizarr/hx/users/sync"' in users_html
+    assert 'hx-get="/wizarr/expired-users/table"' in users_html
+    assert 'hx-post="/wizarr/users/link"' in users_html
+    assert 'hx-post="/wizarr/users/unlink"' in users_html
+    assert 'hx-post="/wizarr/users/bulk-delete"' in users_html
+    assert 'const url = "/wizarr/users/table"' in users_html
+    assert 'hx-get="/users/table"' not in users_html
+
+    pwa_registration = client.get("/wizarr/static/js/pwa-registration.js")
+    service_worker = client.get("/wizarr/static/sw.js")
+    manifest = client.get("/wizarr/static/manifest.json").get_json()
+
+    assert pwa_registration.status_code == 200
+    assert "new URL('../sw.js', registrationScript.src)" in pwa_registration.text
+    assert "register('/static/sw.js'" not in pwa_registration.text
+    assert service_worker.status_code == 200
+    assert "'/static/" not in service_worker.text
+    assert manifest["start_url"] == "../"
+    assert manifest["scope"] == "../"
+    assert all(not icon["src"].startswith("/") for icon in manifest["icons"])
+
+
+def test_created_invite_link_uses_browser_origin_and_subpath(
+    subpath_app, client, session
+):
+    admin = AdminAccount(username="admin")
+    admin.set_password("Password1")
+    server = MediaServer(
+        name="Test Server",
+        server_type="jellyfin",
+        url="http://jellyfin.local",
+        api_key="test-key",
+    )
+    db.session.add_all([admin, server])
+    db.session.commit()
+
+    client.post(
+        "/wizarr/login",
+        data={"username": "admin", "password": "Password1"},
+    )
+
+    invitation = Invitation(code="PUBLIC123", used=False, unlimited=True)
+    with patch("app.blueprints.admin.routes.create_invite", return_value=invitation):
+        response = client.post(
+            "/wizarr/invite",
+            headers={
+                "HX-Request": "true",
+                "HX-Current-URL": "https://example.com/wizarr/admin#invites",
+            },
+            data={"server_ids": str(server.id)},
+        )
+
+    assert response.status_code == 200
+    assert 'value="https://example.com/wizarr/j/PUBLIC123"' in response.text
+
+
+def test_auth_and_profile_templates_use_prefixed_routes(
+    subpath_app, client, session
+):
+    admin = AdminAccount(username="admin")
+    admin.set_password("Password1")
+    db.session.add(admin)
+    db.session.commit()
+
+    login = client.get("/wizarr/login")
+    assert login.status_code == 200
+    assert 'fetch("/wizarr/webauthn/authenticate/begin"' in login.text
+    assert 'fetch("/webauthn/authenticate/begin"' not in login.text
+
+    client.post(
+        "/wizarr/login",
+        data={"username": "admin", "password": "Password1"},
+    )
+    profile = client.get(
+        "/wizarr/profile",
+        headers={"HX-Request": "true"},
+    )
+
+    assert profile.status_code == 200
+    assert 'hx-post="/wizarr/profile/change-password"' in profile.text
+    assert 'hx-get="/wizarr/webauthn/add-form"' in profile.text
+    assert 'hx-get="/wizarr/webauthn/list"' in profile.text


### PR DESCRIPTION
Adding support to be able to run Wizarr behind a reverse-proxy, 

## The Problem

When running Wizarr behind a reverse proxy like nginx with a location block like:

```nginx
location /wizarr {
    proxy_pass http://localhost:5698/;
}
```

The application would show 404 errors because:
1. All blueprints were registered with hardcoded `/` prefixes
2. Static files were served from `/static` without considering the subpath
3. URL generation with `url_for()` didn't account for the custom path

## The Solution

### 1. Configurable `APPLICATION_ROOT` (app/config.py)

Added a new environment variable `APPLICATION_ROOT` that allows you to specify the base path:

```bash
APPLICATION_ROOT=/wizarr
```

If not set, it defaults to `/` (root path).

### 2. Dynamic Blueprint Registration (app/__init__.py)

Modified the blueprint registration to prepend the `APPLICATION_ROOT` to each blueprint's `url_prefix`:

```python
# Example: if APPLICATION_ROOT=/wizarr
# /setup becomes /wizarr/setup
# /api becomes /wizarr/api
# etc.
```

### 3. Static Files Path (app/__init__.py)

Configured Flask to serve static files from the correct path:

```python
static_url_path=f"{app_root}/static"
```

### 4. Reverse Proxy Middleware (app/middleware.py)

Added a `ReverseProxyFix` middleware that:
- Reads `X-Forwarded-Prefix` header (sent by nginx/traefik)
- Sets `SCRIPT_NAME` for correct URL generation
- Handles `X-Forwarded-Proto` for HTTPS detection
- Handles `X-Forwarded-Host` for correct host detection

### 5. Onboarding Path Handling (app/middleware.py)

Updated the `require_onboarding()` function to handle paths correctly when running under a subpath.

## Usage

### Environment Variables

Set these in your Docker compose or environment:

```bash
# Required: the path where Wizarr is served
APPLICATION_ROOT=/wizarr

# Optional: if using HTTPS behind proxy
PREFERRED_URL_SCHEME=https
```

### Nginx Configuration

```nginx
location /wizarr {
    proxy_pass http://localhost:5698;
    proxy_set_header X-Forwarded-Prefix /wizarr;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Forwarded-Host $host:$server_port;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header Host $host;
}
```

### Docker Compose Example

```yaml
services:
  wizarr:
    image: ghcr.io/wizarrrr/wizarr:latest
    container_name: wizarr
    environment:
      - APPLICATION_ROOT=/wizarr
      - PREFERRED_URL_SCHEME=https
    volumes:
      - ./config/wizarr:/config
```
### Traefik Configuration
If using Traefik, you can use `X-Forwarded-Prefix` middleware:

```yaml
labels:
  - "traefik.http.middlewares.wizarr-strip.stripprefix.prefixes=/wizarr"
  - "traefik.http.routers.wizarr.middlewares=wizarr-strip"
```

## Notes

- The `APPLICATION_ROOT` is used as a fallback if `X-Forwarded-Prefix` header is not present
- Static files are automatically served from the correct path
- All internal redirects and `url_for()` calls now generate correct URLs
- No changes are needed to templates or JavaScript files

## Testing

To test the subpath setup:

1. Set `APPLICATION_ROOT=/wizarr` environment variable
2. Start the application
3. Access via `http://localhost:5698/wizarr/` directly, or
4. Configure your reverse proxy and access via `https://example.com/wizarr`



Fixes #79 