### PR TITLE
Keep invite form open on errors

### DIFF
--- a/app/blueprints/media_common/routes.py
+++ b/app/blueprints/media_common/routes.py
@@ -8,7 +8,47 @@ from flask import Blueprint, abort, jsonify, redirect, render_template, request
 from flask_login import login_required
 
 from app.forms.join import JoinForm
+from app.models import Invitation, MediaServer
+from app.services.invitation_flow.workflows import _get_server_colors
 from app.services.invitation_manager import InvitationManager, LibraryScanner
+from app.services.server_name_resolver import resolve_invitation_server_name
+
+
+def _join_template_context(
+    server_type: str, form: JoinForm, error: str | None = None
+) -> dict:
+    """Build the complete context needed to render the join form."""
+    code = form.code.data or request.form.get("code")
+    servers = []
+
+    if code:
+        invitation = Invitation.query.filter_by(code=code).first()
+        if invitation and invitation.servers:
+            servers = [s for s in invitation.servers if s.server_type == server_type]
+            if not servers:
+                servers = list(invitation.servers)
+        elif invitation and invitation.server:
+            servers = [invitation.server]
+
+    if not servers:
+        server = MediaServer.query.filter_by(server_type=server_type).first()
+        if server:
+            servers = [server]
+
+    colors = _get_server_colors(server_type)
+    context = {
+        "form": form,
+        "server_type": server_type,
+        "server_name": resolve_invitation_server_name(servers),
+        "servers": servers,
+        "gradient_start": colors["gradient_start"],
+        "gradient_end": colors["gradient_end"],
+        "shadow_color": colors["shadow_color"],
+        "show_form": bool(error) or bool(form.errors),
+    }
+    if error:
+        context["error"] = error
+    return context
 
 
 def create_media_blueprint(server_type: str, url_prefix: str) -> Blueprint:
@@ -75,9 +115,7 @@ def create_media_blueprint(server_type: str, url_prefix: str) -> Blueprint:
 
         return render_template(
             "welcome-jellyfin.html",
-            form=form,
-            server_type=server_type,
-            error=error,
+            **_join_template_context(server_type, form, error),
         )
 
     return bp

--- a/app/blueprints/public/routes.py
+++ b/app/blueprints/public/routes.py
@@ -30,9 +30,7 @@ def _media_permission_flags(invitation: Invitation, server: MediaServer) -> dict
         or bool(getattr(server, "allow_downloads", False)),
         "allow_live_tv": bool(getattr(invitation, "allow_live_tv", False))
         or bool(getattr(server, "allow_live_tv", False)),
-        "allow_mobile_uploads": bool(
-            getattr(invitation, "allow_mobile_uploads", False)
-        )
+        "allow_mobile_uploads": bool(getattr(invitation, "allow_mobile_uploads", False))
         or bool(getattr(server, "allow_mobile_uploads", False)),
     }
 
@@ -226,6 +224,7 @@ def join():
         "komga",
     ):
         from app.forms.join import JoinForm
+        from app.services.invitation_flow.workflows import _get_server_colors
 
         # Get server name for the invitation using the new resolver if available
         try:
@@ -247,11 +246,15 @@ def join():
 
         form = JoinForm()
         form.code.data = code
+        colors = _get_server_colors(server_type)
         return render_template(
             "welcome-jellyfin.html",
             code=code,
             server_type=server_type,
             server_name=server_name,
+            gradient_start=colors["gradient_start"],
+            gradient_end=colors["gradient_end"],
+            shadow_color=colors["shadow_color"],
             form=form,
         )
 

--- a/app/services/invitation_flow/workflows.py
+++ b/app/services/invitation_flow/workflows.py
@@ -61,6 +61,42 @@ def _get_server_colors(server_type: str | None) -> dict[str, str]:
     )
 
 
