### PR TITLE
Add optional Emby Connect onboarding

### DIFF
--- a/app/blueprints/api/api_routes.py
+++ b/app/blueprints/api/api_routes.py
@@ -956,6 +956,9 @@ class ServersResource(Resource):
                     "allow_mobile_uploads": getattr(
                         server, "allow_mobile_uploads", False
                     ),
+                    "emby_connect_onboarding": getattr(
+                        server, "emby_connect_onboarding", False
+                    ),
                     "created_at": server.created_at.isoformat()
                     if hasattr(server, "created_at") and server.created_at
                     else None,

--- a/app/blueprints/api/models.py
+++ b/app/blueprints/api/models.py
@@ -220,6 +220,9 @@ server_model = api.model(
         "allow_mobile_uploads": fields.Boolean(
             description="Whether mobile uploads are allowed"
         ),
+        "emby_connect_onboarding": fields.Boolean(
+            description="Whether Emby invites use Emby Connect email onboarding"
+        ),
         "created_at": fields.DateTime(description="Server creation date"),
     },
 )

--- a/app/blueprints/media_servers/routes.py
+++ b/app/blueprints/media_servers/routes.py
@@ -112,6 +112,10 @@ def create_server():
         # Universal options (work for all server types)
         server.allow_downloads = bool(data.get("allow_downloads"))
         server.allow_live_tv = bool(data.get("allow_live_tv"))
+        server.allow_mobile_uploads = bool(data.get("allow_mobile_uploads"))
+        server.emby_connect_onboarding = data.get("server_type") == "emby" and bool(
+            data.get("emby_connect_onboarding")
+        )
         server.verified = True
         db.session.add(server)
         db.session.commit()
@@ -246,6 +250,10 @@ def edit_server(server_id):
         # Universal options (work for all server types)
         server.allow_downloads = bool(data.get("allow_downloads"))
         server.allow_live_tv = bool(data.get("allow_live_tv"))
+        server.allow_mobile_uploads = bool(data.get("allow_mobile_uploads"))
+        server.emby_connect_onboarding = data.get("server_type") == "emby" and bool(
+            data.get("emby_connect_onboarding")
+        )
         # update libraries
         chosen = request.form.getlist("libraries")
         if chosen:

--- a/app/blueprints/public/routes.py
+++ b/app/blueprints/public/routes.py
@@ -1,3 +1,5 @@
+import re
+import secrets
 from pathlib import Path
 
 import requests
