### PR TITLE
Bundle external frontend assets

### DIFF
--- a/app/static/copy-assets.js
+++ b/app/static/copy-assets.js
@@ -14,6 +14,7 @@ const assets = [
     { src: 'node_modules/htmx.org/dist/htmx.min.js', dest: 'js/vendor/htmx.min.js' },
     { src: 'node_modules/htmx-ext-preload/dist/preload.min.js', dest: 'js/vendor/htmx-preload.min.js' },
     { src: 'node_modules/animate.css/animate.min.css', dest: 'css/vendor/animate.min.css' },
+    { src: 'node_modules/animejs/lib/anime.min.js', dest: 'js/vendor/anime.min.js' },
     { src: 'node_modules/bowser/bundled.js', dest: 'js/vendor/bowser.min.js' },
     { src: 'node_modules/inapp-spy/dist/index.global.js', dest: 'js/vendor/inapp-spy.min.js' }
 ];

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -12,6 +12,7 @@
         "@alpinejs/collapse": "^3.15.12",
         "alpinejs": "^3.15.12",
         "animate.css": "^4.1.1",
+        "animejs": "^3.2.1",
         "bowser": "^2.13.1",
         "flowbite": "^4.0.2",
         "htmx-ext-preload": "^2.1.2",
@@ -1394,6 +1395,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
       "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==",
+      "license": "MIT"
+    },
+    "node_modules/animejs": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/animejs/-/animejs-3.2.1.tgz",
+      "integrity": "sha512-sWno3ugFryK5nhiDm/2BKeFCpZv7vzerWUcUPyAZLDhMek3+S/p418ldZJbJXo5ZUOpfm2kP2XRO4NJcULMy9A==",
       "license": "MIT"
     },
     "node_modules/bowser": {

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -19,6 +19,7 @@
     "@alpinejs/collapse": "^3.15.12",
     "alpinejs": "^3.15.12",
     "animate.css": "^4.1.1",
+    "animejs": "^3.2.1",
     "bowser": "^2.13.1",
     "flowbite": "^4.0.2",
     "htmx-ext-preload": "^2.1.2",

--- a/app/templates/error/401.html
+++ b/app/templates/error/401.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <title>401 - Permission Denied</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet"
+          href="{{ url_for('static', filename='css/main.css', v=app_version) }}">
     <meta name="viewport"
           content="initial-scale=1, width=device-width, viewport-fit=cover, user-scalable=no">
   </head>
@@ -10,7 +11,7 @@
     <section class="bg-white dark:bg-gray-900">
       <div class="py-8 px-4 mx-auto max-w-(--breakpoint-xl) lg:py-16 lg:px-6">
         <div class="mx-auto max-w-(--breakpoint-sm) text-center">
-          <h1 class="mb-4 text-7xl tracking-tight font-extrabold lg:text-9xl text-primary-600 dark:text-primary-500">401</h1>
+          <h1 class="mb-4 text-7xl tracking-tight font-extrabold lg:text-9xl text-primary dark:text-primary">401</h1>
           <p class="mb-4 text-3xl tracking-tight font-bold text-gray-900 md:text-4xl dark:text-white">
             {{ _("Permission denied.") }}
           </p>

--- a/app/templates/error/404.html
+++ b/app/templates/error/404.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <title>404 - Page Not Found</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet"
+          href="{{ url_for('static', filename='css/main.css', v=app_version) }}">
     <meta name="viewport"
           content="initial-scale=1, width=device-width, viewport-fit=cover, user-scalable=no">
   </head>
@@ -10,7 +11,7 @@
     <section class="bg-white dark:bg-gray-900">
       <div class="py-8 px-4 mx-auto max-w-(--breakpoint-xl) lg:py-16 lg:px-6">
         <div class="mx-auto max-w-(--breakpoint-sm) text-center">
-          <h1 class="mb-4 text-7xl tracking-tight font-extrabold lg:text-9xl text-primary-600 dark:text-primary-500">404</h1>
+          <h1 class="mb-4 text-7xl tracking-tight font-extrabold lg:text-9xl text-primary dark:text-primary">404</h1>
           <p class="mb-4 text-3xl tracking-tight font-bold text-gray-900 md:text-4xl dark:text-white">
             {{ _("Something's missing.") }}
           </p>

--- a/app/templates/error/500.html
+++ b/app/templates/error/500.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <title>500 - Internal Server Error</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet"
+          href="{{ url_for('static', filename='css/main.css', v=app_version) }}">
     <meta name="viewport"
           content="initial-scale=1, width=device-width, viewport-fit=cover, user-scalable=no">
   </head>
@@ -10,7 +11,7 @@
     <section class="bg-white dark:bg-gray-900">
       <div class="py-8 px-4 mx-auto max-w-(--breakpoint-xl) lg:py-16 lg:px-6">
         <div class="mx-auto max-w-(--breakpoint-sm) text-center">
-          <h1 class="mb-4 text-7xl tracking-tight font-extrabold lg:text-9xl text-primary-600 dark:text-primary-500">500</h1>
+          <h1 class="mb-4 text-7xl tracking-tight font-extrabold lg:text-9xl text-primary dark:text-primary">500</h1>
           <p class="mb-4 text-3xl tracking-tight font-bold text-gray-900 md:text-4xl dark:text-white">
             {{ _("Internal Server Error.") }}
           </p>

--- a/app/templates/welcome-jellyfin.html
+++ b/app/templates/welcome-jellyfin.html
@@ -228,8 +228,7 @@
       </div>
     </div>
   </section>
-  <!-- Anime.js CDN -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>
+  <script src="{{ url_for('static', filename='js/vendor/anime.min.js', v=app_version) }}"></script>
   <!-- Custom animations and styles -->
   <style>
       /* Floating blob animations */


### PR DESCRIPTION
Replaces the Tailwind and Anime.js CDN references with bundled static assets. Adds Anime.js to the static npm dependencies and asset copy step so production builds include the vendor file. Updates standalone error pages to load the compiled local stylesheet and use the app primary color token. Validation: pre-commit hooks passed during commit, npm static build passed, and git diff --check passed.