### PR TITLE
Announce GitHub releases in Discord

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -1,0 +1,38 @@
+name: GitHub Releases to Discord
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: Release title to post
+        required: true
+      release_body:
+        description: Release notes body to post
+        required: true
+      release_html_url:
+        description: Release URL to link in Discord
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  github-releases-to-discord:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'wizarrrr'
+
+    steps:
+      - name: Send release notes to Discord
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          username: Wizarr Releases
+          footer_title: Changelog
+          footer_timestamp: "true"
+          reduce_headings: "true"
+          release_name: ${{ inputs.release_name }}
+          release_body: ${{ inputs.release_body }}
+          release_html_url: ${{ inputs.release_html_url }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that posts published GitHub release notes to Discord using SethCohen/github-releases-to-discord@v1. The workflow includes manual dispatch inputs for testing and only grants read content permissions. It expects the Discord webhook URL in the `WEBHOOK_URL` Actions secret; `content` is intentionally omitted so no broadcast mention is configured. Validated with `actionlint`, `git diff --check`, and the repo YAML pre-commit hook.