### PR TITLE
fix(media-servers): preserve library selection across re-scans

### DIFF
--- a/app/blueprints/media_servers/routes.py
+++ b/app/blueprints/media_servers/routes.py
@@ -180,10 +180,11 @@ def scan_server_libraries(server_id):
         fid_key = str(fid)
         incoming_ids.add(fid_key)
         if fid_key in existing_libs:
-            # Update existing row (preserve primary key so invites keep referencing it)
+            # Update existing row (preserve primary key so invites keep referencing it).
+            # Deliberately leave `enabled` untouched: it holds the admin's selection,
+            # and re-enabling here would silently undo any deselection on every scan.
             lib = existing_libs[fid_key]
             lib.name = name
-            lib.enabled = True
         else:
             # New library - insert
             lib = Library(

--- a/tests/test_library_scanning.py
+++ b/tests/test_library_scanning.py
@@ -192,3 +192,67 @@ def test_api_libraries_scan_failure_continues(client, api_key, test_server):
 
         # Should have tried to scan servers
         assert mock_scan.call_count >= 2
+
+
+def _login(client, admin_id):
+    """Establish a Flask-Login session for the given admin account."""
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(admin_id)
+        sess["_fresh"] = True
+
+
+def test_rescan_preserves_disabled_libraries(client, test_server):
+    """A re-scan must not silently re-enable libraries the admin deselected.
+
+    Regression test: scan_server_libraries() used to set ``enabled = True`` on
+    every library returned by the media server, on every scan. Because the
+    library checkbox partial renders ``{% if lib.enabled %}checked{% endif %}``,
+    that quietly undid the admin's selection each time they re-scanned.
+    """
+    with client.application.app_context():
+        Library.query.delete()
+        db.session.commit()
+
+        server = MediaServer.query.filter_by(name="Test Server").first()
+        db.session.add_all(
+            [
+                Library(
+                    external_id="lib1",
+                    name="Movies",
+                    server_id=server.id,
+                    enabled=True,
+                ),
+                Library(
+                    external_id="lib2",
+                    name="TV Shows",
+                    server_id=server.id,
+                    enabled=False,  # admin deselected this one
+                ),
+            ]
+        )
+        db.session.commit()
+
+        admin = AdminAccount.query.filter_by(username="testadmin").first()
+        admin_id, server_id = admin.id, server.id
+
+    _login(client, admin_id)
+
+    # The server still reports both libraries on the next scan.
+    with patch(
+        "app.blueprints.media_servers.routes.scan_libraries_for_server"
+    ) as mock_scan:
+        mock_scan.return_value = {"lib1": "Movies", "lib2": "TV Shows"}
+
+        response = client.post(f"/settings/servers/{server_id}/scan-libraries")
+        assert response.status_code == 200
+
+    with client.application.app_context():
+        enabled_by_ext = {
+            lib.external_id: lib.enabled
+            for lib in Library.query.filter_by(server_id=server_id).all()
+        }
+
+    assert enabled_by_ext["lib1"] is True, "selected library should stay selected"
+    assert enabled_by_ext["lib2"] is False, (
+        "deselected library must stay deselected across a re-scan"
+    )


### PR DESCRIPTION
### What's wrong

`scan_server_libraries()` sets `lib.enabled = True` on every library returned by the media server, on every scan:

https://github.com/wizarrrr/wizarr/blob/main/app/blueprints/media_servers/routes.py#L182-L186

`partials/library_checkboxes.html` renders `{% if lib.enabled %}checked{% endif %}`, so `enabled` *is* the admin's selection state. The result is that re-scanning a server silently re-selects every library the admin had deselected.

### Steps to reproduce

1. Add a media server and scan its libraries.
2. Deselect one or more libraries and save.
3. Scan libraries again on that server.
4. Every library is selected again — the earlier deselection is gone.

### Why this looks like a bug rather than intent

The rest of the same blueprint treats `enabled` as admin state, not scan state:

- `update_server()` computes `lib.enabled = lib.external_id in chosen`
- `create_server()` only enables libraries the admin explicitly picked

Only the scan path forces `enabled = True` unconditionally.

### The change

Leave `enabled` alone when updating an existing row. Two behaviours are deliberately unchanged:

- newly discovered libraries still default to `enabled=True`
- libraries that disappear from the server but are still referenced by an invitation are still set to `enabled=False`

### Tests

Adds `test_rescan_preserves_disabled_libraries` to `tests/test_library_scanning.py`, asserting a deselected library survives a re-scan. Verified it **fails before** this change and **passes after**.

`tests/test_library_scanning.py`, `test_invite_library_picker.py`, `test_emby_library_policy.py` and `test_multiserver_media_policy.py` all pass (12 tests).

Note: `tests/test_invite_code_manager.py::TestInviteCodeValidation::test_validate_expired_invitation` fails on `main` independently of this change — unrelated, left alone.
