### PR TITLE
Fix recent onboarding and media-server bugs

### DIFF
--- a/app/blueprints/api/api_routes.py
+++ b/app/blueprints/api/api_routes.py
@@ -155,21 +155,11 @@ def require_api_key_or_session(f):
 
 
 def _generate_invitation_url(code):
-    """Generate full invitation URL for the given code."""
+    """Generate the stable invitation path for the given code."""
     try:
         from flask import url_for
 
-        # Try to generate URL using url_for with the public blueprint's invite route
-        invite_path = url_for("public.invite", code=code, _external=False)
-
-        # Get the host from the current request if available
-        host = request.headers.get("Host")
-        if host and not host.startswith("localhost"):
-            # Only generate full URL for non-localhost hosts
-            scheme = "https" if request.is_secure else "http"
-            return f"{scheme}://{host}{invite_path}"
-        # For localhost or when no host header, return relative URL
-        return invite_path
+        return url_for("public.invite", code=code, _external=False)
 
     except Exception as e:
         logger.warning("Failed to generate invitation URL: %s", str(e))

--- a/app/services/media/auth_headers.py
+++ b/app/services/media/auth_headers.py
@@ -1,0 +1,7 @@
+def media_browser_auth_headers(token: str | None) -> dict[str, str]:
+    """Return Jellyfin/Emby auth headers accepted by modern and legacy servers."""
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f'MediaBrowser Token="{token}"'
+        headers["X-Emby-Token"] = token
+    return headers

--- a/app/services/media/emby.py
+++ b/app/services/media/emby.py
@@ -9,6 +9,7 @@ from sqlalchemy import or_
 from app.extensions import db
 from app.models import Invitation, MediaServer, User
 
+from .auth_headers import media_browser_auth_headers
 from .client_base import register_media_client
 from .jellyfin import JellyfinClient
 
@@ -52,10 +53,9 @@ class EmbyClient(JellyfinClient):
         """
         try:
             if url and token:
-                headers = {"X-Emby-Token": token}
                 response = requests.get(
                     f"{url.rstrip('/')}/Library/MediaFolders",
-                    headers=headers,
+                    headers=media_browser_auth_headers(token),
                     timeout=10,
                 )
                 response.raise_for_status()

--- a/app/services/media/emby.py
+++ b/app/services/media/emby.py
@@ -26,15 +26,20 @@ log = structlog.get_logger(__name__)
 class EmbyClient(JellyfinClient):
     """Wrapper around the Emby REST API using credentials from Settings."""
 
-    def libraries(self) -> dict[str, str]:
-        """Return mapping of library Id to names.
+    @staticmethod
+    def _library_policy_id(item: dict) -> str:
+        """Return the folder identifier Emby expects in user policies."""
+        return item.get("Guid") or item["Id"]
 
-        Uses ``Id`` (not ``Guid``) so that ``Library.external_id`` stores the
-        value that Emby's ``EnabledFolders`` policy field actually expects.
+    def libraries(self) -> dict[str, str]:
+        """Return mapping of Emby policy folder IDs to names.
+
+        Emby expects ``Guid`` values in ``EnabledFolders`` on servers where
+        ``Id`` and ``Guid`` differ. Fall back to ``Id`` for older responses.
         """
         try:
             items = self.get("/Library/MediaFolders").json()["Items"]
-            return {item["Id"]: item["Name"] for item in items}
+            return {self._library_policy_id(item): item["Name"] for item in items}
         except Exception as exc:
             log.warning("emby.libraries.failed", error=str(exc))
             return {}
@@ -49,7 +54,7 @@ class EmbyClient(JellyfinClient):
             token: Optional API token override
 
         Returns:
-            dict: Library name -> library Id mapping (uses ``Id``, not ``Guid``)
+            dict: Library name -> Emby policy folder ID mapping
         """
         try:
             if url and token:
@@ -63,7 +68,7 @@ class EmbyClient(JellyfinClient):
             else:
                 items = self.get("/Library/MediaFolders").json()["Items"]
 
-            return {item["Name"]: item["Id"] for item in items}
+            return {item["Name"]: self._library_policy_id(item) for item in items}
         except Exception as exc:
             log.warning("emby.scan_libraries.failed", error=str(exc))
             return {}
@@ -195,15 +200,17 @@ class EmbyClient(JellyfinClient):
     def _set_specific_folders(self, user_id: str, names: list[str]) -> None:
         """Set library access for a user and ensure playback permissions.
 