+def _create_join_form_template_data(
+    invitation: Invitation,
+    servers: list[MediaServer],
+    *,
+    form=None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Build the complete template context for form-based invite screens."""
+    from app.forms.join import JoinForm
+    from app.services.server_name_resolver import resolve_invitation_server_name
+
+    if form is None:
+        form = JoinForm()
+    form.code.data = invitation.code
+
+    primary_server = servers[0] if servers else None
+    server_type = primary_server.server_type if primary_server else "jellyfin"
+    server_name = resolve_invitation_server_name(servers)
+    colors = _get_server_colors(server_type)
+
+    context = {
+        "template_name": "welcome-jellyfin.html",
+        "form": form,
+        "server_type": server_type,
+        "server_name": server_name,
+        "servers": servers,
+        "gradient_start": colors["gradient_start"],
+        "gradient_end": colors["gradient_end"],
+        "shadow_color": colors["shadow_color"],
+        "show_form": bool(error) or bool(getattr(form, "errors", None)),
+    }
+    if error:
+        context["error"] = error
+    return context
+
+
 class InvitationWorkflow(ABC):
     """Base class for invitation workflows."""
 
@@ -239,37 +275,12 @@ class FormBasedWorkflow(InvitationWorkflow):
         self, invitation: Invitation, servers: list[MediaServer]
     ) -> InvitationResult:
         """Show form-based authentication form."""
-        from app.forms.join import JoinForm
-        from app.services.server_name_resolver import resolve_invitation_server_name
-
-        form = JoinForm()
-        form.code.data = invitation.code
-
-        # Determine primary server type for UI
-        primary_server = servers[0] if servers else None
-        server_type = primary_server.server_type if primary_server else "jellyfin"
-
-        # Resolve the server name to display
-        server_name = resolve_invitation_server_name(servers)
-
-        # Get server-specific color scheme for theming
-        colors = _get_server_colors(server_type)
-
         return InvitationResult(
             status=ProcessingStatus.AUTHENTICATION_REQUIRED,
             message="Authentication required",
             successful_servers=[],
             failed_servers=[],
-            template_data={
-                "template_name": "welcome-jellyfin.html",
-                "form": form,
-                "server_type": server_type,
-                "server_name": server_name,
-                "servers": servers,
-                "gradient_start": colors["gradient_start"],
-                "gradient_end": colors["gradient_end"],
-                "shadow_color": colors["shadow_color"],
-            },
+            template_data=_create_join_form_template_data(invitation, servers),
             session_data={"invitation_in_progress": True},
         )
 
@@ -327,31 +338,14 @@ class FormBasedWorkflow(InvitationWorkflow):
         self, invitation: Invitation, servers: list[MediaServer], error_message: str
     ) -> InvitationResult:
         """Create result for authentication errors."""
-        from app.forms.join import JoinForm
-        from app.services.server_name_resolver import resolve_invitation_server_name
-
-        form = JoinForm()
-        form.code.data = invitation.code
-
-        primary_server = servers[0] if servers else None
-        server_type = primary_server.server_type if primary_server else "jellyfin"
-
-        # Resolve the server name to display
-        server_name = resolve_invitation_server_name(servers)
-
         return InvitationResult(
             status=ProcessingStatus.FAILURE,
             message=error_message,
             successful_servers=[],
             failed_servers=[],
-            template_data={
-                "template_name": "welcome-jellyfin.html",
-                "form": form,
-                "server_type": server_type,
-                "server_name": server_name,
-                "servers": servers,
-                "error": error_message,
-            },
+            template_data=_create_join_form_template_data(
+                invitation, servers, error=error_message
+            ),
             session_data={"invitation_in_progress": True},
         )
 
@@ -362,18 +356,6 @@ class FormBasedWorkflow(InvitationWorkflow):
         failed: list[ServerResult],
     ) -> InvitationResult:
         """Create result for server failures."""
-        from app.forms.join import JoinForm
-        from app.services.server_name_resolver import resolve_invitation_server_name
-
-        form = JoinForm()
-        form.code.data = invitation.code
-
-        primary_server = servers[0] if servers else None
-        server_type = primary_server.server_type if primary_server else "jellyfin"
-
-        # Resolve the server name to display
-        server_name = resolve_invitation_server_name(servers)
-
         error_messages = [
             f"{result.server.name}: {result.message}" for result in failed
         ]
@@ -384,14 +366,9 @@ class FormBasedWorkflow(InvitationWorkflow):
             message=error_text,
             successful_servers=[],
             failed_servers=failed,
-            template_data={
-                "template_name": "welcome-jellyfin.html",
-                "form": form,
-                "server_type": server_type,
-                "server_name": server_name,
-                "servers": servers,
-                "error": error_text,
-            },
+            template_data=_create_join_form_template_data(
+                invitation, servers, error=error_text
+            ),
             session_data={"invitation_in_progress": True},
         )
 

--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -1284,8 +1284,9 @@ def handle_oauth_token(app, token: str, code: str) -> None:
         if not servers:
             raise ValueError("No media server found")
 
-        from app.services.expiry import calculate_user_expiry
         from flask import current_app
+
+        from app.services.expiry import calculate_user_expiry
 
         for server in servers:
             server_id = server.id

--- a/app/templates/hybrid-password-form.html
+++ b/app/templates/hybrid-password-form.html
@@ -90,9 +90,7 @@
           <form class="space-y-4 md:space-y-6"
                 action="{{ url_for('public.process_invitation') }}"
                 method="post">
-            {% if form %}
-              {{ form.hidden_tag() }}
-            {% endif %}
+            {% if form %}{{ form.hidden_tag() }}{% endif %}
             <input type="hidden"
                    name="code"
                    value="{{ form.code.data if form and form.code else code }}">

--- a/app/templates/welcome-jellyfin.html
+++ b/app/templates/welcome-jellyfin.html
@@ -3,17 +3,20 @@
   Accept Invite
 {% endblock title %}
 {% block og_title %}
-  {{ _(server_name) }}
+  {{ _(server_name|default("Media Server", true)) }}
 {% endblock og_title %}
 {% block og_description %}
-  {{ _("You've been invited to join the %(name)s server!", name=server_name) }}
+  {{ _("You've been invited to join the %(name)s server!", name=server_name|default("Media Server", true)) }}
 {% endblock og_description %}
 {% block main %}
+  {% set has_form_errors = form is defined and form.errors %}
+  {% set show_form_on_load = show_form|default(false) or error|default(false) or has_form_errors %}
+  {% set form_field_style = "opacity: 1; transform: translateY(0);" if show_form_on_load else "opacity: 0; transform: translateY(10px);" %}
   <style>
       /* Override CSS custom properties with server-specific colors */
       :root {
-          --color-primary: {{ gradient_start }};
-          --color-primary_hover: {{ gradient_end }};
+          --color-primary: {{ gradient_start|default("#AA5CC3", true) }};
+          --color-primary_hover: {{ gradient_end|default("#00A4DC", true) }};
       }
   </style>
   <section id="invite-section"
@@ -52,13 +55,13 @@
         </p>
       </div>
       <!-- Main Card Container -->
-      <div class="w-full max-w-md transition-all duration-700 ease-out"
+      <div class="w-full {{ 'max-w-lg' if show_form_on_load else 'max-w-md' }} transition-all duration-700 ease-out"
            id="main-container">
-        <div class="bg-white/90 dark:bg-gray-800/40 backdrop-blur-xl rounded-2xl shadow-xl dark:shadow-2xl border border-gray-200 dark:border-gray-700/50 transition-all duration-700 ease-out h-[400px]"
+        <div class="bg-white/90 dark:bg-gray-800/40 backdrop-blur-xl rounded-2xl shadow-xl dark:shadow-2xl border border-gray-200 dark:border-gray-700/50 transition-all duration-700 ease-out {{ 'h-auto min-h-[520px] md:h-[520px]' if show_form_on_load else 'h-[400px]' }}"
              id="card-container"
-             style="overflow: hidden">
+             style="overflow: {{ 'visible' if show_form_on_load else 'hidden' }}">
           <!-- Welcome Screen -->
-          <div class="p-8 space-y-6 transition-all duration-500 ease-out"
+          <div class="p-8 space-y-6 transition-all duration-500 ease-out {{ 'hidden' if show_form_on_load else '' }}"
                id="welcome-screen">
             <div class="text-center">
               <div class="mx-auto w-16 h-16 bg-gradient-to-r from-primary to-primary_hover rounded-full flex items-center justify-center mb-4 shadow-lg">
@@ -79,7 +82,7 @@
             </button>
           </div>
           <!-- Account Creation Form (initially hidden) -->
-          <div class="h-full flex flex-col opacity-0 pointer-events-none transition-all duration-500 ease-out absolute inset-0 overflow-hidden hidden"
+          <div class="h-full flex flex-col transition-all duration-500 ease-out {{ 'relative opacity-100 pointer-events-auto overflow-visible' if show_form_on_load else 'opacity-0 pointer-events-none absolute inset-0 overflow-hidden hidden' }}"
                id="form-screen">
             <div class="text-center relative py-4 px-6 flex-shrink-0">
               <button id="back-btn"
@@ -104,8 +107,7 @@
                 {{ form.hidden_tag() }}
                 <div class="form-field"
                      data-field="1"
-                     style="opacity: 0;
-                            transform: translateY(10px)">
+                     style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -123,8 +125,7 @@
                 </div>
                 <div class="form-field"
                      data-field="2"
-                     style="opacity: 0;
-                            transform: translateY(10px)">
+                     style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -142,8 +143,7 @@
                 </div>
                 <div class="form-field"
                      data-field="3"
-                     style="opacity: 0;
-                            transform: translateY(10px)">
+                     style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -161,8 +161,7 @@
                 </div>
                 <div class="form-field"
                      data-field="4"
-                     style="opacity: 0;
-                            transform: translateY(10px)">
+                     style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -180,8 +179,7 @@
                 </div>
                 <div class="form-field"
                      data-field="5"
-                     style="opacity: 0;
-                            transform: translateY(10px)">
+                     style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -201,8 +199,7 @@
                         id="submit-btn"
                         class="w-full py-3 px-4 text-white font-semibold text-sm bg-gradient-to-r from-primary to-primary_hover hover:from-primary_hover hover:to-primary rounded-lg transition-all duration-200 transform hover:scale-[1.02] focus:ring-4 focus:ring-primary/30 focus:outline-none shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed form-field"
                         data-field="6"
-                        style="opacity: 0;
-                               transform: translateY(10px)">
+                        style="{{ form_field_style }}">
                   <span id="btn-text">{{ _("Create Account") }}</span>
                   <span id="btn-loading" class="hidden">
                     <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white inline"

--- a/app/templates/welcome-jellyfin.html
+++ b/app/templates/welcome-jellyfin.html
@@ -3,10 +3,10 @@
   Accept Invite
 {% endblock title %}
 {% block og_title %}
-  {{ _(server_name|default("Media Server", true)) }}
+  {{ _(server_name|default("Media Server", true) ) }}
 {% endblock og_title %}
 {% block og_description %}
-  {{ _("You've been invited to join the %(name)s server!", name=server_name|default("Media Server", true)) }}
+  {{ _("You've been invited to join the %(name)s server!", name=server_name|default("Media Server", true) ) }}
 {% endblock og_description %}
 {% block main %}
   {% set has_form_errors = form is defined and form.errors %}
@@ -105,9 +105,7 @@
                     action="{{ url_for('public.process_invitation') }}"
                     method="post">
                 {{ form.hidden_tag() }}
-                <div class="form-field"
-                     data-field="1"
-                     style="{{ form_field_style }}">
+                <div class="form-field" data-field="1" style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -123,9 +121,7 @@
                   ) }}
                   {% for err in form.username.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
                 </div>
-                <div class="form-field"
-                     data-field="2"
-                     style="{{ form_field_style }}">
+                <div class="form-field" data-field="2" style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -141,9 +137,7 @@
                   ) }}
                   {% for err in form.email.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
                 </div>
-                <div class="form-field"
-                     data-field="3"
-                     style="{{ form_field_style }}">
+                <div class="form-field" data-field="3" style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -159,9 +153,7 @@
                   ) }}
                   {% for err in form.password.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
                 </div>
-                <div class="form-field"
-                     data-field="4"
-                     style="{{ form_field_style }}">
+                <div class="form-field" data-field="4" style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"
@@ -177,9 +169,7 @@
                   ) }}
                   {% for err in form.confirm_password.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
                 </div>
-                <div class="form-field"
-                     data-field="5"
-                     style="{{ form_field_style }}">
+                <div class="form-field" data-field="5" style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
                          fill="none"

--- a/app/templates/welcome-jellyfin.html
+++ b/app/templates/welcome-jellyfin.html
@@ -57,7 +57,7 @@
       <!-- Main Card Container -->
       <div class="w-full {{ 'max-w-lg' if show_form_on_load else 'max-w-md' }} transition-all duration-700 ease-out"
            id="main-container">
-        <div class="bg-white/90 dark:bg-gray-800/40 backdrop-blur-xl rounded-2xl shadow-xl dark:shadow-2xl border border-gray-200 dark:border-gray-700/50 transition-all duration-700 ease-out {{ 'h-auto min-h-[520px] md:h-[520px]' if show_form_on_load else 'h-[400px]' }}"
+        <div class="relative bg-white/90 dark:bg-gray-800/40 backdrop-blur-xl rounded-2xl shadow-xl dark:shadow-2xl border border-gray-200 dark:border-gray-700/50 transition-all duration-700 ease-out {{ 'h-auto min-h-[520px] md:h-[520px]' if show_form_on_load else 'h-[400px]' }}"
              id="card-container"
              style="overflow: {{ 'visible' if show_form_on_load else 'hidden' }}">
           <!-- Welcome Screen -->
@@ -484,12 +484,44 @@
           // Initialize background shimmer particles
           createShimmerParticles();
 
+          function revealFormWithoutAnimation() {
+              const isMobile = window.innerWidth < 768;
+              formScreen.classList.remove('hidden');
+              formScreen.style.opacity = '1';
+              formScreen.style.pointerEvents = 'auto';
+              welcomeScreen.style.display = 'none';
+              mainContainer.style.maxWidth = isMobile ? '100%' : '32rem';
+              cardContainer.style.height = isMobile ? 'auto' : '520px';
+              cardContainer.style.minHeight = isMobile ? `${formScreen.scrollHeight + 48}px` : '';
+              cardContainer.style.overflow = isMobile ? 'visible' : 'hidden';
+              if (isMobile) {
+                  layoutWrapper.style.justifyContent = 'flex-start';
+                  layoutWrapper.style.paddingTop = '3rem';
+                  layoutWrapper.style.paddingBottom = '2rem';
+                  formScreen.style.position = 'relative';
+                  formScreen.style.height = 'auto';
+                  formScreen.style.overflow = 'visible';
+              }
+              const formFields = formScreen.querySelectorAll('.form-field');
+              formFields.forEach(field => {
+                  field.style.opacity = '1';
+                  field.style.transform = 'translateY(0)';
+              });
+              const firstInput = form.querySelector('input[type="text"], input[type="email"]');
+              if (firstInput) firstInput.focus();
+          }
+
           // Smooth container expansion animation
           acceptBtn.addEventListener('click', async function() {
               // Prevent multiple clicks
               acceptBtn.disabled = true;
 
               try {
+                  if (typeof anime === 'undefined') {
+                      revealFormWithoutAnimation();
+                      return;
+                  }
+
                   const isMobile = window.innerWidth < 768;
                   let mobileCardHeight = null;
 
@@ -602,7 +634,7 @@
 
               } catch (error) {
                   console.error('Animation error:', error);
-                  // Fallback to simple transition
+                  revealFormWithoutAnimation();
                   acceptBtn.disabled = false;
               }
           });

--- a/tests/e2e/test_invitation_e2e.py
+++ b/tests/e2e/test_invitation_e2e.py
@@ -150,8 +150,8 @@ class TestInvitationUserJourney:
 
         # Fill out the form
         page.fill("input[name='username']", "e2etestuser")
-        page.fill("input[name='password']", "testpassword123")
-        page.fill("input[name='confirm_password']", "testpassword123")
+        page.fill("input[name='password']", "Testpassword123")
+        page.fill("input[name='confirm_password']", "Testpassword123")
         page.fill("input[name='email']", "e2etest@example.com")
 
         # Submit the form
@@ -216,8 +216,8 @@ class TestInvitationUserJourney:
             "input[name='username']:not([style*='opacity: 0'])", timeout=5000
         )
         page.fill("input[name='username']", "testuser")
-        page.fill("input[name='password']", "password123")
-        page.fill("input[name='confirm_password']", "differentpassword")
+        page.fill("input[name='password']", "Password123")
+        page.fill("input[name='confirm_password']", "Differentpassword123")
         page.fill("input[name='email']", "test@example.com")
         expect(page.locator("button[type='submit']")).to_be_visible()
         page.click("button[type='submit']")
@@ -304,8 +304,8 @@ class TestInvitationUserJourney:
 
         # Fill and submit form
         page.fill("input[name='username']", "erroruser")
-        page.fill("input[name='password']", "testpass123")
-        page.fill("input[name='confirm_password']", "testpass123")
+        page.fill("input[name='password']", "Testpass123")
+        page.fill("input[name='confirm_password']", "Testpass123")
         page.fill("input[name='email']", "error@example.com")
         expect(page.locator("button[type='submit']")).to_be_visible()
         page.click("button[type='submit']")
@@ -417,8 +417,8 @@ class TestMultiServerInvitationFlow:
 
         # Fill and submit the user registration form
         page.fill("input[name='username']", "multiuser")
-        page.fill("input[name='password']", "testpass123")
-        page.fill("input[name='confirm_password']", "testpass123")
+        page.fill("input[name='password']", "Testpass123")
+        page.fill("input[name='confirm_password']", "Testpass123")
         page.fill("input[name='email']", "multi@example.com")
         page.click("button:has-text('Create Account')")
 
@@ -515,8 +515,8 @@ class TestMultiServerInvitationFlow:
         # Should show invitation content and registration form
         page.wait_for_selector("input[name='username']", timeout=10000)
         page.fill("input[name='username']", "partialuser")
-        page.fill("input[name='password']", "testpass123")
-        page.fill("input[name='confirm_password']", "testpass123")
+        page.fill("input[name='password']", "Testpass123")
+        page.fill("input[name='confirm_password']", "Testpass123")
         page.fill("input[name='email']", "partial@example.com")
         page.click("button:has-text('Create Account')")
 

--- a/tests/test_invitation_form_errors.py
+++ b/tests/test_invitation_form_errors.py
@@ -1,0 +1,65 @@
+import re
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.models import Invitation, MediaServer
+
+
+def _create_jellyfin_invitation(session):
+    server = MediaServer(
+        name="Test Jellyfin",
+        server_type="jellyfin",
+        url="http://jellyfin.example.com",
+        api_key="test-key",
+    )
+    invitation = Invitation(code="ERR123", unlimited=True, used=False)
+
+    session.add(server)
+    session.add(invitation)
+    session.flush()
+    invitation.servers.append(server)
+    session.commit()
+
+    return server, invitation
+
+
+@pytest.mark.parametrize(
+    "join_error",
+    [
+        "Invalid e-mail address.",
+        "User or e-mail already exists.",
+    ],
+)
+def test_invitation_process_rerenders_open_join_form_on_email_error(
+    client, session, join_error
+):
+    _create_jellyfin_invitation(session)
+    media_client = Mock()
+    media_client.join.return_value = (False, join_error)
+
+    with patch(
+        "app.services.invitation_flow.workflows.get_client_for_media_server",
+        return_value=media_client,
+    ):
+        response = client.post(
+            "/invitation/process",
+            data={
+                "code": "ERR123",
+                "username": "validuser",
+                "email": "user@example.com",
+                "password": "ValidPass1",
+                "confirm_password": "ValidPass1",
+            },
+        )
+
+    body = response.data
+    form_screen = re.search(rb'<div class="[^"]*"[^>]*id="form-screen"', body)
+
+    assert response.status_code == 200
+    assert join_error.encode() in body
+    assert b"Test Jellyfin" in body
+    assert b"--color-primary: #AA5CC3;" in body
+    assert form_screen is not None
+    assert b"opacity-100" in form_screen.group(0)
+    assert b"hidden" not in form_screen.group(0)


### PR DESCRIPTION
## Summary
Keep form-based invitation screens open when account creation fails so users can see validation or server errors without replaying the welcome animation.

Centralize the Jellyfin-style join form template context, preserve server-specific theming for public and media-specific invite routes, and add fallbacks for missing display context.

Add regression coverage for email-related join failures to verify the error, server name, theme color, and visible form state are rendered.

## Validation
- `uv run --group dev pytest -q tests/test_invitation_form_errors.py`
- `uv run --group dev ruff check app/blueprints/media_common/routes.py app/blueprints/public/routes.py app/services/invitation_flow/workflows.py tests/test_invitation_form_errors.py`