### PR TITLE
Fix Docker healthcheck default port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ FROM ghcr.io/astral-sh/uv:python3.13-alpine
 # Set default environment variables for user/group IDs
 ENV PUID=1000
 ENV PGID=1000
+ENV HOST=0.0.0.0
+ENV PORT=5690
 
 # Install runtime dependencies only
 RUN apk add --no-cache curl tzdata su-exec
@@ -77,14 +79,14 @@ ENV APP_VERSION=${APP_VERSION}
 # Set Flask environment to production
 ENV FLASK_ENV=production
 
-# Healthcheck: curl to localhost:$PORT/health
+# Healthcheck: curl to localhost:${PORT:-5690}/health
 # Increased start-period to 60s to account for:
 # - Database migrations
 # - Library scanning
 # - Wizard step imports
 # - Worker initialization (4 workers * ~10s each)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
-  CMD ["sh", "-c", "curl -fs http://localhost:$PORT/health || exit 1"]
+  CMD ["sh", "-c", "curl -fs http://localhost:${PORT:-5690}/health || exit 1"]
 
 # Expose port 5690
 EXPOSE 5690

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).resolve().parents[1] / "Dockerfile"
+
+
+def test_dockerfile_sets_default_bind_port_for_runtime_and_healthcheck():
+    dockerfile = DOCKERFILE.read_text()
+
+    assert "ENV HOST=0.0.0.0" in dockerfile
+    assert "ENV PORT=5690" in dockerfile
+    assert "http://localhost:${PORT:-5690}/health" in dockerfile


### PR DESCRIPTION
Sets default HOST and PORT values in the Docker image and updates the healthcheck to fall back to 5690 when PORT is unset.

This fixes deployments where the app starts on the Gunicorn default port but Docker marks the container unhealthy, causing Traefik to skip it.

Adds a regression test that checks the Dockerfile keeps the runtime defaults and healthcheck fallback aligned.

Validation: pytest tests/test_dockerfile.py, Ruff on tests/test_dockerfile.py, and commit hooks.