-        Builds a mapping of ``{Name: Id, Id: Id}`` so that lookups succeed
-        whether ``names`` contains library names or already-resolved Ids.
+        Builds a mapping so lookups succeed whether ``names`` contains library
+        names, current Guid-based external IDs, or legacy Id-based external IDs.
         """
         items = self.get("/Library/MediaFolders").json()["Items"]
-        # Primary mapping: Name -> Id
-        mapping: dict[str, str] = {i["Name"]: i["Id"] for i in items}
-        # Also allow Id passthrough and Guid -> Id for backwards compatibility
-        mapping.update({i["Id"]: i["Id"] for i in items})
-        mapping.update({i["Guid"]: i["Id"] for i in items if "Guid" in i})
+        mapping: dict[str, str] = {}
+        for item in items:
+            policy_id = self._library_policy_id(item)
+            mapping[item["Name"]] = policy_id
+            mapping[item["Id"]] = policy_id
+            if item.get("Guid"):
+                mapping[item["Guid"]] = policy_id
 
         log.debug("emby._set_specific_folders", user_id=user_id, requested=names)
 
@@ -215,7 +222,7 @@ class EmbyClient(JellyfinClient):
                 "emby._set_specific_folders.no_libraries_resolved",
                 user_id=user_id,
                 requested=names,
-                hint="No requested libraries could be mapped to an Emby folder Id. "
+                hint="No requested libraries could be mapped to an Emby folder ID. "
                 "Re-scan libraries on the server settings page to refresh external IDs.",
             )
             # Restrict to nothing rather than silently granting everything.

--- a/app/services/media/jellyfin.py
+++ b/app/services/media/jellyfin.py
@@ -10,6 +10,7 @@ from app.extensions import db
 from app.models import Invitation, Library, User
 from app.services.invites import is_invite_valid
 
+from .auth_headers import media_browser_auth_headers
 from .client_base import RestApiMixin, register_media_client
 
 if TYPE_CHECKING:
@@ -28,11 +29,8 @@ class JellyfinClient(RestApiMixin):
         super().__init__(*args, **kwargs)
 
     def _headers(self) -> dict[str, str]:  # type: ignore
-        """Return default headers including X-Emby-Token if available."""
-        headers = {"Accept": "application/json"}
-        if self.token:
-            headers["X-Emby-Token"] = self.token
-        return headers
+        """Return default headers for Jellyfin API requests."""
+        return media_browser_auth_headers(self.token)
 
     def libraries(self) -> dict[str, str]:
         """Return mapping of library_id → library_name."""
@@ -57,10 +55,9 @@ class JellyfinClient(RestApiMixin):
         """
         try:
             if url and token:
-                headers = {"X-Emby-Token": token}
                 response = requests.get(
                     f"{url.rstrip('/')}/Library/MediaFolders",
-                    headers=headers,
+                    headers=media_browser_auth_headers(token),
                     timeout=10,
                 )
                 response.raise_for_status()

--- a/app/services/servers.py
+++ b/app/services/servers.py
@@ -6,6 +6,8 @@ from plexapi.exceptions import PlexApiException
 from plexapi.server import PlexServer
 from requests import exceptions as req_exc
 
+from app.services.media.auth_headers import media_browser_auth_headers
+
 
 # Raised when a server returns a non-200 status code.
 class ServerResponseError(Exception):
@@ -67,7 +69,9 @@ def check_plex(url: str, token: str) -> tuple[bool, str]:
 
 
 def check_jellyfin_or_emby_internal(url: str, token: str) -> tuple[bool, str]:
-    resp = requests.get(f"{url}/Users", headers={"X-Emby-Token": token}, timeout=10)
+    resp = requests.get(
+        f"{url}/Users", headers=media_browser_auth_headers(token), timeout=10
+    )
     if resp.status_code != 200:
         raise ServerResponseError(resp.status_code, resp.url)
     return True, ""

