### PR TITLE
Validate invitation form submissions

### DIFF
--- a/app/services/invitation_flow/workflows.py
+++ b/app/services/invitation_flow/workflows.py
@@ -192,6 +192,30 @@ class InvitationWorkflow(ABC):
 
         return successful, failed
 
+    def _validate_join_form(
+        self, form_data: dict[str, Any]
+    ) -> tuple[bool, dict[str, Any], Any]:
+        """Validate submitted account data using the public join form rules."""
+        from werkzeug.datastructures import MultiDict
+
+        from app.forms.join import JoinForm
+
+        form = JoinForm(formdata=MultiDict(form_data))
+        if not form.validate():
+            return False, form_data, form
+
+        validated_data = dict(form_data)
+        validated_data.update(
+            {
+                "username": form.username.data or "",
+                "email": form.email.data or "",
+                "password": form.password.data or "",
+                "confirm_password": form.confirm_password.data or "",
+                "code": form.code.data or "",
+            }
+        )
+        return True, validated_data, form
+
     def _create_success_result(
         self,
         invitation: Invitation,
@@ -280,6 +304,16 @@ class FormBasedWorkflow(InvitationWorkflow):
         form_data: dict[str, Any],
     ) -> InvitationResult:
         """Process form submission."""
+        form_valid, validated_data, form = self._validate_join_form(form_data)
+        if not form_valid:
+            return self._create_auth_error_result(
+                invitation,
+                servers,
+                "Please correct the highlighted fields.",
+                form=form,
+            )
+        form_data = validated_data
+
         # Authenticate
         strategy = StrategyFactory.create_strategy(servers)
         auth_success, auth_message, _user_data = strategy.authenticate(
@@ -324,14 +358,19 @@ class FormBasedWorkflow(InvitationWorkflow):
         return self._create_server_error_result(invitation, servers, failed)
 
     def _create_auth_error_result(
-        self, invitation: Invitation, servers: list[MediaServer], error_message: str
+        self,
+        invitation: Invitation,
+        servers: list[MediaServer],
+        error_message: str,
+        form: Any | None = None,
     ) -> InvitationResult:
         """Create result for authentication errors."""
         from app.forms.join import JoinForm
         from app.services.server_name_resolver import resolve_invitation_server_name
 
-        form = JoinForm()
-        form.code.data = invitation.code
+        if form is None:
+            form = JoinForm()
+            form.code.data = invitation.code
 
         primary_server = servers[0] if servers else None
         server_type = primary_server.server_type if primary_server else "jellyfin"
@@ -524,10 +563,14 @@ class MixedWorkflow(InvitationWorkflow):
             )
 
         if other_servers:
+            from app.forms.join import JoinForm
+
             # Show password form for local servers
             # Use first local server's colors
             local_server_type = other_servers[0].server_type if other_servers else None
             colors = _get_server_colors(local_server_type)
