### PR TITLE
fix(libraries): preserve enabled state on re-scan

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -791,10 +791,11 @@ def invite_scan_libraries():
             fid = str(fid)
             incoming_ids.add(fid)
             if fid in existing_libs:
-                # Update existing row (preserve primary key so invites keep referencing it)
+                # Update existing row (preserve primary key so invites keep referencing it).
+                # Preserve `enabled` — it is the admin's selection and must not be
+                # clobbered by merely opening the invite library picker.
                 lib = existing_libs[fid]
                 lib.name = name
-                lib.enabled = True
             else:
                 # New library - insert
                 lib = Library(

--- a/app/blueprints/media_servers/routes.py
+++ b/app/blueprints/media_servers/routes.py
@@ -180,10 +180,11 @@ def scan_server_libraries(server_id):
         fid_key = str(fid)
         incoming_ids.add(fid_key)
         if fid_key in existing_libs:
-            # Update existing row (preserve primary key so invites keep referencing it)
+            # Update existing row (preserve primary key so invites keep referencing it).
+            # Preserve `enabled` — it is the admin's selection and must not be reset
+            # to True on every re-scan.
             lib = existing_libs[fid_key]
             lib.name = name
-            lib.enabled = True
         else:
             # New library - insert
             lib = Library(

--- a/app/services/library_scanner.py
+++ b/app/services/library_scanner.py
@@ -80,9 +80,11 @@ def scan_all_server_libraries(show_logs: bool = True) -> tuple[int, list[str]]:
                 incoming_ids.add(str(external_id))
                 if external_id in existing_libs:
                     lib = existing_libs[external_id]
-                    # Update mutable attributes while preserving primary key
+                    # Update mutable attributes while preserving primary key.
+                    # Do NOT touch `enabled` — that is the admin's selection and
+                    # must survive re-scans (see edit_server). Only new libraries
+                    # default to enabled below.
                     lib.name = name
-                    lib.enabled = True
                     updated_count += 1
                 else:
                     lib = Library(


### PR DESCRIPTION
Disclosure: This PR was authored with help from Claude Code. It was verified by me, a real human boy, and also tested by me. 

## Problem

Libraries an admin disables (via the "edit server" library checkboxes) get
silently **re-enabled** the next time a library scan runs. This includes:

- App startup (`scan_all_server_libraries`)
- The "Scan Libraries" button on a server's edit page
  (`scan_server_libraries`)
- Simply **opening the invite modal's library picker**
  (`invite_scan_libraries`) — a read/listing action that ends up performing
  a persistent write

### Steps to reproduce
1. Add a media server with multiple libraries.
2. Edit the server, uncheck a couple of libraries, save. Re-open the server
   — the disabled libraries stay disabled. ✅
3. Start creating an invitation and open "select libraries".
4. All libraries are listed and checked, including the ones just disabled. ❌
5. Go back to the server view — the disabled libraries are now enabled again.

## Root cause

The correct save path, `edit_server`
(`app/blueprints/media_servers/routes.py`), respects the admin's checkboxes:

```python
for lib in Library.query.filter_by(server_id=server.id):
    lib.enabled = lib.external_id in chosen
```

But all three scan/upsert routines above unconditionally set
`lib.enabled = True` for every library still present on the remote server,
clobbering that saved state on every scan.

## Fix

In each upsert loop, preserve `enabled` for libraries that already exist;
only default newly-discovered libraries to `enabled=True`. Scans still
correctly refresh names and add/remove libraries — they just no longer
touch the enabled flag of a library that already exists.

## Testing

Verified locally against a real Plex server with multiple libraries:
disabled 2 of 4 libraries, ran a full library scan, confirmed both stayed
disabled and the other two were unaffected. Also verified in the running
app: disable a library → open the invite library picker → the disabled
library is no longer pre-checked / its state is preserved across scans.