--- a/app/services/wizard_widgets.py
+++ b/app/services/wizard_widgets.py
@@ -208,7 +208,7 @@ class ButtonWidget(WizardWidget):
 
             url = kwargs.get("url", "")
             text = kwargs.get("text", "Click Here")
-            context = _context or {}
+            context = _context or kwargs.pop("context", {}) or {}
 
             # If URL is a Jinja variable name (no protocol and no slashes), try to resolve it from context
             if (
@@ -396,7 +396,7 @@ def process_widget_placeholders(
         # Get widget and render
         widget = WIDGET_REGISTRY.get(widget_name)
         if widget:
-            return widget.render(server_type, context=context, **params)
+            return widget.render(server_type, _context=context, **params)
         return f'<div class="text-sm text-red-500">Unknown widget: {widget_name}</div>'
 
     # Match {{ widget:... }} patterns specifically (not other {{ }} expressions)

--- a/tests/test_api_restx.py
+++ b/tests/test_api_restx.py
@@ -304,6 +304,19 @@ class TestAPIInvitations:
             assert "url" in invitation
             assert invitation["status"] == "pending"
 
+    def test_list_invitations_returns_relative_url_for_loopback_host(
+        self, client, api_key, sample_data
+    ):
+        """Test invitation URLs do not include internal loopback hosts."""
+        response = client.get(
+            "/api/invitations",
+            headers={"X-API-Key": api_key, "Host": "127.0.0.1:5690"},
+        )
+        assert response.status_code == 200
+
+        invitation = response.get_json()["invitations"][0]
+        assert invitation["url"] == f"/j/{invitation['code']}"
+
     def test_create_invitation_unauthorized(self, client):
         """Test invitation creation without authentication."""
         response = client.post(

--- a/tests/test_emby_library_policy.py
+++ b/tests/test_emby_library_policy.py
@@ -1,0 +1,102 @@
+from app.services.media.emby import EmbyClient
+
+EMBY_LIBRARIES = [
+    {
+        "Id": "3",
+        "Guid": "2a97f52972644bc2b7b52b0c9c0e9053",
+        "Name": "Movies",
+    },
+    {
+        "Id": "5",
+        "Guid": "9f14df642ca947db933576babc24f36b",
+        "Name": "Music",
+    },
+]
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+def _emby_client():
+    client = object.__new__(EmbyClient)
+    client.policy_updates = []
+
+    def get(endpoint):
+        if endpoint == "/Library/MediaFolders":
+            return _Response({"Items": EMBY_LIBRARIES})
+        if endpoint == "/Users/emby-user-1":
+            return _Response({"Policy": {"EnableAllFolders": True}})
+        raise AssertionError(f"Unexpected endpoint: {endpoint}")
+
+    def set_policy(user_id, policy):
+        client.policy_updates.append((user_id, policy))
+
+    client.get = get
+    client.set_policy = set_policy
+    return client
+
+
+def test_emby_libraries_use_guid_for_external_id():
+    assert _emby_client().libraries() == {
+        "2a97f52972644bc2b7b52b0c9c0e9053": "Movies",
+        "9f14df642ca947db933576babc24f36b": "Music",
+    }
+
+
+def test_emby_scan_libraries_uses_guid_for_external_id(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _Response({"Items": EMBY_LIBRARIES})
+
+    monkeypatch.setattr("app.services.media.emby.requests.get", fake_get)
+
+    assert EmbyClient().scan_libraries("http://emby.local", "test-token") == {
+        "Movies": "2a97f52972644bc2b7b52b0c9c0e9053",
+        "Music": "9f14df642ca947db933576babc24f36b",
+    }
+    assert captured["url"] == "http://emby.local/Library/MediaFolders"
+    assert captured["headers"]["Authorization"] == 'MediaBrowser Token="test-token"'
+
+
+def test_emby_set_specific_folders_maps_legacy_id_to_guid():
+    client = _emby_client()
+
+    client._set_specific_folders("emby-user-1", ["3"])
+
+    assert client.policy_updates == [
+        (
+            "emby-user-1",
+            {
+                "EnableAllFolders": False,
+                "EnabledFolders": ["2a97f52972644bc2b7b52b0c9c0e9053"],
+                "EnableMediaPlayback": True,
+                "EnableAudioPlaybackTranscoding": True,
+                "EnableVideoPlaybackTranscoding": True,
+                "EnablePlaybackRemuxing": True,
+                "EnableRemoteAccess": True,
+            },
+        )
+    ]
+
+
+def test_emby_set_specific_folders_maps_name_to_guid():
+    client = _emby_client()
+
+    client._set_specific_folders("emby-user-1", ["Movies"])
+
+    assert client.policy_updates[0][1]["EnabledFolders"] == [
+        "2a97f52972644bc2b7b52b0c9c0e9053"
+    ]

--- a/tests/test_media_browser_auth.py
+++ b/tests/test_media_browser_auth.py
@@ -1,0 +1,47 @@
+from app.services.media.auth_headers import media_browser_auth_headers
+from app.services.media.jellyfin import JellyfinClient
+from app.services.servers import check_jellyfin_or_emby_internal
+
+
+class _Response:
+    status_code = 200
+    url = "http://jellyfin.local/Users"
+
+
+def test_media_browser_auth_headers_include_modern_and_legacy_tokens():
+    headers = media_browser_auth_headers("test-token")
+
+    assert headers["Accept"] == "application/json"
+    assert headers["Authorization"] == 'MediaBrowser Token="test-token"'
+    assert headers["X-Emby-Token"] == "test-token"
+
+
+def test_jellyfin_client_uses_modern_media_browser_auth_header():
+    client = object.__new__(JellyfinClient)
+    client.token = "test-token"
+
+    headers = client._headers()
+
+    assert headers["Authorization"] == 'MediaBrowser Token="test-token"'
+    assert headers["X-Emby-Token"] == "test-token"
+
+
+def test_jellyfin_health_check_uses_modern_media_browser_auth_header(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr("app.services.servers.requests.get", fake_get)
+
+    assert check_jellyfin_or_emby_internal("http://jellyfin.local", "test-token") == (
+        True,
+        "",
+    )
+    assert captured["url"] == "http://jellyfin.local/Users"
+    assert captured["headers"]["Authorization"] == 'MediaBrowser Token="test-token"'
+    assert captured["headers"]["X-Emby-Token"] == "test-token"
+    assert captured["timeout"] == 10

--- a/tests/test_wizard_widgets.py
+++ b/tests/test_wizard_widgets.py
@@ -1,0 +1,35 @@
+from app.services.wizard_widgets import ButtonWidget, process_widget_placeholders
+
+
+def test_button_widget_resolves_context_variable_url():
+    html = ButtonWidget().render(
+        "jellyfin",
+        _context={"external_url": "https://jellyfin.example.com"},
+        url="external_url",
+        text="Open Jellyfin",
+    )
+
+    assert 'href="https://jellyfin.example.com"' in html
+    assert "Open Jellyfin" in html
+
+
+def test_button_widget_accepts_legacy_context_keyword():
+    html = ButtonWidget().render(
+        "jellyfin",
+        context={"external_url": "https://jellyfin.example.com"},
+        url="external_url",
+        text="Open Jellyfin",
+    )
+
+    assert 'href="https://jellyfin.example.com"' in html
+
+
+def test_process_widget_placeholders_passes_context_to_button_widget():
+    html = process_widget_placeholders(
+        '{{ widget:button url="external_url" text="Open Jellyfin" }}',
+        "jellyfin",
+        context={"external_url": "https://jellyfin.example.com"},
+    )
+
+    assert 'href="https://jellyfin.example.com"' in html
+    assert "Open Jellyfin" in html


### PR DESCRIPTION
Fixes #1280 by passing wizard widget context through to button widgets, fixes #1262 by returning stable relative invite URLs from the API, fixes #1309 by sending modern MediaBrowser auth headers for Jellyfin/Emby while retaining legacy token headers, and fixes #1303 by using Emby library GUIDs for folder policies while still accepting legacy IDs.

The included regression tests cover widget URL rendering, loopback invitation URLs, MediaBrowser auth headers, and Emby GUID library policy mapping.

Validation: `uv run --group dev pytest tests/test_wizard_widgets.py tests/test_api_restx.py::TestAPIInvitations tests/test_media_browser_auth.py tests/test_emby_library_policy.py`; `uv run --group dev ruff check` over touched files.

API clients should treat `invitation.url` as a relative path and prepend their public base URL when needed.