### PR TITLE
fix(invite): only offer libraries enabled in server settings

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -791,10 +791,11 @@ def invite_scan_libraries():
             fid = str(fid)
             incoming_ids.add(fid)
             if fid in existing_libs:
-                # Update existing row (preserve primary key so invites keep referencing it)
+                # Update existing row (preserve primary key so invites keep referencing it).
+                # Preserve `enabled` — it is the admin's selection and must not be
+                # clobbered by merely opening the invite library picker.
                 lib = existing_libs[fid]
                 lib.name = name
-                lib.enabled = True
             else:
                 # New library - insert
                 lib = Library(

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -823,8 +823,13 @@ def invite_scan_libraries():
 
         # Flush so the temporary changes are visible for listing
         db.session.flush()
+        # Only offer libraries the admin has enabled in the server's settings —
+        # disabled libraries are intentionally excluded from Wizarr entirely,
+        # not just unchecked by default.
         server_libs[server.id] = (
-            Library.query.filter_by(server_id=server.id).order_by(Library.name).all()
+            Library.query.filter_by(server_id=server.id, enabled=True)
+            .order_by(Library.name)
+            .all()
         )
 
     db.session.commit()

--- a/app/blueprints/media_servers/routes.py
+++ b/app/blueprints/media_servers/routes.py
@@ -180,10 +180,11 @@ def scan_server_libraries(server_id):
         fid_key = str(fid)
         incoming_ids.add(fid_key)
         if fid_key in existing_libs:
-            # Update existing row (preserve primary key so invites keep referencing it)
+            # Update existing row (preserve primary key so invites keep referencing it).
+            # Preserve `enabled` — it is the admin's selection and must not be reset
+            # to True on every re-scan.
             lib = existing_libs[fid_key]
             lib.name = name
-            lib.enabled = True
         else:
             # New library - insert
             lib = Library(

--- a/app/services/library_scanner.py
+++ b/app/services/library_scanner.py
@@ -80,9 +80,11 @@ def scan_all_server_libraries(show_logs: bool = True) -> tuple[int, list[str]]:
                 incoming_ids.add(str(external_id))
                 if external_id in existing_libs:
                     lib = existing_libs[external_id]
-                    # Update mutable attributes while preserving primary key
+                    # Update mutable attributes while preserving primary key.
+                    # Do NOT touch `enabled` — that is the admin's selection and
+                    # must survive re-scans (see edit_server). Only new libraries
+                    # default to enabled below.
                     lib.name = name
-                    lib.enabled = True
                     updated_count += 1
                 else:
                     lib = Library(

--- a/app/templates/partials/server_library_picker.html
+++ b/app/templates/partials/server_library_picker.html
@@ -1,4 +1,8 @@
 {# Render library checkboxes grouped by server #}
+<div class="mb-2 text-xs text-gray-500 dark:text-gray-400"
+     title="{{ _('Go to the server\'s settings and use \'Scan Libraries\' to enable additional libraries.') }}">
+  {{ _("Only libraries enabled in this server's settings are shown here.") }}
+</div>
 {% if servers|length > 1 %}
   <div class="mb-2 text-xs text-gray-500 dark:text-gray-400">
     Libraries are grouped by server. Each library can be selected independently.


### PR DESCRIPTION
Disclosure: I am a real human boy, but I used Claude Code to help make this PR and the description. I tested this personally myself. This PR is based on the assumption that an invite link should only be able to grant an invited user access to libraries that are enabled within the server configuration. This might be an incorrect assumption. It's possible that the server configuration should define the *default* libraries for invitations, but it was ambiguous. This PR is based on ym assumption.

**Body:**
```markdown
## Depends on #1344 
This builds on #1344 (preserve enabled state on re-scan). Without
that fix, disabled libraries would keep getting silently re-enabled, making
this filter meaningless — please merge that one first, or review both
together.
## Problem
The invite library picker lists **every** library on a server, including
ones the admin has explicitly disabled in the server's settings — they just
start out unchecked. This is confusing: there's no other control anywhere
in the app for "available at invite time" vs "enabled at all", so a
disabled library reads as excluded from Wizarr entirely, not merely
unchecked-by-default.
## Fix
- `invite_scan_libraries` now filters to `Library.query.filter_by(server_id=server.id, enabled=True)`
  when building the picker's library list, so disabled libraries don't
  appear at all.
- Added a short hint above the picker (with a tooltip pointing at the
  server's settings) so admins understand why a library might be missing,
  following the existing plain `title="..."` tooltip convention used
  elsewhere in the app (e.g. `tables/invite_card.html`).
## Testing
Verified in the running app: disabled a library in server settings, opened
the invite modal's library picker, confirmed the disabled library no
longer appears in the list and the hint text/tooltip renders correctly.