### PR TITLE
Fix Docker healthcheck default port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ RUN mkdir -p app/static/js app/static/css && DOCKER_BUILD=true npm --prefix app/
 # ─── Stage 3: Runtime ─────────────────────────────────────────────────────
 FROM ghcr.io/astral-sh/uv:python3.13-alpine
 
+# Default bind values used by Gunicorn and Docker-level consumers such as HEALTHCHECK.
+# These can still be overridden at runtime with HOST/PORT environment variables.
+ENV HOST=0.0.0.0
+ENV PORT=5690
+
 # Set default environment variables for user/group IDs
 ENV PUID=1000
 ENV PGID=1000


### PR DESCRIPTION
## Summary

Fixes the Docker healthcheck introduced with configurable `HOST`/`PORT` support by defining default `HOST` and `PORT` environment variables in the image.

## Problem

`gunicorn.conf.py` defaults `HOST` and `PORT` when the environment variables are missing:

```python
host = os.getenv("HOST", "0.0.0.0")
port = os.getenv("PORT", "5690")
bind = f"{host}:{port}"
```

However, the Docker healthcheck uses `$PORT` directly:

```dockerfile
CMD ["sh", "-c", "curl -fs http://localhost:$PORT/health || exit 1"]
```

Because the Python defaults do not export environment variables into the container environment, `$PORT` can be empty for the healthcheck. This can cause the container to become unhealthy even though Wizarr is running correctly on port `5690`.

This also affects reverse proxies such as Traefik, which may ignore unhealthy containers and therefore not create the expected router/service (see issue #1329).

## Fix

Define the default bind values at the Docker image level:

```dockerfile
ENV HOST=0.0.0.0
ENV PORT=5690
```

`PORT` is required so the Docker healthcheck and Gunicorn use the same default port.

`HOST` is not directly required for the healthcheck, but defining both defaults in the Dockerfile makes the container-level configuration match the new configurable bind behavior. This keeps the runtime contract clear: the image defaults to binding Wizarr on `0.0.0.0:5690`, while users can still override either value with their own `HOST` or `PORT` environment variables.

`gunicorn.conf.py` still keeps its Python-side defaults as a fallback, but Docker-level consumers such as the healthcheck no longer depend on defaults that only exist inside the Python process.

## Testing

* Built the image
* Started the container without explicitly setting `HOST` or `PORT`
* Confirmed Wizarr listens on `0.0.0.0:5690`
* Confirmed the Docker healthcheck uses port `5690`
* Confirmed the container stays healthy
