### PR TITLE
fix(app): trust proxy headers for external URLs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ import os
 
 from flask import Flask
 
+from werkzeug.middleware.proxy_fix import ProxyFix
 from .config import DevelopmentConfig
 from .error_handlers import register_error_handlers
 from .extensions import init_extensions
@@ -31,6 +32,17 @@ def create_app(config_object=DevelopmentConfig):
         logger.step("Creating Flask application", "🌐")
     app = Flask(__name__)
     app.config.from_object(config_object)
+
+    # Apply ProxyFix if configured
+    if app.config.get("TRUST_PROXY_HEADERS"):
+        app.wsgi_app = ProxyFix(
+            app.wsgi_app,
+            x_for=app.config.get("PROXY_FIX_X_FOR", 1),
+            x_proto=app.config.get("PROXY_FIX_X_PROTO", 1),
+            x_host=app.config.get("PROXY_FIX_X_HOST", 1),
+            x_port=app.config.get("PROXY_FIX_X_PORT", 1),
+            x_prefix=app.config.get("PROXY_FIX_X_PREFIX", 1),
+        )
 
     # Step 3: Initialize extensions
     if show_startup:

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,26 @@ from app.utils.session_cache import RobustFileSystemCache
 BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")
 
+
+def env_bool(key: str, default: bool = False) -> bool:
+    value = os.getenv(key)
+    if value is None:
+        return default
+
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def env_int(key: str, default: int) -> int:
+    value = os.getenv(key)
+    if value is None:
+        return default
+
+    try:
+        return int(value)
+    except ValueError:
+        return default
+    
+
 # Initialize session cache at module level so Flask-Session can access it
 
 # Ensure database directory exists
@@ -79,6 +99,14 @@ class BaseConfig:
     # Sessions
     SESSION_TYPE = "cachelib"  # Changed from 'filesystem' to 'cachelib'
     SESSION_CACHELIB = SESSION_CACHELIB  # Reference the module-level cache
+
+    # Reverse proxy support
+    TRUST_PROXY_HEADERS = env_bool("TRUST_PROXY_HEADERS", False)
+    PROXY_FIX_X_FOR = env_int("PROXY_FIX_X_FOR", 1)
+    PROXY_FIX_X_PROTO = env_int("PROXY_FIX_X_PROTO", 1)
+    PROXY_FIX_X_HOST = env_int("PROXY_FIX_X_HOST", 1)
+    PROXY_FIX_X_PORT = env_int("PROXY_FIX_X_PORT", 1)
+    PROXY_FIX_X_PREFIX = env_int("PROXY_FIX_X_PREFIX", 1)
 
     # Babel / i18n
     LANGUAGES: ClassVar[dict[str, str]] = {

--- a/docs/getting-started/reverse-proxy.md
+++ b/docs/getting-started/reverse-proxy.md
@@ -1,5 +1,28 @@
 # Reverse Proxy
 
+## Trusted proxy headers
+
+When Wizarr runs behind a reverse proxy such as Nginx, Traefik, Caddy, SWAG, or Nginx Proxy Manager, the browser may connect to the proxy over HTTPS while the proxy connects to Wizarr over plain HTTP.
+
+Enable trusted proxy headers so Wizarr can use the original public request details when generating URLs and redirects.
+
+Add the following environment variables to the Wizarr service:
+
+```env
+TRUST_PROXY_HEADERS=true
+PROXY_FIX_X_FOR=1
+PROXY_FIX_X_PROTO=1
+PROXY_FIX_X_HOST=1
+PROXY_FIX_X_PORT=1
+PROXY_FIX_X_PREFIX=1
+```
+
+For a typical setup with one reverse proxy in front of Wizarr, use `1` for each `PROXY_FIX_*` value.
+
+Only enable `TRUST_PROXY_HEADERS` when Wizarr is reachable only through your trusted reverse proxy. **Do not** enable it if clients can connect directly to the Wizarr container.
+
+If Wizarr is behind multiple trusted proxy hops, increase the relevant `PROXY_FIX_*` value to match the number of trusted proxies.
+
 ## Nginx
 
 {% tabs %}
@@ -40,7 +63,7 @@ Add a new proxy host with the following settings:
 * **Forward Hostname / IP:** Internal wizarr hostname or IP
 * **Forward Port:** `5690`
 * **Cache Assets:** yes
-* **Block Common Exploits:** no 
+* **Block Common Exploits:** no
 
 #### SSL
 
@@ -70,9 +93,9 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Real-Port $remote_port;
-    proxy_set_header X-Forwarded-Host $host:$remote_port;
+    proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Server $host;
-    proxy_set_header X-Forwarded-Port $remote_port;
+    proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Ssl on;
@@ -143,7 +166,7 @@ plex.example.com {
             # include in join code path copy
             "navigator.clipboard.writeText(url + \"/j/\" + invite_code);" "navigator.clipboard.writeText(url + \"/wizarr/j/\" + invite_code);"
         }
-        
+
         # Your wizarr backend
         reverse_proxy http://127.0.0.1:5690
     }
@@ -151,7 +174,6 @@ plex.example.com {
     reverse_proxy http://127.0.0.1:5055
 }
 ```
-
 
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
## Summary

This PR adds optional support for [Werkzeug `ProxyFix`](https://werkzeug.palletsprojects.com/en/stable/middleware/proxy_fix/) so Wizarr can correctly handle deployments behind a reverse proxy such as Traefik, Nginx, Caddy, SWAG, or Nginx Proxy Manager.

When Wizarr is deployed behind a proxy, users may access Wizarr via:

```text
https://wizarr.example.com
```

while the app itself receives the proxied request as:

```text
http://wizarr:5690
```

Without trusting forwarded headers, Flask may generate absolute URLs and redirects with the internal scheme/host instead of the public URL. `ProxyFix` lets Wizarr use headers such as `X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Port` from a trusted reverse proxy.

## Changes

- Add optional trusted proxy header support via `ProxyFix`
- Add environment configuration for proxy hop counts:
  - `TRUST_PROXY_HEADERS`
  - `PROXY_FIX_X_FOR`
  - `PROXY_FIX_X_PROTO`
  - `PROXY_FIX_X_HOST`
  - `PROXY_FIX_X_PORT`
  - `PROXY_FIX_X_PREFIX`
- Keep trusted proxy headers disabled by default
- Document the new settings in `docs/getting-started/reverse-proxy.md`

## Why

This is useful for any Wizarr deployment behind a frontend reverse proxy, not just one specific integration. It ensures generated URLs and redirects use the original public request details instead of the internal container connection.

I also need this as a prerequisite for my [external account enrollment PR](https://github.com/wizarrrr/wizarr/pull/1317). That flow generates an absolute callback URL with Flask’s external URL generation and passes it to the external enrollment provider. Without trusted proxy headers, that callback URL can be generated as `http://...` even though the public Wizarr URL is `https://...`.

Keeping this in a separate PR keeps the reverse-proxy behavior change independent from the external enrollment feature.

## Configuration example

```env
TRUST_PROXY_HEADERS=true
PROXY_FIX_X_FOR=1
PROXY_FIX_X_PROTO=1
PROXY_FIX_X_HOST=1
PROXY_FIX_X_PORT=1
PROXY_FIX_X_PREFIX=1
```

For a typical setup with one trusted reverse proxy in front of Wizarr, use `1` for each `PROXY_FIX_*` value.

Only enable `TRUST_PROXY_HEADERS` when Wizarr is reachable only through the trusted reverse proxy.