### PR TITLE
Fix: unlimited invite only shows first user in Latest Accepted Invites

### DIFF
--- a/app/services/invitation_flow/workflows.py
+++ b/app/services/invitation_flow/workflows.py
@@ -127,7 +127,7 @@ class InvitationWorkflow(ABC):
                         db.session.commit()
 
                         user = User.query.filter_by(
-                            code=invitation_code, server_id=server.id
+                            username=form_data.get("username"), server_id=server.id
                         ).first()
 
                         # If user not found, log debug info

--- a/tests/test_invitation_comprehensive.py
+++ b/tests/test_invitation_comprehensive.py
@@ -694,6 +694,52 @@ class TestInvitationMarkingUsed:
             # But user should be tracked
             assert user1 in invite.users  # type: ignore
 
+    def test_mark_server_used_unlimited_multiple_users(self, app):
+        """All users who accept an unlimited invite are recorded in invitation_users."""
+        with app.app_context():
+            server = MediaServer(
+                name="Test Server",
+                server_type="jellyfin",
+                url="http://localhost:8096",
+                api_key="test-key",
+            )
+            db.session.add(server)
+            db.session.flush()
+
+            form_data = {
+                "expires": "never",
+                "unlimited": True,
+                "server_ids": [str(server.id)],
+            }
+            invite = create_invite(form_data)
+            invite.code = "UNLIMULTI"
+            db.session.commit()
+
+            userA = User(
+                username="alice",
+                email="alice@example.com",
+                token="token-a",
+                code="UNLIMULTI",
+                server_id=server.id,
+            )
+            userB = User(
+                username="bob",
+                email="bob@example.com",
+                token="token-b",
+                code="UNLIMULTI",
+                server_id=server.id,
+            )
+            db.session.add_all([userA, userB])
+            db.session.commit()
+
+            mark_server_used(invite, server.id, userA)
+            mark_server_used(invite, server.id, userB)
+
+            db.session.refresh(invite)
+            assert userA in invite.users  # type: ignore
+            assert userB in invite.users  # type: ignore
+            assert len(invite.users) == 2  # type: ignore
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #1305

## Summary

- **Bug**: When multiple users accept the same unlimited invite code, the Home page "Latest Accepted Invites" card only shows the first user who ever used that code.
- **Root cause**: After a successful join in `_process_servers`, the user lookup used `filter_by(code=invitation_code, server_id=server.id).first()`. On an unlimited invite, multiple users share the same `code` value on the same server, so `.first()` always returns the *earliest* user (lowest PK). Every subsequent user was looked up as the first user, found already present in `invitation_users`, and skipped — never recorded.
- **Fix**: Look up the newly created user by `username` (unique per server) instead of invite code, so each acceptance is correctly attributed.

## Changes

1 line change + tests.

- `app/services/invitation_flow/workflows.py` — change user lookup from `code=invitation_code` to `username=form_data.get("username")` after a successful join
- `tests/test_invitation_comprehensive.py` — add `test_mark_server_used_unlimited_multiple_users` regression test asserting all users appear in `invite.users` after multiple acceptances of an unlimited invite

## Test plan

- [x] Run `pytest tests/test_invitation_comprehensive.py::TestInvitationMarkingUsed::test_mark_server_used_unlimited_multiple_users`
- [x] Create an unlimited invite, have two users sign up with it, verify both appear in the Home page Latest Accepted Invites card

## Screenshots

Tested on my own server. I have 2 invite codes, one of them has had 6 people join. The 2nd screenshot shows the correct 7 users joining from invite codes.

Before
<img width="1368" height="934" alt="image" src="https://github.com/user-attachments/assets/da8f1228-577c-4ca1-bd0f-b7fdee077758" />


After
<img width="1212" height="834" alt="image" src="https://github.com/user-attachments/assets/59dde3fc-1d58-4522-91ce-0649b5065f35" />