### PR TITLE
Remove Blacksmith from GitHub workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   check-release:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: |
       github.event.pull_request.merged == true && 
       startsWith(github.event.pull_request.title, 'Release v') &&

--- a/.github/workflows/build-plus.yml.wip
+++ b/.github/workflows/build-plus.yml.wip
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-plus:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/calver-automation.yml
+++ b/.github/workflows/calver-automation.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   release-please:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'wizarrrr'
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   docker-dev:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -45,11 +45,11 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build & push multi-arch :dev image
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-release:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: |
       github.event.pull_request.merged == true && 
       startsWith(github.event.pull_request.title, 'Release v') &&

--- a/.github/workflows/i18n-template.yml
+++ b/.github/workflows/i18n-template.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pot:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # don’t run if the commit came from the Weblate bot
     if: github.actor != 'weblate'
     steps:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint-and-format:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: github.actor != 'weblate'
     
     steps:

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ secrets.SPONSORS_TOKEN }}
       SPONSOR_LOGIN: "mtthidoteu"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: github.actor != 'weblate'
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
 jobs:
     # ──────────────────── Docker Stable Release ────────────────────
     stable-release:
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ubuntu-24.04
         permissions:
             contents: read
             packages: write
@@ -73,11 +73,11 @@ jobs:
             -   name: Set up QEMU
                 uses: docker/setup-qemu-action@v4
 
-            - name: Setup Blacksmith Builder
-              uses: useblacksmith/setup-docker-builder@v1
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
             -   name: Build & push stable release image
-                uses: useblacksmith/build-push-action@v2
+                uses: docker/build-push-action@v5
                 with:
                     context: .
                     push: true

--- a/.github/workflows/verify-translations.yml
+++ b/.github/workflows/verify-translations.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   compile:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - name: Install uv


### PR DESCRIPTION
## Summary
- Replaces all Blacksmith runner labels with GitHub-hosted ubuntu-24.04 across workflows.
- Swaps the Blacksmith Docker builder and build/push actions for Docker Buildx and docker/build-push-action in image workflows.

## Validation
- Searched for remaining Blacksmith references.
- Parsed GitHub workflow YAML files with Ruby.
- Ran git diff --check.
- Pre-commit YAML hook passed during commit.