### PR TITLE
Release v2026.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wizarr",
-  "version": "2026.7.1",
+  "version": "2026.7.2",
   "description": "Multi-server invitation manager for Plex, Jellyfin, Emby & AudiobookShelf",
   "private": true,
   "scripts": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wizarr"
-version = "2026.7.1"
+version = "2026.7.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -154,7 +154,7 @@ reportUnusedVariable = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2026.7.1"
+version = "2026.7.2"
 version_files = [
     "pyproject.toml:version"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1674,7 +1674,7 @@ wheels = [
 
 [[package]]
 name = "wizarr"
-version = "2026.7.1"
+version = "2026.7.2"
 source = { virtual = "." }
 dependencies = [
     { name = "apprise" },


### PR DESCRIPTION
# 🚀 Stable Release v2026.7.2

## What's Changed

### 🐛 Bug Fixes
- include legacy single-server invites in table filter
- delete invites via explicit delete_id with defensive parsing
- don't disable libraries on a partial or empty scan
- close the Plex OAuth popup so the token isn't lost and the user reaches the wizard
- allow deleting invitations whose code contains whitespace
- invite table server filter never actually filters
- don't delete every local user when Plex returns an empty user list
- stop library scans resetting the invite library defaults

### 🧹 Chores
- 

### 📝 Other Changes
- validate resolved libraries, not raw submitted ids
- stop guessing scan authoritativeness from row counts
- Merge commit from fork
- reject invites whose library picker was opened and then cleared
- extract the shared library-scan upsert into one helper
- apply the empty-remote user-sync guard to every backend


**Full Changelog**: https://github.com/wizarrrr/wizarr/compare/v2026.7.2...v2026.7.2

## 📋 All Commits Included (15 commits)

<details>
<summary>Click to expand commit list</summary>

```
9f1d57fc4 chore: release v2026.7.2
73327ca56 validate resolved libraries, not raw submitted ids
bb02613f5 stop guessing scan authoritativeness from row counts
ea3aaa3bd fix(admin): include legacy single-server invites in table filter
5f5b5e196 fix(admin): delete invites via explicit delete_id with defensive parsing
fdda0263b Merge commit from fork
869df770b fix: don't disable libraries on a partial or empty scan
71de6c39b fix: close the Plex OAuth popup so the token isn't lost and the user reaches the wizard
63872b5a1 reject invites whose library picker was opened and then cleared
cdd83198d extract the shared library-scan upsert into one helper
3497467b2 fix: allow deleting invitations whose code contains whitespace
dc92e5f3d apply the empty-remote user-sync guard to every backend
1e79d2a76 fix: invite table server filter never actually filters
713a8a9d5 fix: don't delete every local user when Plex returns an empty user list
e040ac7d3 fix: stop library scans resetting the invite library defaults
```
</details>

---

## Stable Release

**Merge this PR when**: You're ready for production deployment

**This will**:
- Create GitHub release `v2026.7.2`
- Deploy to production
- Build Docker images with `:latest` and `v2026.7.2` tags
- Notify stakeholders

---

🤖 Auto-generated by CalVer Automation