+            form = JoinForm()
+            form.code.data = invitation.code
 
             return InvitationResult(
                 status=ProcessingStatus.AUTHENTICATION_REQUIRED,
@@ -536,6 +579,7 @@ class MixedWorkflow(InvitationWorkflow):
                 failed_servers=[],
                 template_data={
                     "template_name": "hybrid-password-form.html",
+                    "form": form,
                     "code": invitation.code,
                     "plex_authenticated": True,
                     "plex_token": plex_token,
@@ -571,6 +615,17 @@ class MixedWorkflow(InvitationWorkflow):
             # Need password for local servers
             return self.show_initial_form(invitation, servers)
 
+        if other_servers:
+            form_valid, validated_data, form = self._validate_join_form(form_data)
+            if not form_valid:
+                return self._create_local_form_error_result(
+                    invitation,
+                    other_servers,
+                    "Please correct the highlighted fields.",
+                    form,
+                )
+            form_data = validated_data
+
         # Process all servers
         all_successful = []
         all_failed = []
@@ -598,6 +653,38 @@ class MixedWorkflow(InvitationWorkflow):
             return self._create_success_result(invitation, all_successful, all_failed)
         return self._create_mixed_error_result(
             invitation, "Failed to create accounts on any server"
+        )
+
+    def _create_local_form_error_result(
+        self,
+        invitation: Invitation,
+        local_servers: list[MediaServer],
+        error_message: str,
+        form: Any,
+    ) -> InvitationResult:
+        """Create result for local account form validation errors."""
+        plex_token = session.get("plex_oauth_token")
+        local_server_type = local_servers[0].server_type if local_servers else None
+        colors = _get_server_colors(local_server_type)
+
+        return InvitationResult(
+            status=ProcessingStatus.FAILURE,
+            message=error_message,
+            successful_servers=[],
+            failed_servers=[],
+            template_data={
+                "template_name": "hybrid-password-form.html",
+                "form": form,
+                "code": invitation.code,
+                "plex_authenticated": True,
+                "plex_token": plex_token,
+                "local_servers": local_servers,
+                "gradient_start": colors["gradient_start"],
+                "gradient_end": colors["gradient_end"],
+                "shadow_color": colors["shadow_color"],
+                "error": error_message,
+            },
+            session_data={"invitation_in_progress": True},
         )
 
     def _create_mixed_error_result(

--- a/app/templates/hybrid-password-form.html
+++ b/app/templates/hybrid-password-form.html
@@ -92,11 +92,12 @@
                 method="post">
             {% if form %}
               {{ form.hidden_tag() }}
-            {% else %}
-              <input type="hidden" name="code" value="{{ code }}">
-              <input type="hidden" name="plex_token" value="{{ plex_token }}">
-              <input type="hidden" name="step" value="local_password">
             {% endif %}
+            <input type="hidden"
+                   name="code"
+                   value="{{ form.code.data if form and form.code else code }}">
+            <input type="hidden" name="plex_token" value="{{ plex_token }}">
+            <input type="hidden" name="step" value="local_password">
             <div>
               <label for="username"
                      class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Username") }}</label>

--- a/tests/test_invitation_flow.py
+++ b/tests/test_invitation_flow.py
@@ -4,6 +4,8 @@ Working tests for the invitation flow system
 
 from unittest.mock import Mock, patch
 
+from flask import render_template, session
+
 from app.extensions import db
 from app.models import Invitation, MediaServer
 from app.services.invitation_flow import InvitationFlowManager
@@ -381,10 +383,90 @@ class TestFormBasedWorkflow:
             mock_process.return_value = ([mock_server_result], [])
 
             with app.test_request_context():
-                result = workflow.process_submission(mock_invitation, [], {})
+                result = workflow.process_submission(
+                    mock_invitation,
+                    [],
+                    {
+                        "code": "TEST123",
+                        "username": "testuser",
+                        "email": "test@example.com",
+                        "password": "Testpass123",
+                        "confirm_password": "Testpass123",
+                    },
+                )
 
                 assert result.status == ProcessingStatus.SUCCESS
                 assert result.redirect_url == "/wizard/"
+
+    @patch("app.services.invitation_flow.workflows.StrategyFactory")
+    def test_process_submission_rejects_invalid_username(
+        self, mock_strategy_factory, app
+    ):
+        """Test submission validation rejects usernames before provisioning."""
+        workflow = FormBasedWorkflow()
+
+        mock_invitation = Mock()
+        mock_invitation.code = "TEST123"
+
+        with (
+            patch.object(workflow, "_process_servers") as mock_process,
+            app.test_request_context(),
+        ):
+            result = workflow.process_submission(
+                mock_invitation,
+                [],
+                {
+                    "code": "TEST123",
+                    "username": "ab",
+                    "email": "test@example.com",
+                    "password": "Testpass123",
+                    "confirm_password": "Testpass123",
+                },
+            )
+
+            assert result.status == ProcessingStatus.FAILURE
+            assert result.template_data is not None
+            assert result.template_data["template_name"] == "welcome-jellyfin.html"
+            assert result.template_data["form"].username.errors
+
+        mock_strategy_factory.create_strategy.assert_not_called()
+        mock_process.assert_not_called()
+
+
+class TestMixedWorkflow:
+    """Test MixedWorkflow"""
+
+    def test_show_local_password_form_preserves_invite_code(self, app):
+        """Test hybrid password form keeps form state and hidden invite code."""
+        workflow = MixedWorkflow()
+
+        mock_invitation = Mock()
+        mock_invitation.code = "MIXED123"
+
+        mock_plex_server = Mock()
+        mock_plex_server.server_type = "plex"
+        mock_local_server = Mock()
+        mock_local_server.server_type = "jellyfin"
+        mock_local_server.name = "Local Server"
+
+        with app.test_request_context():
+            session["plex_oauth_token"] = "plex-token"
+
+            result = workflow.show_initial_form(
+                mock_invitation, [mock_plex_server, mock_local_server]
+            )
+
+            assert result.status == ProcessingStatus.AUTHENTICATION_REQUIRED
+            assert result.template_data is not None
+            assert result.template_data["template_name"] == "hybrid-password-form.html"
+            assert result.template_data["form"].code.data == "MIXED123"
+
+            rendered = render_template(
+                result.template_data["template_name"], **result.template_data
+            )
+
+            assert 'name="code"' in rendered
+            assert 'value="MIXED123"' in rendered
 
 
 class TestIntegrationWithDatabase:
@@ -505,8 +587,8 @@ class TestEndToEndFlow:
                 "code": "E2E123",
                 "username": "testuser",
                 "email": "test@example.com",
-                "password": "testpass123",
-                "confirm_password": "testpass123",
+                "password": "Testpass123",
+                "confirm_password": "Testpass123",
             }
 
             with patch("flask.session", {}):


### PR DESCRIPTION
Adds shared JoinForm validation before invitation provisioning so invalid usernames, emails, passwords, and invite codes are rejected before account creation. Preserves submitted form state on validation errors and fixes the mixed Plex plus local flow by rendering a real form with CSRF support and always posting the invite code. This prevents hybrid retry submissions from losing the invite code after validation errors. Validated with `uv run pytest tests/test_invitation_flow.py -q` and `uv run ruff check app/services/invitation_flow/workflows.py tests/test_invitation_flow.py`.