@@ -62,6 +64,19 @@ def _apply_safe_media_user_policy(
 
     client.set_policy(user_id, current_policy)
     return permissions
+
+
+def _uses_emby_connect_onboarding(servers: list[MediaServer]) -> bool:
+    return bool(servers) and all(
+        server.server_type == "emby"
+        and bool(getattr(server, "emby_connect_onboarding", False))
+        for server in servers
+    )
+
+
+def _create_emby_connect_credentials(email: str) -> tuple[str, str]:
+    local_part = re.sub(r"[^a-z0-9]+", "", email.split("@", 1)[0])[:12] or "emby"
+    return f"{local_part}{secrets.token_hex(3)}", secrets.token_urlsafe(24)
 
 
 # ─── Landing “/” ──────────────────────────────────────────────────────────────
@@ -350,35 +365,59 @@ def password_prompt(code):
     if plex_server:
         plex_user = User.query.filter_by(code=code, server_id=plex_server.id).first()
 
+    remaining_servers = [s for s in invitation.servers if s.server_type != "plex"]
+    emby_connect_onboarding = _uses_emby_connect_onboarding(remaining_servers)
+
     if request.method == "POST":
-        pw = request.form.get("password") or ""
-        confirm = request.form.get("confirm") or ""
-        if pw != confirm or len(pw) < 8:
+        if emby_connect_onboarding:
+            email = (request.form.get("email") or "").strip().lower()
+            if not re.fullmatch(r"[^@]+@[^@]+\.[^@]+", email):
+                return render_template(
+                    "choose-password.html",
+                    code=code,
+                    emby_connect_onboarding=True,
+                    error="Enter the email address used for your Emby Connect account.",
+                )
+            username, pw = _create_emby_connect_credentials(email)
+        else:
+            pw = request.form.get("password") or ""
+            confirm = request.form.get("confirm") or ""
+            if pw != confirm or len(pw) < 8:
+                return render_template(
+                    "choose-password.html",
+                    code=code,
+                    error="Passwords do not match or too short (8 chars).",
+                )
+
+            # Fallback: generate strong password if checkbox ticked or blank
+            if request.form.get("generate") or pw.strip() == "":
+                import string
+
+                pw = "".join(
+                    secrets.choice(string.ascii_letters + string.digits)
+                    for _ in range(16)
+                )
+
+            # Determine username and email for all account creations
+            if plex_user:
+                username = plex_user.username
+                email = plex_user.email
+            else:
+                # For non-Plex flows, use form data or generate a unique username
+                import uuid
+
+                username = (
+                    request.form.get("username") or f"user-{uuid.uuid4().hex[:8]}"
+                )
+                email = request.form.get("email") or ""
+
+        if emby_connect_onboarding and not email:
             return render_template(
                 "choose-password.html",
                 code=code,
-                error="Passwords do not match or too short (8 chars).",
+                emby_connect_onboarding=emby_connect_onboarding,
+                error="Email address is required.",
             )
-
-        # Fallback: generate strong password if checkbox ticked or blank
-        if request.form.get("generate") or pw.strip() == "":
-            import secrets
-            import string
-
-            pw = "".join(
-                secrets.choice(string.ascii_letters + string.digits) for _ in range(16)
-            )
-
-        # Determine username and email for all account creations
-        if plex_user:
-            username = plex_user.username
-            email = plex_user.email
-        else:
-            # For non-Plex flows, use form data or generate a unique username
-            import uuid
-
-            username = request.form.get("username") or f"user-{uuid.uuid4().hex[:8]}"
-            email = request.form.get("email") or ""
 
         # Create LDAP user if configured
         from app.services.ldap.invitation_ldap import InvitationLDAPHandler
@@ -423,6 +462,12 @@ def password_prompt(code):
                     permissions = _apply_safe_media_user_policy(
                         client, uid, invitation, srv
                     )
+                    if (
+                        srv.server_type == "emby"
+                        and getattr(srv, "emby_connect_onboarding", False)
+                        and hasattr(client, "link_emby_connect_user")
+                    ):
+                        client.link_emby_connect_user(uid, email)
                 elif srv.server_type in ("audiobookshelf", "romm"):
                     uid = client.create_user(username, pw, email=email)
                 else:
@@ -461,7 +506,11 @@ def password_prompt(code):
         return redirect(url_for("wizard.start"))
 
     # GET request – show form
-    return render_template("choose-password.html", code=code)
+    return render_template(
+        "choose-password.html",
+        code=code,
+        emby_connect_onboarding=emby_connect_onboarding,
+    )
 
 
 # ─── Image proxy to allow internal artwork URLs ─────────────────────────────

--- a/app/blueprints/settings/routes.py
+++ b/app/blueprints/settings/routes.py
@@ -38,7 +38,12 @@ def _load_settings() -> dict:
     settings = {s.key: s.value for s in Settings.query.all()}
 
     # Convert specific boolean fields from strings to booleans
-    boolean_fields = ["allow_downloads", "allow_live_tv", "wizard_acl_enabled"]
+    boolean_fields = [
+        "allow_downloads",
+        "allow_live_tv",
+        "emby_connect_onboarding",
+        "wizard_acl_enabled",
+    ]
     for field in boolean_fields:
         if field in settings and settings[field] is not None:
             settings[field] = str(settings[field]).lower() == "true"
@@ -144,6 +149,10 @@ def server_settings():
             existing_server.external_url = data.get("external_url")
             existing_server.allow_downloads = bool(data.get("allow_downloads"))
             existing_server.allow_live_tv = bool(data.get("allow_live_tv"))
+            existing_server.emby_connect_onboarding = (
+                data.get("server_type") == "emby"
+                and bool(data.get("emby_connect_onboarding"))
+            )
             existing_server.verified = True
             db.session.commit()
         else:
@@ -156,6 +165,9 @@ def server_settings():
             server.external_url = data.get("external_url")
             server.allow_downloads = bool(data.get("allow_downloads"))
             server.allow_live_tv = bool(data.get("allow_live_tv"))
+            server.emby_connect_onboarding = data.get("server_type") == "emby" and bool(
+                data.get("emby_connect_onboarding")
+            )
             server.verified = True
             db.session.add(server)
             db.session.commit()

--- a/app/forms/settings.py
+++ b/app/forms/settings.py
@@ -32,6 +32,11 @@ class SettingsForm(FlaskForm):
     allow_live_tv = BooleanField(
         str(_l("Allow Live TV")), default=False, validators=[Optional()]
     )
+    emby_connect_onboarding = BooleanField(
+        str(_l("Use Emby Connect onboarding")),
+        default=False,
+        validators=[Optional()],
+    )
     overseerr_url = StringField(
         str(_l("Overseerr/Ombi URL")), validators=[Optional(), URL()]
     )

--- a/app/models.py
+++ b/app/models.py
@@ -443,6 +443,7 @@ class MediaServer(db.Model):
     allow_downloads = db.Column(db.Boolean, default=False, nullable=False)
     allow_live_tv = db.Column(db.Boolean, default=False, nullable=False)
     allow_mobile_uploads = db.Column(db.Boolean, default=False, nullable=False)
+    emby_connect_onboarding = db.Column(db.Boolean, default=False, nullable=False)
 
     # Whether the connection credentials were validated successfully
     verified = db.Column(db.Boolean, default=False, nullable=False)

--- a/app/services/invitation_flow/workflows.py
+++ b/app/services/invitation_flow/workflows.py
@@ -3,6 +3,8 @@ Simple workflow implementations for invitation flows.
 """
 
 import logging
+import re
+import secrets
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -87,6 +89,7 @@ def _create_join_form_template_data(
         "server_type": server_type,
         "server_name": server_name,
         "servers": servers,
+        "emby_connect_onboarding": _uses_emby_connect_onboarding(servers),
         "gradient_start": colors["gradient_start"],
         "gradient_end": colors["gradient_end"],
         "shadow_color": colors["shadow_color"],
@@ -95,6 +98,39 @@ def _create_join_form_template_data(
     if error:
         context["error"] = error
     return context
+
+
+def _uses_emby_connect_onboarding(servers: list[MediaServer]) -> bool:
+    return bool(servers) and all(
+        server.server_type == "emby"
+        and bool(getattr(server, "emby_connect_onboarding", False))
+        for server in servers
+    )
+
+
+def _create_emby_connect_form_data(
+    form_data: dict[str, Any],
+) -> tuple[bool, dict[str, Any], str | None]:
+    email = (form_data.get("email") or "").strip().lower()
+    if not re.fullmatch(r"[^@]+@[^@]+\.[^@]+", email):
+        return (
+            False,
+            form_data,
+            "Enter the email address used for your Emby Connect account.",
+        )
+
+    local_part = re.sub(r"[^a-z0-9]+", "", email.split("@", 1)[0])[:12] or "emby"
+    password = secrets.token_urlsafe(24)
+    updated = dict(form_data)
+    updated.update(
+        {
+            "username": f"{local_part}{secrets.token_hex(3)}",
+            "email": email,
+            "password": password,
+            "confirm_password": password,
+        }
+    )
+    return True, updated, None
 
 
 class InvitationWorkflow(ABC):
@@ -315,14 +351,30 @@ class FormBasedWorkflow(InvitationWorkflow):
         form_data: dict[str, Any],
     ) -> InvitationResult:
         """Process form submission."""
-        form_valid, validated_data, form = self._validate_join_form(form_data)
-        if not form_valid:
-            return self._create_auth_error_result(
-                invitation,
-                servers,
-                "Please correct the highlighted fields.",
-                form=form,
+        if _uses_emby_connect_onboarding(servers):
+            form_valid, validated_data, error_message = _create_emby_connect_form_data(
+                form_data
             )
+            if not form_valid:
+                from werkzeug.datastructures import MultiDict
+
+                from app.forms.join import JoinForm
+
+                return self._create_auth_error_result(
+                    invitation,
+                    servers,
+                    error_message or "Please correct the highlighted fields.",
+                    form=JoinForm(formdata=MultiDict(form_data)),
+                )
+        else:
+            form_valid, validated_data, form = self._validate_join_form(form_data)
+            if not form_valid:
+                return self._create_auth_error_result(
+                    invitation,
+                    servers,
+                    "Please correct the highlighted fields.",
+                    form=form,
+                )
         form_data = validated_data
 
         # Authenticate
@@ -541,16 +593,21 @@ class MixedWorkflow(InvitationWorkflow):
         if other_servers:
             from app.forms.join import JoinForm
 
-            # Show password form for local servers
+            # Show password or Emby Connect form for local servers
             # Use first local server's colors
             local_server_type = other_servers[0].server_type if other_servers else None
             colors = _get_server_colors(local_server_type)
             form = JoinForm()
             form.code.data = invitation.code
+            emby_connect_onboarding = _uses_emby_connect_onboarding(other_servers)
 
             return InvitationResult(
                 status=ProcessingStatus.AUTHENTICATION_REQUIRED,
-                message="Password required for local servers",
+                message=(
+                    "Emby Connect email required"
+                    if emby_connect_onboarding
+                    else "Password required for local servers"
+                ),
                 successful_servers=[],
                 failed_servers=[],
                 template_data={
@@ -560,6 +617,7 @@ class MixedWorkflow(InvitationWorkflow):
                     "plex_authenticated": True,
                     "plex_token": plex_token,
                     "local_servers": other_servers,
+                    "emby_connect_onboarding": emby_connect_onboarding,
                     "gradient_start": colors["gradient_start"],
                     "gradient_end": colors["gradient_end"],
                     "shadow_color": colors["shadow_color"],
@@ -587,18 +645,25 @@ class MixedWorkflow(InvitationWorkflow):
             # Need Plex OAuth first
             return self.show_initial_form(invitation, servers)
 
-        if other_servers and not form_data.get("password"):
-            # Need password for local servers
+        emby_connect_onboarding = _uses_emby_connect_onboarding(other_servers)
+        required_field = "email" if emby_connect_onboarding else "password"
+        if other_servers and not form_data.get(required_field):
+            # Need password or Emby Connect email for local servers
             return self.show_initial_form(invitation, servers)
 
         if other_servers:
-            form_valid, validated_data, form = self._validate_join_form(form_data)
+            if emby_connect_onboarding:
+                form_valid, validated_data, error_message = (
+                    _create_emby_connect_form_data(form_data)
+                )
+                form = None
+                message = error_message or "Please correct the highlighted fields."
+            else:
+                form_valid, validated_data, form = self._validate_join_form(form_data)
+                message = "Please correct the highlighted fields."
             if not form_valid:
                 return self._create_local_form_error_result(
-                    invitation,
-                    other_servers,
-                    "Please correct the highlighted fields.",
-                    form,
+                    invitation, other_servers, message, form
                 )
             form_data = validated_data
 
@@ -655,6 +720,9 @@ class MixedWorkflow(InvitationWorkflow):
                 "plex_authenticated": True,
                 "plex_token": plex_token,
                 "local_servers": local_servers,
+                "emby_connect_onboarding": _uses_emby_connect_onboarding(
+                    local_servers
+                ),
                 "gradient_start": colors["gradient_start"],
                 "gradient_end": colors["gradient_end"],
                 "shadow_color": colors["shadow_color"],

--- a/app/services/media/emby.py
+++ b/app/services/media/emby.py
@@ -197,6 +197,37 @@ class EmbyClient(JellyfinClient):
         """Return placeholder password for local DB."""
         return "emby-user"
 
+    def link_emby_connect_user(
+        self, user_id: str, connect_username: str | None
+    ) -> None:
+        """Request an Emby Connect link for a local Emby user."""
+        if not connect_username or not EMAIL_RE.fullmatch(connect_username):
+            logging.info(
+                "Skipping Emby Connect link for user %s: no valid Connect email",
+                user_id,
+            )
+            return
+
+        try:
+            response = self.post(
+                f"/Users/{user_id}/Connect/Link",
+                params={"ConnectUsername": connect_username},
+            )
+            result = response.json() if response.content else {}
+            logging.info(
+                "Emby Connect link result for user %s: pending=%s new_invitation=%s",
+                user_id,
+                result.get("IsPending"),
+                result.get("IsNewUserInvitation"),
+            )
+        except Exception as e:
+            logging.warning(
+                "Failed to link Emby Connect account %s for local user %s: %s",
+                connect_username,
+                user_id,
+                e,
+            )
+
     def _set_specific_folders(self, user_id: str, names: list[str]) -> None:
         """Set library access for a user and ensure playback permissions.
 
@@ -316,5 +347,8 @@ class EmbyClient(JellyfinClient):
                 f"Failed to set Emby download/live TV/mobile uploads permissions for user {username}: {e!s}"
             )
             # Don't fail the join process for this
+
+        if getattr(current_server, "emby_connect_onboarding", False):
+            self.link_emby_connect_user(user.token, email)
 
         return success, message

--- a/app/templates/choose-password.html
+++ b/app/templates/choose-password.html
@@ -1,7 +1,7 @@
 {# Password prompt page #}
 {% extends "base.html" %}
 {% block title %}
-  Choose Password
+  {{ _("Connect Emby") if emby_connect_onboarding else _("Choose Password") }}
 {% endblock title %}
 {% block main %}
   <section class="py-5 bg-gray-50 dark:bg-gray-900">
@@ -12,47 +12,70 @@
       <div class="w-full bg-white rounded-lg shadow dark:border dark:bg-gray-800 dark:border-gray-700">
         <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
           <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
-            {{ _("Choose a password for the remaining servers") }}
+            {{ _("Connect Emby") if emby_connect_onboarding else _("Choose a password for the remaining servers") }}
           </h1>
+          {% if emby_connect_onboarding %}
+            <p class="text-sm text-gray-600 dark:text-gray-300">
+              {{ _("Enter your Emby Connect email. Wizarr will create local fallback credentials and send an Emby approval email.") }}
+            </p>
+          {% endif %}
           {% if error %}<div class="text-red-500 text-sm">{{ error }}</div>{% endif %}
           <form class="space-y-4 md:space-y-6" method="post">
             <input type="hidden" name="code" value="{{ code }}" />
-            <div>
-              <label for="password"
-                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Password") }}</label>
-              <input type="password"
-                     name="password"
-                     id="password"
-                     minlength="8"
-                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
-                     required>
-            </div>
-            <div>
-              <label for="confirm"
-                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-                {{ _("Confirm Password") }}
-              </label>
-              <input type="password"
-                     name="confirm"
-                     id="confirm"
-                     minlength="8"
-                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
-                     required>
-            </div>
-            <div class="flex items-center">
-              <input id="generate"
-                     name="generate"
-                     type="checkbox"
-                     value="true"
-                     class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500">
-              <label for="generate"
-                     class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300">
-                {{ _("Generate a strong random password instead") }}
-              </label>
-            </div>
+            {% if emby_connect_onboarding %}
+              <div>
+                <label for="email"
+                       class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                  {{ _("Emby Connect Email") }}
+                </label>
+                <input type="email"
+                       name="email"
+                       id="email"
+                       autocomplete="email"
+                       class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
+                       required>
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                  {{ _("Accept the approval email from Emby after this step, then sign in with Emby Connect.") }}
+                </p>
+              </div>
+            {% else %}
+              <div>
+                <label for="password"
+                       class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Password") }}</label>
+                <input type="password"
+                       name="password"
+                       id="password"
+                       minlength="8"
+                       class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
+                       required>
+              </div>
+              <div>
+                <label for="confirm"
+                       class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                  {{ _("Confirm Password") }}
+                </label>
+                <input type="password"
+                       name="confirm"
+                       id="confirm"
+                       minlength="8"
+                       class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
+                       required>
+              </div>
+              <div class="flex items-center">
+                <input id="generate"
+                       name="generate"
+                       type="checkbox"
+                       value="true"
+                       class="w-4 h-4 text-blue-600 bg-gray-100 rounded border-gray-300 focus:ring-blue-500">
+                <label for="generate"
+                       class="ml-2 text-sm font-medium text-gray-900 dark:text-gray-300">
+                  {{ _("Generate a strong random password instead") }}
+                </label>
+              </div>
+            {% endif %}
             <button type="submit"
                     class="w-full text-white bg-primary hover:bg-primary-dark focus:ring-4 focus:outline-none font-medium rounded-lg text-sm px-5 py-2.5 text-center">
-              {{ _("Continue") }}
+              {{ _("Connect Emby") if emby_connect_onboarding else _("Continue") }}
             </button>
           </form>
         </div>

--- a/app/templates/hybrid-password-form.html
+++ b/app/templates/hybrid-password-form.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 {% block title %}
-  Complete Setup
+  {{ _("Connect Emby") if emby_connect_onboarding else _("Complete Setup") }}
 {% endblock title %}
 {% block og_title %}
   {{ _(server_name) }}
 {% endblock og_title %}
 {% block og_description %}
-  {{ _("Complete your account setup for local servers") }}
+  {{ _("Connect Emby access") if emby_connect_onboarding else _("Complete your account setup for local servers") }}
 {% endblock og_description %}
 {% block main %}
   <section class="bg-white dark:bg-gray-900">
@@ -28,7 +28,7 @@
           <span class="sr-only">Info</span>
           <div>
             <span class="font-medium">{{ _("Plex Authentication Complete!") }}</span>
-            {{ _("Now please set a password for your local server accounts.") }}
+            {{ _("Now connect your Emby account.") if emby_connect_onboarding else _("Now please set a password for your local server accounts.") }}
           </div>
         </div>
       {% endif %}
@@ -69,7 +69,7 @@
       <div class="w-full bg-white rounded-lg shadow-sm dark:border md:mt-0 sm:max-w-md xl:p-0 dark:bg-gray-800 dark:border-gray-700">
         <div class="p-6 space-y-4 md:space-y-6 sm:p-8">
           <h1 class="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl dark:text-white">
-            {{ _("Set Password for Local Servers") }}
+            {{ _("Connect Emby") if emby_connect_onboarding else _("Set Password for Local Servers") }}
           </h1>
           {% if error %}
             <div class="flex items-center p-4 mb-4 text-sm text-red-800 border border-red-300 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 dark:border-red-800"
@@ -87,6 +87,15 @@
               </div>
             </div>
           {% endif %}
+          {% if emby_connect_onboarding %}
+            <div class="flex items-center p-4 mb-4 text-sm text-blue-800 border border-blue-300 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-300 dark:border-blue-800"
+                 role="alert">
+              <div>
+                <span class="font-medium">{{ _("Check your email after this step.") }}</span>
+                {{ _("Wizarr will create local Emby access and send an Emby Connect approval email.") }}
+              </div>
+            </div>
+          {% endif %}
           <form class="space-y-4 md:space-y-6"
                 action="{{ url_for('public.process_invitation') }}"
                 method="post">
@@ -95,71 +104,82 @@
                    name="code"
                    value="{{ form.code.data if form and form.code else code }}">
             <input type="hidden" name="plex_token" value="{{ plex_token }}">
-            <input type="hidden" name="step" value="local_password">
-            <div>
-              <label for="username"
-                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Username") }}</label>
-              <input type="text"
-                     name="username"
-                     id="username"
-                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                     placeholder="{{ _('Your username') }}"
-                     value="{{ form.username.data if form and form.username else '' }}"
-                     required>
-              {% if form and form.username.errors %}
-                {% for error in form.username.errors %}
-                  <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ error }}</p>
-                {% endfor %}
-              {% endif %}
-            </div>
+            <input type="hidden"
+                   name="step"
+                   value="{{ 'emby_connect' if emby_connect_onboarding else 'local_password' }}">
+            {% if not emby_connect_onboarding %}
+              <div>
+                <label for="username"
+                       class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Username") }}</label>
+                <input type="text"
+                       name="username"
+                       id="username"
+                       class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                       placeholder="{{ _('Your username') }}"
+                       value="{{ form.username.data if form and form.username else '' }}"
+                       required>
+                {% if form and form.username.errors %}
+                  {% for error in form.username.errors %}
+                    <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ error }}</p>
+                  {% endfor %}
+                {% endif %}
+              </div>
+            {% endif %}
             <div>
               <label for="email"
                      class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-                {{ _("Email Address") }}
+                {{ _("Emby Connect Email") if emby_connect_onboarding else _("Email Address") }}
               </label>
               <input type="email"
                      name="email"
                      id="email"
                      class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                     placeholder="{{ _('your.email@example.com') }}"
+                     placeholder="{{ _('you@example.com') if emby_connect_onboarding else _('your.email@example.com') }}"
                      value="{{ form.email.data if form and form.email else '' }}"
                      required>
               {% if form and form.email.errors %}
                 {% for error in form.email.errors %}<p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ error }}</p>{% endfor %}
               {% endif %}
-            </div>
-            <div>
-              <label for="password"
-                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Password") }}</label>
-              <input type="password"
-                     name="password"
-                     id="password"
-                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                     placeholder="{{ _('Your password') }}"
-                     required>
-              {% if form and form.password.errors %}
-                {% for error in form.password.errors %}
-                  <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ error }}</p>
-                {% endfor %}
+              {% if emby_connect_onboarding %}
+                <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                  {{ _("Use the same email you use for Emby Connect, then accept the approval email from Emby.") }}
+                </p>
               {% endif %}
             </div>
-            <div>
-              <label for="confirm_password"
-                     class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
-                {{ _("Confirm Password") }}
-              </label>
-              <input type="password"
-                     name="confirm_password"
-                     id="confirm_password"
-                     class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                     placeholder="{{ _('Confirm your password') }}"
-                     required>
-              {% if form and form.confirm_password.errors %}
-                {% for error in form.confirm_password.errors %}
-                  <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ error }}</p>
-                {% endfor %}
-              {% endif %}
-            </div>
+            {% if not emby_connect_onboarding %}
+              <div>
+                <label for="password"
+                       class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">{{ _("Password") }}</label>
+                <input type="password"
+                       name="password"
+                       id="password"
+                       class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                       placeholder="{{ _('Your password') }}"
+                       required>
+                {% if form and form.password.errors %}
+                  {% for error in form.password.errors %}
+                    <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ error }}</p>
+                  {% endfor %}
+                {% endif %}
+              </div>
+              <div>
+                <label for="confirm_password"
+                       class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                  {{ _("Confirm Password") }}
+                </label>
+                <input type="password"
+                       name="confirm_password"
+                       id="confirm_password"
+                       class="bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                       placeholder="{{ _('Confirm your password') }}"
+                       required>
+                {% if form and form.confirm_password.errors %}
+                  {% for error in form.confirm_password.errors %}
+                    <p class="mt-2 text-sm text-red-600 dark:text-red-500">{{ error }}</p>
+                  {% endfor %}
+                {% endif %}
+              </div>
+            {% endif %}
             <div class="flex items-start">
               <div class="flex items-center h-5">
                 <input id="agree"
@@ -181,7 +201,7 @@
             <button type="submit"
                     id="setup-submit-btn"
                     class="w-full text-white bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800 disabled:opacity-50 disabled:cursor-not-allowed">
-              <span id="setup-btn-text">{{ _("Complete Setup") }}</span>
+              <span id="setup-btn-text">{{ _("Connect Emby") if emby_connect_onboarding else _("Complete Setup") }}</span>
               <span id="setup-btn-loading" class="hidden">
                 <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white inline"
                      xmlns="http://www.w3.org/2000/svg"
@@ -200,7 +220,9 @@
             <h3 class="text-sm font-medium text-gray-900 dark:text-white mb-2">{{ _("What happens next?") }}</h3>
             <ul class="text-sm text-gray-600 dark:text-gray-300 space-y-1">
               <li>• {{ _("Your Plex account is already set up and ready to use") }}</li>
-              <li>• {{ _("This password will be used to create accounts on your local servers") }}</li>
+              <li>
+                • {{ _("Accept the Emby Connect approval email to finish linking") if emby_connect_onboarding else _("This password will be used to create accounts on your local servers") }}
+              </li>
               <li>• {{ _("You'll be redirected to the setup wizard to complete configuration") }}</li>
             </ul>
           </div>

--- a/app/templates/modals/create-server.html
+++ b/app/templates/modals/create-server.html
@@ -110,6 +110,21 @@
                   <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Allow Mobile Uploads</span>
                 </label>
               </div>
+              <div id="emby-connect-onboarding-option" class="mt-2">
+                <label class="inline-flex items-center cursor-pointer">
+                  <input id="emby_connect_onboarding"
+                         name="emby_connect_onboarding"
+                         type="checkbox"
+                         value="true"
+                         class="sr-only peer">
+                  <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary dark:peer-focus:ring-primary rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary dark:peer-checked:bg-primary">
+                  </div>
+                  <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Use Emby Connect onboarding</span>
+                </label>
+                <p class="ms-14 mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  Invitees enter their Emby Connect email; Wizarr creates local fallback credentials and sends the Emby link request.
+                </p>
+              </div>
             </div>
             <div id="romm-options" style="display:none;">
               <div>
@@ -195,6 +210,11 @@
         const allowMobileUploadsOption = document.getElementById('allow-mobile-uploads-option');
         if (allowMobileUploadsOption) {
             allowMobileUploadsOption.style.display = ['plex', 'emby'].includes(type) ? 'block' : 'none';
+        }
+
+        const embyConnectOnboardingOption = document.getElementById('emby-connect-onboarding-option');
+        if (embyConnectOnboardingOption) {
+            embyConnectOnboardingOption.style.display = type === 'emby' ? 'block' : 'none';
         }
 
         document.getElementById('romm-options').style.display = type === 'romm' ? 'block' : 'none';

--- a/app/templates/modals/edit-server.html
+++ b/app/templates/modals/edit-server.html
@@ -136,6 +136,22 @@
                   <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Allow Mobile Uploads</span>
                 </label>
               </div>
+              <div id="emby-connect-onboarding-option-edit" class="mt-2">
+                <label class="inline-flex items-center cursor-pointer">
+                  <input id="emby_connect_onboarding"
+                         name="emby_connect_onboarding"
+                         type="checkbox"
+                         value="true"
+                         {% if server.emby_connect_onboarding %}checked{% endif %}
+                         class="sr-only peer">
+                  <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary dark:peer-focus:ring-primary rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary dark:peer-checked:bg-primary">
+                  </div>
+                  <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Use Emby Connect onboarding</span>
+                </label>
+                <p class="ms-14 mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  Invitees enter their Emby Connect email; Wizarr creates local fallback credentials and sends the Emby link request.
+                </p>
+              </div>
             </div>
             <div class="mt-4">
               <button hx-post="{{ url_for('media_servers.scan_server_libraries', server_id=server.id) }}"
@@ -205,6 +221,11 @@
         const allowMobileUploadsOption = document.getElementById('allow-mobile-uploads-option-edit');
         if (allowMobileUploadsOption) {
             allowMobileUploadsOption.style.display = ['plex', 'emby'].includes(type) ? 'block' : 'none';
+        }
+
+        const embyConnectOnboardingOption = document.getElementById('emby-connect-onboarding-option-edit');
+        if (embyConnectOnboardingOption) {
+            embyConnectOnboardingOption.style.display = type === 'emby' ? 'block' : 'none';
         }
 
         document.getElementById('romm-options').style.display = type === 'romm' ? 'block' : 'none';

--- a/app/templates/welcome-jellyfin.html
+++ b/app/templates/welcome-jellyfin.html
@@ -91,8 +91,12 @@
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
                 </svg>
               </button>
-              <h2 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-1">{{ _("Create Account") }}</h2>
-              <p class="text-gray-600 dark:text-gray-400 text-xs md:text-sm">{{ _("Set up your magical account") }}</p>
+              <h2 class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-1">
+                {{ _("Connect Emby") if emby_connect_onboarding else _("Create Account") }}
+              </h2>
+              <p class="text-gray-600 dark:text-gray-400 text-xs md:text-sm">
+                {{ _("Enter your Emby Connect email") if emby_connect_onboarding else _("Set up your magical account") }}
+              </p>
             </div>
             <!-- Form container with error and form content -->
             <div class="flex-1 flex flex-col justify-center px-6 pb-4">
@@ -101,26 +105,41 @@
                   <p class="text-red-600 dark:text-red-400 text-xs font-medium">{{ error }}</p>
                 </div>
               {% endif %}
+              {% if emby_connect_onboarding %}
+                <div class="bg-blue-100 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-500/50 rounded-lg p-2 mb-3">
+                  <p class="text-blue-700 dark:text-blue-300 text-xs font-medium">
+                    {{ _("Wizarr will create a local Emby account and send an Emby Connect link request. Accept the approval email from Emby, then sign in with Emby Connect.") }}
+                  </p>
+                </div>
+              {% endif %}
               <form class="space-y-3 md:space-y-4"
                     action="{{ url_for('public.process_invitation') }}"
                     method="post">
                 {{ form.hidden_tag() }}
-                <div class="form-field" data-field="1" style="{{ form_field_style }}">
-                  <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    <svg class="w-3 h-3 inline mr-1"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z">
-                      </path>
-                    </svg>
-                    {{ _("Username") }}
-                  </label>
-                  {{ form.username(class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm",
-                                    placeholder=_("Enter your username") 
-                  ) }}
-                  {% for err in form.username.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
-                </div>
+                {% if emby_connect_onboarding %}
+                  <input type="hidden" name="code" value="{{ form.code.data }}">
+                {% else %}
+                  <div class="form-field" data-field="1" style="{{ form_field_style }}">
+                    <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      <svg class="w-3 h-3 inline mr-1"
+                           fill="none"
+                           stroke="currentColor"
+                           viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z">
+                        </path>
+                      </svg>
+                      {{ _("Username") }}
+                    </label>
+                    <input type="text"
+                           name="username"
+                           id="username"
+                           class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm"
+                           placeholder="{{ _('Enter your username') }}"
+                           value="{{ form.username.data if form and form.username else '' }}"
+                           required>
+                    {% for err in form.username.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
+                  </div>
+                {% endif %}
                 <div class="form-field" data-field="2" style="{{ form_field_style }}">
                   <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     <svg class="w-3 h-3 inline mr-1"
@@ -130,67 +149,83 @@
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 3.26a2 2 0 001.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
                       </path>
                     </svg>
-                    {{ _("Email") }}
+                    {{ _("Emby Connect Email") if emby_connect_onboarding else _("Email") }}
                   </label>
-                  {{ form.email(class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm",
-                                    placeholder=_("Enter your email") 
-                  ) }}
+                  <input type="email"
+                         name="email"
+                         id="email"
+                         class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm"
+                         placeholder="{{ _('Enter your Emby Connect email') if emby_connect_onboarding else _('Enter your email') }}"
+                         value="{{ form.email.data if form and form.email else '' }}"
+                         required>
                   {% for err in form.email.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
                 </div>
-                <div class="form-field" data-field="3" style="{{ form_field_style }}">
-                  <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    <svg class="w-3 h-3 inline mr-1"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z">
-                      </path>
-                    </svg>
-                    {{ _("Password") }}
-                  </label>
-                  {{ form.password(class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm",
-                                    placeholder=_("Create a password") 
-                  ) }}
-                  {% for err in form.password.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
-                </div>
-                <div class="form-field" data-field="4" style="{{ form_field_style }}">
-                  <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    <svg class="w-3 h-3 inline mr-1"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z">
-                      </path>
-                    </svg>
-                    {{ _("Confirm Password") }}
-                  </label>
-                  {{ form.confirm_password(class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm",
-                                    placeholder=_("Confirm your password") 
-                  ) }}
-                  {% for err in form.confirm_password.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
-                </div>
-                <div class="form-field" data-field="5" style="{{ form_field_style }}">
-                  <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    <svg class="w-3 h-3 inline mr-1"
-                         fill="none"
-                         stroke="currentColor"
-                         viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1721 9z">
-                      </path>
-                    </svg>
-                    {{ _("Invite Code") }}
-                  </label>
-                  {{ form.code(class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm",
-                                    placeholder=_("Enter invite code") 
-                  ) }}
-                  {% for err in form.code.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
-                </div>
+                {% if not emby_connect_onboarding %}
+                  <div class="form-field" data-field="3" style="{{ form_field_style }}">
+                    <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      <svg class="w-3 h-3 inline mr-1"
+                           fill="none"
+                           stroke="currentColor"
+                           viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z">
+                        </path>
+                      </svg>
+                      {{ _("Password") }}
+                    </label>
+                    <input type="password"
+                           name="password"
+                           id="password"
+                           class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm"
+                           placeholder="{{ _('Create a password') }}"
+                           required>
+                    {% for err in form.password.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
+                  </div>
+                  <div class="form-field" data-field="4" style="{{ form_field_style }}">
+                    <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      <svg class="w-3 h-3 inline mr-1"
+                           fill="none"
+                           stroke="currentColor"
+                           viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z">
+                        </path>
+                      </svg>
+                      {{ _("Confirm Password") }}
+                    </label>
+                    <input type="password"
+                           name="confirm_password"
+                           id="confirm_password"
+                           class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm"
+                           placeholder="{{ _('Confirm your password') }}"
+                           required>
+                    {% for err in form.confirm_password.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
+                  </div>
+                  <div class="form-field" data-field="5" style="{{ form_field_style }}">
+                    <label class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      <svg class="w-3 h-3 inline mr-1"
+                           fill="none"
+                           stroke="currentColor"
+                           viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1721 9z">
+                        </path>
+                      </svg>
+                      {{ _("Invite Code") }}
+                    </label>
+                    <input type="text"
+                           name="code"
+                           id="code"
+                           class="w-full px-3 py-2 bg-white/80 dark:bg-gray-700/50 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent backdrop-blur-sm transition-all duration-200 text-sm"
+                           placeholder="{{ _('Enter invite code') }}"
+                           value="{{ form.code.data if form and form.code else '' }}"
+                           required>
+                    {% for err in form.code.errors %}<p class="text-red-400 text-xs mt-1">{{ err }}</p>{% endfor %}
+                  </div>
+                {% endif %}
                 <button type="submit"
                         id="submit-btn"
                         class="w-full py-3 px-4 text-white font-semibold text-sm bg-gradient-to-r from-primary to-primary_hover hover:from-primary_hover hover:to-primary rounded-lg transition-all duration-200 transform hover:scale-[1.02] focus:ring-4 focus:ring-primary/30 focus:outline-none shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed form-field"
                         data-field="6"
                         style="{{ form_field_style }}">
-                  <span id="btn-text">{{ _("Create Account") }}</span>
+                  <span id="btn-text">{{ _("Connect Emby") if emby_connect_onboarding else _("Create Account") }}</span>
                   <span id="btn-loading" class="hidden">
                     <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white inline"
                          xmlns="http://www.w3.org/2000/svg"

--- a/migrations/versions/20260713_add_emby_connect_onboarding.py
+++ b/migrations/versions/20260713_add_emby_connect_onboarding.py
@@ -1,0 +1,33 @@
+"""Add Emby Connect onboarding option
+
+Revision ID: 20260713_emby_connect
+Revises: 20260401_repair
+Create Date: 2026-07-13 11:45:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260713_emby_connect"
+down_revision = "20260401_repair"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("media_server", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "emby_connect_onboarding",
+                sa.Boolean(),
+                nullable=False,
+                server_default="0",
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("media_server", schema=None) as batch_op:
+        batch_op.drop_column("emby_connect_onboarding")

--- a/tests/test_emby_library_policy.py
+++ b/tests/test_emby_library_policy.py
@@ -18,6 +18,7 @@ class _Response:
     def __init__(self, payload):
         self._payload = payload
         self.status_code = 200
+        self.content = b"{}"
 
     def json(self):
         return self._payload
@@ -100,3 +101,37 @@ def test_emby_set_specific_folders_maps_name_to_guid():
     assert client.policy_updates[0][1]["EnabledFolders"] == [
         "2a97f52972644bc2b7b52b0c9c0e9053"
     ]
+
+
+def test_emby_connect_link_posts_connect_username():
+    client = _emby_client()
+    captured = {}
+
+    def post(endpoint, params=None):
+        captured["endpoint"] = endpoint
+        captured["params"] = params
+        return _Response({"IsPending": True, "IsNewUserInvitation": False})
+
+    client.post = post
+
+    client.link_emby_connect_user("emby-user-1", "viewer@example.com")
+
+    assert captured == {
+        "endpoint": "/Users/emby-user-1/Connect/Link",
+        "params": {"ConnectUsername": "viewer@example.com"},
+    }
+
+
+def test_emby_connect_link_skips_invalid_email():
+    client = _emby_client()
+    called = False
+
+    def post(endpoint, params=None):
+        nonlocal called
+        called = True
+
+    client.post = post
+
+    client.link_emby_connect_user("emby-user-1", "not-an-email")
+
+    assert called is False

--- a/tests/test_invitation_flow.py
+++ b/tests/test_invitation_flow.py
@@ -432,6 +432,72 @@ class TestFormBasedWorkflow:
         mock_strategy_factory.create_strategy.assert_not_called()
         mock_process.assert_not_called()
 
+    def test_emby_connect_onboarding_generates_local_credentials(self, app):
+        """Emby Connect mode only requires email and creates hidden credentials."""
+        workflow = FormBasedWorkflow()
+
+        mock_invitation = Mock()
+        mock_invitation.code = "TEST123"
+        mock_invitation.wizard_bundle_id = None
+
+        mock_server = Mock()
+        mock_server.server_type = "emby"
+        mock_server.emby_connect_onboarding = True
+
+        with (
+            patch.object(workflow, "_process_servers") as mock_process,
+            app.test_request_context(),
+        ):
+            mock_server_result = Mock()
+            mock_server_result.server.name = "Emby"
+            mock_server_result.message = "Success"
+            mock_process.return_value = ([mock_server_result], [])
+
+            result = workflow.process_submission(
+                mock_invitation,
+                [mock_server],
+                {"code": "TEST123", "email": "Viewer@Example.COM"},
+            )
+
+        assert result.status == ProcessingStatus.SUCCESS
+        processed_data = mock_process.call_args.args[1]
+        assert processed_data["email"] == "viewer@example.com"
+        assert processed_data["username"].startswith("viewer")
+        assert len(processed_data["username"]) > len("viewer")
+        assert processed_data["password"]
+        assert processed_data["confirm_password"] == processed_data["password"]
+
+    def test_emby_connect_onboarding_rejects_invalid_email(self, app):
+        workflow = FormBasedWorkflow()
+
+        mock_invitation = Mock()
+        mock_invitation.code = "TEST123"
+        mock_invitation.wizard_bundle_id = None
+
+        mock_server = Mock()
+        mock_server.server_type = "emby"
+        mock_server.emby_connect_onboarding = True
+
+        with (
+            patch.object(workflow, "_process_servers") as mock_process,
+            app.test_request_context(),
+        ):
+            result = workflow.process_submission(
+                mock_invitation,
+                [mock_server],
+                {"code": "TEST123", "email": "not-an-email"},
+            )
+
+        assert result.status == ProcessingStatus.FAILURE
+        assert "Emby Connect" in result.message
+        assert result.template_data is not None
+        rendered = render_template(
+            result.template_data["template_name"], **result.template_data
+        )
+        assert 'name="email"' in rendered
+        assert 'name="password"' not in rendered
+        mock_process.assert_not_called()
+
 
 class TestMixedWorkflow:
     """Test MixedWorkflow"""
@@ -467,6 +533,37 @@ class TestMixedWorkflow:
 
             assert 'name="code"' in rendered
             assert 'value="MIXED123"' in rendered
+
+    def test_show_emby_connect_form_for_enabled_mixed_emby(self, app):
+        workflow = MixedWorkflow()
+
+        mock_invitation = Mock()
+        mock_invitation.code = "MIXED123"
+
+        mock_plex_server = Mock()
+        mock_plex_server.server_type = "plex"
+        mock_emby_server = Mock()
+        mock_emby_server.server_type = "emby"
+        mock_emby_server.emby_connect_onboarding = True
+        mock_emby_server.name = "Emby"
+
+        with app.test_request_context():
+            session["plex_oauth_token"] = "plex-token"
+
+            result = workflow.show_initial_form(
+                mock_invitation, [mock_plex_server, mock_emby_server]
+            )
+
+            assert result.template_data is not None
+            assert result.template_data["emby_connect_onboarding"] is True
+
+            rendered = render_template(
+                result.template_data["template_name"], **result.template_data
+            )
+
+            assert 'name="email"' in rendered
+            assert 'name="password"' not in rendered
+            assert 'name="confirm_password"' not in rendered
 
 
 class TestIntegrationWithDatabase:

--- a/tests/test_multiserver_media_policy.py
+++ b/tests/test_multiserver_media_policy.py
@@ -16,6 +16,7 @@ class PolicyCapturingClient:
     def __init__(self):
         self.user_id = "emby-user-1"
         self.policy_updates = []
+        self.emby_connect_links = []
 
     def create_user(self, username, password):
         return self.user_id
@@ -42,6 +43,9 @@ class PolicyCapturingClient:
     def set_policy(self, user_id, policy):
         assert user_id == self.user_id
         self.policy_updates.append(policy)
+
+    def link_emby_connect_user(self, user_id, email):
+        self.emby_connect_links.append((user_id, email))
 
 
 def _complete_setup():
@@ -84,7 +88,6 @@ def test_password_prompt_applies_safe_emby_policy(client, session):
             "/j/EMBYPOLICY/password",
             data={
                 "username": "viewer",
-                "email": "viewer@example.com",
                 "password": "password123",
                 "confirm": "password123",
             },
@@ -103,3 +106,47 @@ def test_password_prompt_applies_safe_emby_policy(client, session):
     assert policy["AllowSharingPersonalItems"] is False
     assert policy["EnableSubtitleManagement"] is False
     assert policy["EnableRemoteControlOfOtherUsers"] is False
+
+
+def test_password_prompt_emby_connect_onboarding_uses_email_only(client, session):
+    _complete_setup()
+    server = MediaServer(
+        name="Emby",
+        server_type="emby",
+        url="http://emby.local",
+        api_key="emby-key",
+        emby_connect_onboarding=True,
+    )
+    invitation = Invitation(
+        code="EMBYCONN",
+        used=False,
+        unlimited=True,
+        allow_downloads=False,
+        allow_live_tv=False,
+        allow_mobile_uploads=False,
+    )
+    invitation.servers = [server]
+    db.session.add_all([server, invitation])
+    db.session.commit()
+
+    get_response = client.get("/j/EMBYCONN/password")
+    assert get_response.status_code == 200
+    assert b'name="email"' in get_response.data
+    assert b'name="password"' not in get_response.data
+    assert b'name="confirm"' not in get_response.data
+
+    media_client = PolicyCapturingClient()
+
+    with patch(
+        "app.services.media.service.get_client_for_media_server",
+        return_value=media_client,
+    ):
+        response = client.post(
+            "/j/EMBYCONN/password",
+            data={"email": "Viewer@Example.COM"},
+        )
+
+    assert response.status_code == 302
+    assert media_client.emby_connect_links == [
+        ("emby-user-1", "viewer@example.com")
+    ]


### PR DESCRIPTION
## Summary
- add an opt-in Emby server setting for Emby Connect email onboarding
- create local fallback credentials internally, apply existing safe Emby policy, then request the Emby Connect link
- support the single-server, mixed Plex+Emby, and legacy password continuation invite paths
- expose/persist the setting in media server UI, settings/API, and database migration

## Testing
- uv run pytest tests/test_emby_library_policy.py tests/test_invitation_flow.py tests/test_multiserver_media_policy.py tests/test_api_restx.py tests/test_api_comprehensive_deprecated.py -q
- uv run djlint app/templates --check --profile=jinja
- uv run ruff check app tests && git diff --check
- uv run python -m py_compile app/models.py app/forms/settings.py app/blueprints/settings/routes.py app/blueprints/media_servers/routes.py app/blueprints/api/api_routes.py app/blueprints/api/models.py app/services/media/emby.py app/services/invitation_flow/workflows.py app/blueprints/public/routes.py