### PR TITLE
Release v2026.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2026.7.0",
+  "version": "2026.7.1",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2026.7.0"
+version = "2026.7.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -154,7 +154,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2026.7.0"
+version = "2026.7.1"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1674,7 +1674,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2026.7.0"
+version = "2026.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2026.7.1

## What's Changed

### 🐛 Bug Fixes
- default Docker healthcheck port (#1331)

### 🧹 Chores
- 

### 📝 Other Changes
- Bump docker/build-push-action from 5 to 7 (#1336)
- Bump docker/setup-buildx-action from 3 to 4 (#1335)


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2026.7.1...v2026.7.1

## 📋 All Commits Included (4 commits)

<details>
<summary>Click to expand commit list</summary>

```
c16709c15 chore: release v2026.7.1
d84a79080 Bump docker/build-push-action from 5 to 7 (#1336)
bb00d7bdf Bump docker/setup-buildx-action from 3 to 4 (#1335)
080752b75 fix: default Docker healthcheck port (#1331)
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2026.7.1`
- Deploy to production
- Build Docker images with `:latest` and `v2026.7.1` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation