### PR TITLE
fix: library scan defaults, plus scan-handler dedup and empty-invite guard

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -792,9 +792,10 @@ def invite_scan_libraries():
             incoming_ids.add(fid)
             if fid in existing_libs:
                 # Update existing row (preserve primary key so invites keep referencing it)
+                # `enabled` is the admin's saved default for new invites and is what
+                # the checkbox partial renders from, so it must survive a rescan.
                 lib = existing_libs[fid]
                 lib.name = name
-                lib.enabled = True
             else:
                 # New library - insert
                 lib = Library(

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -39,6 +39,7 @@ from app.services.media.service import (
     list_users_all_servers,
     list_users_for_server,
     scan_libraries_for_server,
+    upsert_scanned_libraries,
 )
 from app.services.update_check import (
     check_update_available,
@@ -756,7 +757,7 @@ def update_user_libraries(db_id: int):
 def invite_scan_libraries():
     """Scan libraries for one or multiple selected servers and return grouped checkboxes."""
 
-    from app.models import Library, MediaServer, invite_libraries
+    from app.models import Library, MediaServer
 
     # Accept either multi-select checkboxes (server_ids) or legacy single server_id
     ids = request.form.getlist("server_ids") or []
@@ -775,51 +776,13 @@ def invite_scan_libraries():
     for server in servers:
         try:
             raw = scan_libraries_for_server(server)
-            items = raw.items() if isinstance(raw, dict) else [(n, n) for n in raw]
         except Exception as exc:
             logging.warning("Library scan failed for %s: %s", server.name, exc)
-            items = []
+            raw = []
 
-        # Upsert libraries: update existing rows, insert new ones, and preserve invite associations.
-        existing_libs = {
-            lib.external_id: lib
-            for lib in Library.query.filter_by(server_id=server.id).all()
-        }
-
-        incoming_ids: set[str] = set()
-        for fid, name in items:
-            fid = str(fid)
-            incoming_ids.add(fid)
-            if fid in existing_libs:
-                # Update existing row (preserve primary key so invites keep referencing it)
-                # `enabled` is the admin's saved default for new invites and is what
-                # the checkbox partial renders from, so it must survive a rescan.
-                lib = existing_libs[fid]
-                lib.name = name
-            else:
-                # New library - insert
-                lib = Library(
-                    external_id=fid,
-                    name=name,
-                    server_id=server.id,
-                    enabled=True,
-                )
-                db.session.add(lib)
-
-        # Handle libraries that used to exist but weren't returned by the server
-        for ext, lib in existing_libs.items():
-            if ext not in incoming_ids:
-                # If this library is referenced by any invitation, disable it to preserve associations
-                referenced = db.session.execute(
-                    invite_libraries.select().where(
-                        invite_libraries.c.library_id == lib.id
-                    )
-                ).first()
-                if referenced:
-                    lib.enabled = False
-                else:
-                    # Safe to remove since no invites reference it
-                    db.session.delete(lib)
+        # Upsert scanned libraries, preserving each row's enabled flag (the admin's
+        # saved default, rendered by the checkbox partial) and invite associations.
+        upsert_scanned_libraries(server, raw)
 
         # Flush so the temporary changes are visible for listing
         db.session.flush()

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -775,14 +775,14 @@ def invite_scan_libraries():
 
     for server in servers:
         try:
-            raw = scan_libraries_for_server(server)
+            raw, authoritative = scan_libraries_for_server(server)
         except Exception as exc:
             logging.warning("Library scan failed for %s: %s", server.name, exc)
-            raw = []
+            raw, authoritative = [], False
 
         # Upsert scanned libraries, preserving each row's enabled flag (the admin's
         # saved default, rendered by the checkbox partial) and invite associations.
-        upsert_scanned_libraries(server, raw)
+        upsert_scanned_libraries(server, raw, authoritative=authoritative)
 
         # Flush so the temporary changes are visible for listing
         db.session.flush()

--- a/app/blueprints/api/api_routes.py
+++ b/app/blueprints/api/api_routes.py
@@ -867,7 +867,7 @@ class LibrariesResource(Resource):
                         logger.info(f"Scanning libraries for server {server.name}")
                         from app.services.media.service import scan_libraries_for_server
 
-                        library_data = scan_libraries_for_server(server)
+                        library_data, _ = scan_libraries_for_server(server)
 
                         # Create Library records for each scanned library
                         for external_id, name in library_data.items():

--- a/app/blueprints/media_servers/routes.py
+++ b/app/blueprints/media_servers/routes.py
@@ -181,9 +181,10 @@ def scan_server_libraries(server_id):
         incoming_ids.add(fid_key)
         if fid_key in existing_libs:
             # Update existing row (preserve primary key so invites keep referencing it)
+            # `enabled` is the admin's saved selection; this scan runs when the edit
+            # form OPENS, so resetting it here wiped the checkboxes being rendered.
             lib = existing_libs[fid_key]
             lib.name = name
-            lib.enabled = True
         else:
             # New library - insert
             lib = Library(

--- a/app/blueprints/media_servers/routes.py
+++ b/app/blueprints/media_servers/routes.py
@@ -28,7 +28,11 @@ from app.models import (
     invitation_servers,
     invitation_users,
 )
-from app.services.media.service import list_users_for_server, scan_libraries_for_server
+from app.services.media.service import (
+    list_users_for_server,
+    scan_libraries_for_server,
+    upsert_scanned_libraries,
+)
 from app.services.servers import (
     check_audiobookshelf,
     check_drop,
@@ -161,53 +165,11 @@ def scan_server_libraries(server_id):
             500,
         )
 
-    # items may be dict or list[str]
-    pairs = (
-        items.items() if isinstance(items, dict) else [(name, name) for name in items]
-    )
-
-    # Upsert libraries: update existing rows, insert new ones, and preserve invite associations.
-    from app.models import invite_libraries
-
-    # Load existing libraries for this server keyed by external_id
-    existing_libs = {
-        lib.external_id: lib
-        for lib in Library.query.filter_by(server_id=server.id).all()
-    }
-
-    incoming_ids: set[str] = set()
-    for fid, name in pairs:
-        fid_key = str(fid)
-        incoming_ids.add(fid_key)
-        if fid_key in existing_libs:
-            # Update existing row (preserve primary key so invites keep referencing it)
-            # `enabled` is the admin's saved selection; this scan runs when the edit
-            # form OPENS, so resetting it here wiped the checkboxes being rendered.
-            lib = existing_libs[fid_key]
-            lib.name = name
-        else:
-            # New library - insert
-            lib = Library(
-                external_id=fid,
-                name=name,
-                server_id=server.id,
-                enabled=True,
-            )
-            db.session.add(lib)
-
-    # Handle libraries that used to exist but weren't returned by the server
-    for ext, lib in existing_libs.items():
-        if str(ext) not in incoming_ids:
-            # If this library is referenced by any invitation, disable it to preserve associations
-            referenced = db.session.execute(
-                invite_libraries.select().where(invite_libraries.c.library_id == lib.id)
-            ).first()
-            if referenced:
-                lib.enabled = False
-            else:
-                # Safe to remove since no invites reference it
-                db.session.delete(lib)
-
+    # Upsert scanned libraries, preserving each row's enabled flag and invite
+    # associations. `enabled` is the admin's saved selection and this scan runs
+    # when the edit form OPENS, so resetting it would wipe the checkboxes being
+    # rendered.
+    upsert_scanned_libraries(server, items)
     db.session.commit()
 
     # Render checkboxes partial (reuse existing partials)

--- a/app/blueprints/media_servers/routes.py
+++ b/app/blueprints/media_servers/routes.py
@@ -156,7 +156,7 @@ def create_server():
 def scan_server_libraries(server_id):
     server = MediaServer.query.get_or_404(server_id)
     try:
-        items = scan_libraries_for_server(server)
+        items, authoritative = scan_libraries_for_server(server)
     except Exception as exc:
         error_message = str(exc) if str(exc) else "Library scan failed"
         flash(f"Library scan failed: {exc}", "error")
@@ -169,7 +169,7 @@ def scan_server_libraries(server_id):
     # associations. `enabled` is the admin's saved selection and this scan runs
     # when the edit form OPENS, so resetting it would wipe the checkboxes being
     # rendered.
-    upsert_scanned_libraries(server, items)
+    upsert_scanned_libraries(server, items, authoritative=authoritative)
     db.session.commit()
 
     # Render checkboxes partial (reuse existing partials)

--- a/app/blueprints/settings/routes.py
+++ b/app/blueprints/settings/routes.py
@@ -235,9 +235,12 @@ def scan_libraries():
         error_message = str(exc) if str(exc) else _("Library scan failed")
         return f"<div class='text-red-500 p-3 border border-red-300 rounded-lg bg-red-50 dark:bg-red-900 dark:border-red-700'><strong>{_('Error')}:</strong> {error_message}</div>"
 
-    # 3) Delete all old libraries and insert fresh ones
-    # Note: This assumes single-server legacy setup (settings route)
-    Library.query.delete()
+    # 3) Replace the rows this legacy route owns and insert fresh ones.
+    # Scoped to server_id IS NULL: this route predates multi-server support and
+    # creates unbound rows, so an unscoped delete would also destroy libraries
+    # belonging to real MediaServers and orphan the invite_libraries rows that
+    # reference them.
+    Library.query.filter_by(server_id=None).delete()
     db.session.flush()
 
     # Insert fresh libraries with correct external IDs

--- a/app/services/invites.py
+++ b/app/services/invites.py
@@ -99,6 +99,23 @@ def create_invite(form: Any) -> Invitation:
     other_servers = [s for s in servers if s.server_type != "plex"]
     servers = plex_servers + other_servers
 
+    # Validate the library selection before creating anything. The invite picker
+    # (server_library_picker.html) emits a hidden `library_picker_used` marker; if
+    # it is present but no box is checked, the admin opened the picker and cleared
+    # it. That is almost always a mistake rather than a request for an invite that
+    # grants nothing (which the media backends cannot represent anyway), so reject
+    # it and point them at the permissive default. When the picker was never opened
+    # there is no marker and the redeem-time fallback still grants all enabled
+    # libraries, so unattended invites are unaffected.
+    selected_library_ids = [
+        int(lid) for lid in _get_form_list(form, "libraries") if str(lid).isdigit()
+    ]
+    if form.get("library_picker_used") and not selected_library_ids:
+        raise ValueError(
+            "Select at least one library, or leave the library selector "
+            "untouched to grant access to all enabled libraries."
+        )
+
     invite = Invitation(
         code=code,
         used=False,
@@ -149,44 +166,32 @@ def create_invite(form: Any) -> Invitation:
 
         invite.servers.extend(servers)
 
-    # Wire up library associations
-    selected = _get_form_list(
-        form, "libraries"
-    )  # these are now library IDs (not external_ids)
-    if selected:
-        # Convert string IDs to integers and filter out invalid values
-        try:
-            library_ids = [int(lid) for lid in selected if lid.isdigit()]
-        except (ValueError, AttributeError):
-            library_ids = []
+    # Wire up library associations (selected_library_ids computed and validated above)
+    if selected_library_ids:
+        # Clear any existing library associations for this invite to avoid UNIQUE constraint violations
+        # This handles cases where there might be leftover data from previous attempts
+        from app.models import invite_libraries
 
-        if library_ids:
-            # Clear any existing library associations for this invite to avoid UNIQUE constraint violations
-            # This handles cases where there might be leftover data from previous attempts
-            from app.models import invite_libraries
+        db.session.execute(
+            invite_libraries.delete().where(invite_libraries.c.invite_id == invite.id)
+        )
+        db.session.flush()  # Ensure the delete is committed before adding new records
 
-            db.session.execute(
-                invite_libraries.delete().where(
-                    invite_libraries.c.invite_id == invite.id
-                )
-            )
-            db.session.flush()  # Ensure the delete is committed before adding new records
+        # Look up the Library objects by their IDs
+        # Also ensure they belong to one of the selected servers
+        server_ids = [s.id for s in servers]
+        libs = Library.query.filter(
+            Library.id.in_(selected_library_ids), Library.server_id.in_(server_ids)
+        ).all()
 
-            # Look up the Library objects by their IDs
-            # Also ensure they belong to one of the selected servers
-            server_ids = [s.id for s in servers]
-            libs = Library.query.filter(
-                Library.id.in_(library_ids), Library.server_id.in_(server_ids)
-            ).all()
-
-            # Since we're now using unique library IDs from the frontend,
-            # we shouldn't have duplicates, but we'll keep the deduplication
-            # logic as a safety measure
-            seen_lib_ids = set()
-            for lib in libs:
-                if lib.id not in seen_lib_ids:
-                    seen_lib_ids.add(lib.id)
-                    invite.libraries.append(lib)
+        # Since we're now using unique library IDs from the frontend,
+        # we shouldn't have duplicates, but we'll keep the deduplication
+        # logic as a safety measure
+        seen_lib_ids = set()
+        for lib in libs:
+            if lib.id not in seen_lib_ids:
+                seen_lib_ids.add(lib.id)
+                invite.libraries.append(lib)
 
     # Wire up LDAP user creation flag
     invite.create_ldap_user = bool(form.get("create_ldap_user"))

--- a/app/services/invites.py
+++ b/app/services/invites.py
@@ -107,10 +107,24 @@ def create_invite(form: Any) -> Invitation:
     # it and point them at the permissive default. When the picker was never opened
     # there is no marker and the redeem-time fallback still grants all enabled
     # libraries, so unattended invites are unaffected.
+    #
+    # The submitted IDs are validated by resolving them against Library rows that
+    # actually belong to one of the selected servers, not by their raw presence:
+    # a stale or nonexistent ID would otherwise pass this check while resolving
+    # to zero libraries below, committing an unscoped invite that the picker
+    # appeared to have restricted.
     selected_library_ids = [
         int(lid) for lid in _get_form_list(form, "libraries") if str(lid).isdigit()
     ]
-    if form.get("library_picker_used") and not selected_library_ids:
+    resolved_libraries = (
+        Library.query.filter(
+            Library.id.in_(selected_library_ids),
+            Library.server_id.in_([s.id for s in servers]),
+        ).all()
+        if selected_library_ids
+        else []
+    )
+    if form.get("library_picker_used") and not resolved_libraries:
         raise ValueError(
             "Select at least one library, or leave the library selector "
             "untouched to grant access to all enabled libraries."
@@ -166,8 +180,8 @@ def create_invite(form: Any) -> Invitation:
 
         invite.servers.extend(servers)
 
-    # Wire up library associations (selected_library_ids computed and validated above)
-    if selected_library_ids:
+    # Wire up library associations (resolved_libraries computed and validated above)
+    if resolved_libraries:
         # Clear any existing library associations for this invite to avoid UNIQUE constraint violations
         # This handles cases where there might be leftover data from previous attempts
         from app.models import invite_libraries
@@ -177,18 +191,11 @@ def create_invite(form: Any) -> Invitation:
         )
         db.session.flush()  # Ensure the delete is committed before adding new records
 
-        # Look up the Library objects by their IDs
-        # Also ensure they belong to one of the selected servers
-        server_ids = [s.id for s in servers]
-        libs = Library.query.filter(
-            Library.id.in_(selected_library_ids), Library.server_id.in_(server_ids)
-        ).all()
-
         # Since we're now using unique library IDs from the frontend,
         # we shouldn't have duplicates, but we'll keep the deduplication
         # logic as a safety measure
         seen_lib_ids = set()
-        for lib in libs:
+        for lib in resolved_libraries:
             if lib.id not in seen_lib_ids:
                 seen_lib_ids.add(lib.id)
                 invite.libraries.append(lib)

--- a/app/services/media/client_base.py
+++ b/app/services/media/client_base.py
@@ -192,6 +192,18 @@ class MediaClient(ABC):
     def libraries(self):
         raise NotImplementedError
 
+    def libraries_scan_authoritative(self, scan_result) -> bool:  # noqa: ARG002
+        """Whether `scan_result` (this call's `libraries()` return value) can be
+        trusted to reconcile libraries that are missing from it as removed.
+
+        Default True: most backends are queried directly, so a result either
+        reflects the server's real state or the request raised and never got
+        here. Override this only if a backend's scan source can silently
+        return a partial view of a healthy server without raising - see
+        PlexClient, whose account-level global-id lookup does exactly that.
+        """
+        return True
+
     @abstractmethod
     def create_user(self, *args, **kwargs):
         raise NotImplementedError

--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -132,6 +132,24 @@ class PlexClient(MediaClient):
         # Return {global_id: name} so external_id stores the global ID
         return {str(global_id): name for name, global_id in library_map.items()}
 
+    def libraries_scan_authoritative(self, scan_result: dict[str, str]) -> bool:
+        """Cross-check the global-id lookup's count against the local server.
+
+        `libraries()` gets its global section IDs from `plex.tv/api/v2/servers`,
+        an account-level endpoint that can transiently return a partial or empty
+        `librarySections` list from a perfectly healthy server without raising.
+        The local server's own `library.sections()` talks to the Plex Media
+        Server directly and isn't subject to that flakiness, so it's a genuine
+        second source rather than a guess based on what we already have on file.
+        A count mismatch means the global-id result can't be trusted to tell us
+        a library was actually removed.
+        """
+        try:
+            true_count = len(self.server.library.sections())
+        except Exception:
+            return False
+        return len(scan_result) == true_count
+
     # ─── Helper Methods ────────────────────────────────────────────────────────
 
     def _get_server_users(self) -> list[User]:

--- a/app/services/media/service.py
+++ b/app/services/media/service.py
@@ -287,6 +287,59 @@ def scan_libraries_for_server(server: MediaServer):
     return client.libraries()
 
 
+def upsert_scanned_libraries(server: MediaServer, scan_result: Any) -> None:
+    """Reconcile a server's Library rows with a scan result. Does not commit.
+
+    ``scan_result`` is either a ``{external_id: name}`` dict or a list of names.
+    Existing rows keep their primary key (so invites keep referencing them) and
+    their ``enabled`` flag, which is the admin's saved default and what the
+    checkbox partial renders from. New libraries are inserted enabled. A library
+    that vanished from the scan is disabled if any invitation still references
+    it, otherwise deleted.
+
+    Shared by the invite modal scan and the server edit-form scan; each caller
+    keeps its own handling of a failed scan and its own commit/flush.
+    """
+    from app.models import Library, invite_libraries
+
+    pairs = (
+        scan_result.items()
+        if isinstance(scan_result, dict)
+        else [(name, name) for name in scan_result]
+    )
+
+    existing_libs = {
+        lib.external_id: lib
+        for lib in Library.query.filter_by(server_id=server.id).all()
+    }
+
+    incoming_ids: set[str] = set()
+    for fid, name in pairs:
+        fid = str(fid)
+        incoming_ids.add(fid)
+        if fid in existing_libs:
+            existing_libs[fid].name = name
+        else:
+            db.session.add(
+                Library(
+                    external_id=fid,
+                    name=name,
+                    server_id=server.id,
+                    enabled=True,
+                )
+            )
+
+    for ext, lib in existing_libs.items():
+        if str(ext) not in incoming_ids:
+            referenced = db.session.execute(
+                invite_libraries.select().where(invite_libraries.c.library_id == lib.id)
+            ).first()
+            if referenced:
+                lib.enabled = False
+            else:
+                db.session.delete(lib)
+
+
 def reset_user_password(db_id: int, new_password: str) -> bool:
     """Reset the password for a user on LDAP and/or their associated media server.
 

--- a/app/services/media/service.py
+++ b/app/services/media/service.py
@@ -294,8 +294,15 @@ def upsert_scanned_libraries(server: MediaServer, scan_result: Any) -> None:
     Existing rows keep their primary key (so invites keep referencing them) and
     their ``enabled`` flag, which is the admin's saved default and what the
     checkbox partial renders from. New libraries are inserted enabled. A library
-    that vanished from the scan is disabled if any invitation still references
-    it, otherwise deleted.
+    that vanished from the scan is disabled if any invitation still references it,
+    otherwise deleted, but only when the scan is authoritative.
+
+    Removal reconciliation is skipped when the scan returns nothing, or fewer
+    libraries than we already have on record. Plex's global-id source
+    (``plex.tv/api/v2/servers``) can transiently return a partial or empty
+    ``librarySections`` list, and trusting a short response would disable real
+    libraries and wipe the admin's saved invite defaults. Adds and name updates
+    still apply, so genuinely new libraries always show up.
 
     Shared by the invite modal scan and the server edit-form scan; each caller
     keeps its own handling of a failed scan and its own commit/flush.
@@ -307,6 +314,12 @@ def upsert_scanned_libraries(server: MediaServer, scan_result: Any) -> None:
         if isinstance(scan_result, dict)
         else [(name, name) for name in scan_result]
     )
+
+    # A scan that returns nothing must not mutate anything: Plex's global-id source
+    # can transiently return an empty librarySections list, and trusting it would
+    # disable or delete every real library and wipe the admin's invite defaults.
+    if not pairs:
+        return
 
     existing_libs = {
         lib.external_id: lib
@@ -328,6 +341,14 @@ def upsert_scanned_libraries(server: MediaServer, scan_result: Any) -> None:
                     enabled=True,
                 )
             )
+
+    # Only reconcile removals when the scan is authoritative. A scan that returns
+    # fewer libraries than we already have on record is treated as a partial (flaky)
+    # response and leaves existing rows untouched. This is the reported failure mode:
+    # a 12-library Plex came back as a 7-library scan and silently disabled the two
+    # libraries (Movies and TV Shows) the admin had kept as the invite default.
+    if len(incoming_ids) < len(existing_libs):
+        return
 
     for ext, lib in existing_libs.items():
         if str(ext) not in incoming_ids:

--- a/app/services/media/service.py
+++ b/app/services/media/service.py
@@ -281,13 +281,23 @@ def scan_libraries(
     return client.libraries()
 
 
-def scan_libraries_for_server(server: MediaServer):
-    """Scan libraries for the given server and upsert into our Library table."""
+def scan_libraries_for_server(server: MediaServer) -> tuple[Any, bool]:
+    """Scan libraries for the given server and upsert into our Library table.
+
+    Returns ``(scan_result, authoritative)``. ``authoritative`` reports whether
+    ``scan_result`` can be trusted to reconcile libraries that are missing from
+    it as actually removed - see ``MediaClient.libraries_scan_authoritative``
+    and ``upsert_scanned_libraries``. Callers that only add/update and never
+    reconcile removals (e.g. the API library listing) can ignore it.
+    """
     client = get_client_for_media_server(server)
-    return client.libraries()
+    scan_result = client.libraries()
+    return scan_result, client.libraries_scan_authoritative(scan_result)
 
 
-def upsert_scanned_libraries(server: MediaServer, scan_result: Any) -> None:
+def upsert_scanned_libraries(
+    server: MediaServer, scan_result: Any, *, authoritative: bool = True
+) -> None:
     """Reconcile a server's Library rows with a scan result. Does not commit.
 
     ``scan_result`` is either a ``{external_id: name}`` dict or a list of names.
@@ -295,25 +305,34 @@ def upsert_scanned_libraries(server: MediaServer, scan_result: Any) -> None:
     their ``enabled`` flag, which is the admin's saved default and what the
     checkbox partial renders from. New libraries are inserted enabled. A library
     that vanished from the scan is disabled if any invitation still references it,
-    otherwise deleted, but only when the scan is authoritative.
+    otherwise deleted, but only when ``authoritative`` is true.
 
-    Removal reconciliation is skipped when the scan returns nothing, or fewer
-    libraries than we already have on record. Plex's global-id source
-    (``plex.tv/api/v2/servers``) can transiently return a partial or empty
-    ``librarySections`` list, and trusting a short response would disable real
-    libraries and wipe the admin's saved invite defaults. Adds and name updates
-    still apply, so genuinely new libraries always show up.
+    ``authoritative`` (see ``scan_libraries_for_server``) is the caller's signal
+    that ``scan_result`` genuinely reflects the server's current libraries, not
+    a guess based on counts alone: a same-size scan can still have silently
+    swapped in a different library, and a real removal must not be blocked
+    forever just because it shrinks the count. When it's false, removal
+    reconciliation is skipped entirely; adds and name updates still apply, so
+    genuinely new libraries always show up.
+
+    A malformed ``scan_result`` (e.g. ``None``) is treated the same as an empty
+    one rather than raising, so a bad result from one server in a multi-server
+    scan can't abort reconciliation already done for earlier servers in the
+    same request.
 
     Shared by the invite modal scan and the server edit-form scan; each caller
     keeps its own handling of a failed scan and its own commit/flush.
     """
     from app.models import Library, invite_libraries
 
-    pairs = (
-        scan_result.items()
-        if isinstance(scan_result, dict)
-        else [(name, name) for name in scan_result]
-    )
+    try:
+        pairs = list(
+            scan_result.items()
+            if isinstance(scan_result, dict)
+            else [(name, name) for name in scan_result]
+        )
+    except TypeError:
+        pairs = []
 
     # A scan that returns nothing must not mutate anything: Plex's global-id source
     # can transiently return an empty librarySections list, and trusting it would
@@ -342,12 +361,7 @@ def upsert_scanned_libraries(server: MediaServer, scan_result: Any) -> None:
                 )
             )
 
-    # Only reconcile removals when the scan is authoritative. A scan that returns
-    # fewer libraries than we already have on record is treated as a partial (flaky)
-    # response and leaves existing rows untouched. This is the reported failure mode:
-    # a 12-library Plex came back as a 7-library scan and silently disabled the two
-    # libraries (Movies and TV Shows) the admin had kept as the invite default.
-    if len(incoming_ids) < len(existing_libs):
+    if not authoritative:
         return
 
     for ext, lib in existing_libs.items():

--- a/app/templates/partials/server_library_picker.html
+++ b/app/templates/partials/server_library_picker.html
@@ -1,4 +1,7 @@
 {# Render library checkboxes grouped by server #}
+{# Marker so the invite form can distinguish "opened the picker and cleared it"
+   (reject, must choose >=1) from "never opened it" (fall back to all enabled). #}
+<input type="hidden" name="library_picker_used" value="1">
 {% if servers|length > 1 %}
   <div class="mb-2 text-xs text-gray-500 dark:text-gray-400">
     Libraries are grouped by server. Each library can be selected independently.

--- a/tests/test_invite_library_picker.py
+++ b/tests/test_invite_library_picker.py
@@ -99,7 +99,7 @@ def test_invite_scan_libraries_renders_existing_choices_without_duplicate_ids(
 
     with patch(
         "app.blueprints.admin.routes.scan_libraries_for_server",
-        return_value=scanned_libraries,
+        return_value=(scanned_libraries, True),
     ):
         response = client.post(
             "/invite/scan-libraries",

--- a/tests/test_invite_library_selection.py
+++ b/tests/test_invite_library_selection.py
@@ -73,6 +73,65 @@ def test_picker_with_a_selection_is_created(client, session):
     assert [library.id for library in inv.libraries] == [lib.id]
 
 
+def test_picker_used_with_only_a_stale_library_id_is_rejected(client, session):
+    """A submitted ID that resolves to zero eligible libraries (stale/deleted, or
+    never existed) must be rejected the same as an empty selection - otherwise
+    the invite commits with no library associations and redemption falls back
+    to every enabled library, defeating the picker's restriction.
+    """
+    _login(client, session)
+    server = _server(session)
+
+    resp = client.post(
+        "/invite",
+        data={
+            "server_ids": str(server.id),
+            "expires": "never",
+            "library_picker_used": "1",
+            "libraries": "999999",
+        },
+        headers=HX,
+    )
+    assert resp.status_code == 400
+    assert b"at least one library" in resp.data
+    assert Invitation.query.count() == 0
+
+
+def test_picker_used_with_a_library_from_an_unselected_server_is_rejected(
+    client, session
+):
+    """A submitted ID belonging to a server that isn't part of this invite must
+    not silently resolve to zero libraries and slip through as an unscoped
+    invite.
+    """
+    _login(client, session)
+    server = _server(session)
+    other_server = MediaServer(
+        name="Other Plex", server_type="plex", url="http://other.local", api_key="tok"
+    )
+    session.add(other_server)
+    session.commit()
+    foreign_lib = Library(
+        external_id="1", name="Movies", server_id=other_server.id, enabled=True
+    )
+    session.add(foreign_lib)
+    session.commit()
+
+    resp = client.post(
+        "/invite",
+        data={
+            "server_ids": str(server.id),
+            "expires": "never",
+            "library_picker_used": "1",
+            "libraries": str(foreign_lib.id),
+        },
+        headers=HX,
+    )
+    assert resp.status_code == 400
+    assert b"at least one library" in resp.data
+    assert Invitation.query.count() == 0
+
+
 def test_untouched_picker_is_allowed(client, session):
     """No marker (picker never opened) -> allowed; redeem-time fallback still applies."""
     _login(client, session)

--- a/tests/test_invite_library_selection.py
+++ b/tests/test_invite_library_selection.py
@@ -1,0 +1,88 @@
+"""Creating an invite with the library picker opened but every box cleared is
+rejected, replacing the silent "unchecked all -> grant every enabled library"
+surprise with an explicit error. An invite whose picker was never opened is
+unaffected and still falls back to all enabled libraries at redeem time.
+"""
+
+from app.models import AdminAccount, Invitation, Library, MediaServer
+
+# /invite is an HTMX-only endpoint (it redirects to the dashboard otherwise).
+HX = {"HX-Request": "true", "HX-Current-URL": "http://localhost/admin/invites"}
+
+
+def _login(client, session):
+    admin = AdminAccount(username="testadmin")
+    admin.set_password("TestPass123")
+    session.add(admin)
+    session.commit()
+    resp = client.post(
+        "/login", data={"username": "testadmin", "password": "TestPass123"}
+    )
+    assert resp.status_code in {200, 302, 303}
+    return admin
+
+
+def _server(session):
+    server = MediaServer(
+        name="Plex", server_type="plex", url="http://plex.local", api_key="token"
+    )
+    session.add(server)
+    session.commit()
+    return server
+
+
+def test_opened_picker_but_cleared_is_rejected(client, session):
+    """Marker present + zero boxes checked -> 400 and no invite is created."""
+    _login(client, session)
+    server = _server(session)
+
+    resp = client.post(
+        "/invite",
+        data={
+            "server_ids": str(server.id),
+            "expires": "never",
+            "library_picker_used": "1",
+        },
+        headers=HX,
+    )
+    assert resp.status_code == 400
+    assert b"at least one library" in resp.data
+    assert Invitation.query.count() == 0
+
+
+def test_picker_with_a_selection_is_created(client, session):
+    """Marker present + a library kept -> invite created with exactly that library."""
+    _login(client, session)
+    server = _server(session)
+    lib = Library(external_id="1", name="Movies", server_id=server.id, enabled=True)
+    session.add(lib)
+    session.commit()
+
+    resp = client.post(
+        "/invite",
+        data={
+            "server_ids": str(server.id),
+            "expires": "never",
+            "library_picker_used": "1",
+            "libraries": str(lib.id),
+        },
+        headers=HX,
+    )
+    assert resp.status_code == 200
+    inv = Invitation.query.one()
+    assert [library.id for library in inv.libraries] == [lib.id]
+
+
+def test_untouched_picker_is_allowed(client, session):
+    """No marker (picker never opened) -> allowed; redeem-time fallback still applies."""
+    _login(client, session)
+    server = _server(session)
+
+    resp = client.post(
+        "/invite",
+        data={"server_ids": str(server.id), "expires": "never"},
+        headers=HX,
+    )
+    assert resp.status_code == 200
+    inv = Invitation.query.one()
+    assert list(inv.libraries) == []

--- a/tests/test_library_enabled_persistence.py
+++ b/tests/test_library_enabled_persistence.py
@@ -131,6 +131,57 @@ def test_newly_discovered_library_defaults_to_enabled(client, session):
     assert enabled["3"] is True
 
 
+def test_partial_scan_leaves_existing_libraries_untouched(client, session):
+    """A flaky plex.tv scan that returns fewer libraries than we hold must not disable
+    or delete the missing ones. Regression: a 12-library server came back as a
+    7-library scan and silently dropped Movies/TV Shows out of the invite default.
+    """
+    _login(client, session)
+    server = _server(session)
+    _libs(
+        session,
+        server,
+        {
+            "1": ("Movies", True),
+            "2": ("TV Shows", True),
+            "3": ("Home Video", False),
+            "4": ("Music", False),
+        },
+    )
+
+    # scan comes back short (2 of 4), omitting the enabled Movies/TV Shows
+    partial = {"3": "Home Video", "4": "Music"}
+    with patch(
+        "app.blueprints.admin.routes.scan_libraries_for_server",
+        return_value=partial,
+    ):
+        resp = client.post(
+            "/invite/scan-libraries", data={"server_ids": str(server.id)}
+        )
+    assert resp.status_code == 200
+
+    # nothing dropped, nothing re-toggled
+    assert _enabled_map(server.id) == {"1": True, "2": True, "3": False, "4": False}
+
+
+def test_empty_scan_is_a_noop(client, session):
+    """An empty scan result (total plex.tv failure) must not wipe the library table."""
+    _login(client, session)
+    server = _server(session)
+    _libs(session, server, {"1": ("Movies", True), "3": ("Home Video", False)})
+
+    with patch(
+        "app.blueprints.admin.routes.scan_libraries_for_server",
+        return_value={},
+    ):
+        resp = client.post(
+            "/invite/scan-libraries", data={"server_ids": str(server.id)}
+        )
+    assert resp.status_code == 200
+
+    assert _enabled_map(server.id) == {"1": True, "3": False}
+
+
 def test_legacy_settings_scan_does_not_delete_other_servers_libraries(client, session):
     """The legacy route owns only unbound rows; it must not touch real servers'."""
     _login(client, session)

--- a/tests/test_library_enabled_persistence.py
+++ b/tests/test_library_enabled_persistence.py
@@ -1,0 +1,165 @@
+"""Library.enabled is the admin's saved default for new invites.
+
+It is written by the server edit form, rendered as `checked` by
+partials/library_checkboxes.html, and used by _invite_user as the fallback library
+set for invites that carry none of their own. Library scans must therefore not
+reset it, and the legacy settings scan must not delete rows it does not own.
+"""
+
+from unittest.mock import patch
+
+from app.models import AdminAccount, Library, MediaServer
+
+
+def _login(client, session):
+    admin = AdminAccount(username="testadmin")
+    admin.set_password("TestPass123")
+    session.add(admin)
+    session.commit()
+    resp = client.post(
+        "/login", data={"username": "testadmin", "password": "TestPass123"}
+    )
+    assert resp.status_code in {200, 302, 303}
+    return admin
+
+
+def _server(session, name="Plex"):
+    server = MediaServer(
+        name=name, server_type="plex", url="http://plex.local", api_key="token"
+    )
+    session.add(server)
+    session.commit()
+    return server
+
+
+def _libs(session, server, spec):
+    """spec: {external_id: (name, enabled)}"""
+    for ext, (name, enabled) in spec.items():
+        session.add(
+            Library(external_id=ext, name=name, server_id=server.id, enabled=enabled)
+        )
+    session.commit()
+
+
+def _enabled_map(server_id):
+    return {
+        lib.external_id: lib.enabled
+        for lib in Library.query.filter_by(server_id=server_id).all()
+    }
+
+
+SCAN_RESULT = {"1": "Movies", "2": "TV Shows", "3": "Home Video"}
+
+
+def test_invite_scan_preserves_disabled_libraries(client, session):
+    """Opening the invite modal rescans; it must not re-enable what the admin turned off."""
+    _login(client, session)
+    server = _server(session)
+    _libs(
+        session,
+        server,
+        {"1": ("Movies", True), "2": ("TV Shows", True), "3": ("Home Video", False)},
+    )
+
+    with patch(
+        "app.blueprints.admin.routes.scan_libraries_for_server",
+        return_value=SCAN_RESULT,
+    ):
+        resp = client.post(
+            "/invite/scan-libraries", data={"server_ids": str(server.id)}
+        )
+    assert resp.status_code == 200
+
+    assert _enabled_map(server.id) == {"1": True, "2": True, "3": False}
+
+
+def test_invite_scan_rendered_checkboxes_match_enabled(client, session):
+    """The rendered form must offer every library but pre-check only the enabled ones."""
+    _login(client, session)
+    server = _server(session)
+    _libs(
+        session,
+        server,
+        {"1": ("Movies", True), "2": ("TV Shows", False), "3": ("Home Video", False)},
+    )
+
+    with patch(
+        "app.blueprints.admin.routes.scan_libraries_for_server",
+        return_value=SCAN_RESULT,
+    ):
+        resp = client.post(
+            "/invite/scan-libraries", data={"server_ids": str(server.id)}
+        )
+
+    html = resp.get_data(as_text=True)
+    assert html.count('name="libraries"') == 3
+    assert html.count("checked") == 1
+
+
+def test_server_edit_scan_preserves_disabled_libraries(client, session):
+    """Same reset existed on the per-server scan the edit form opens with."""
+    _login(client, session)
+    server = _server(session)
+    _libs(session, server, {"1": ("Movies", True), "3": ("Home Video", False)})
+
+    with patch(
+        "app.blueprints.media_servers.routes.scan_libraries_for_server",
+        return_value=SCAN_RESULT,
+    ):
+        resp = client.post(f"/settings/servers/{server.id}/scan-libraries")
+    assert resp.status_code == 200
+
+    enabled = _enabled_map(server.id)
+    assert enabled["1"] is True
+    assert enabled["3"] is False
+
+
+def test_newly_discovered_library_defaults_to_enabled(client, session):
+    """A library that appears for the first time should not be silently withheld."""
+    _login(client, session)
+    server = _server(session)
+    _libs(session, server, {"1": ("Movies", True)})
+
+    with patch(
+        "app.blueprints.admin.routes.scan_libraries_for_server",
+        return_value=SCAN_RESULT,
+    ):
+        client.post("/invite/scan-libraries", data={"server_ids": str(server.id)})
+
+    enabled = _enabled_map(server.id)
+    assert enabled["2"] is True
+    assert enabled["3"] is True
+
+
+def test_legacy_settings_scan_does_not_delete_other_servers_libraries(client, session):
+    """The legacy route owns only unbound rows; it must not touch real servers'."""
+    _login(client, session)
+    server = _server(session, name="Existing")
+    _libs(session, server, {"1": ("Movies", True), "3": ("Home Video", False)})
+    session.add(Library(external_id="stale", name="Stale", server_id=None))
+    session.commit()
+
+    bound_ids_before = {
+        lib.id for lib in Library.query.filter_by(server_id=server.id).all()
+    }
+
+    with patch(
+        "app.blueprints.settings.routes.scan_media", return_value={"9": "Fresh"}
+    ):
+        resp = client.post(
+            "/settings/scan-libraries",
+            data={
+                "server_type": "plex",
+                "server_url": "http://plex.local",
+                "api_key": "token",
+            },
+        )
+    assert resp.status_code == 200
+
+    bound_after = Library.query.filter_by(server_id=server.id).all()
+    assert {lib.id for lib in bound_after} == bound_ids_before
+    assert _enabled_map(server.id) == {"1": True, "3": False}
+
+    # the unbound staging rows are still replaced, which is this route's job
+    unbound = {lib.external_id for lib in Library.query.filter_by(server_id=None).all()}
+    assert unbound == {"9"}

--- a/tests/test_library_enabled_persistence.py
+++ b/tests/test_library_enabled_persistence.py
@@ -63,7 +63,7 @@ def test_invite_scan_preserves_disabled_libraries(client, session):
 
     with patch(
         "app.blueprints.admin.routes.scan_libraries_for_server",
-        return_value=SCAN_RESULT,
+        return_value=(SCAN_RESULT, True),
     ):
         resp = client.post(
             "/invite/scan-libraries", data={"server_ids": str(server.id)}
@@ -85,7 +85,7 @@ def test_invite_scan_rendered_checkboxes_match_enabled(client, session):
 
     with patch(
         "app.blueprints.admin.routes.scan_libraries_for_server",
-        return_value=SCAN_RESULT,
+        return_value=(SCAN_RESULT, True),
     ):
         resp = client.post(
             "/invite/scan-libraries", data={"server_ids": str(server.id)}
@@ -104,7 +104,7 @@ def test_server_edit_scan_preserves_disabled_libraries(client, session):
 
     with patch(
         "app.blueprints.media_servers.routes.scan_libraries_for_server",
-        return_value=SCAN_RESULT,
+        return_value=(SCAN_RESULT, True),
     ):
         resp = client.post(f"/settings/servers/{server.id}/scan-libraries")
     assert resp.status_code == 200
@@ -122,7 +122,7 @@ def test_newly_discovered_library_defaults_to_enabled(client, session):
 
     with patch(
         "app.blueprints.admin.routes.scan_libraries_for_server",
-        return_value=SCAN_RESULT,
+        return_value=(SCAN_RESULT, True),
     ):
         client.post("/invite/scan-libraries", data={"server_ids": str(server.id)})
 
@@ -131,10 +131,13 @@ def test_newly_discovered_library_defaults_to_enabled(client, session):
     assert enabled["3"] is True
 
 
-def test_partial_scan_leaves_existing_libraries_untouched(client, session):
-    """A flaky plex.tv scan that returns fewer libraries than we hold must not disable
-    or delete the missing ones. Regression: a 12-library server came back as a
-    7-library scan and silently dropped Movies/TV Shows out of the invite default.
+def test_non_authoritative_scan_leaves_existing_libraries_untouched(client, session):
+    """A scan the client flags as unreliable must not disable or delete libraries
+    missing from it, however many it returned. Regression: a 12-library server
+    came back as a 7-library scan and silently dropped Movies/TV Shows out of the
+    invite default. Reliability is a signal from the client
+    (``libraries_scan_authoritative``), not a guess based on counts: a same-size
+    scan is just as capable of having silently swapped in a different library.
     """
     _login(client, session)
     server = _server(session)
@@ -149,11 +152,11 @@ def test_partial_scan_leaves_existing_libraries_untouched(client, session):
         },
     )
 
-    # scan comes back short (2 of 4), omitting the enabled Movies/TV Shows
+    # scan comes back short (2 of 4) and the client marks it unreliable
     partial = {"3": "Home Video", "4": "Music"}
     with patch(
         "app.blueprints.admin.routes.scan_libraries_for_server",
-        return_value=partial,
+        return_value=(partial, False),
     ):
         resp = client.post(
             "/invite/scan-libraries", data={"server_ids": str(server.id)}
@@ -164,6 +167,53 @@ def test_partial_scan_leaves_existing_libraries_untouched(client, session):
     assert _enabled_map(server.id) == {"1": True, "2": True, "3": False, "4": False}
 
 
+def test_equal_count_non_authoritative_scan_does_not_swap_libraries(client, session):
+    """Count alone never proves a scan is complete: an unreliable scan that comes
+    back the same size as what we hold, but with different libraries, must still
+    leave the missing one alone rather than treating the matching count as proof
+    it's a real replacement.
+    """
+    _login(client, session)
+    server = _server(session)
+    _libs(session, server, {"1": ("Movies", True), "2": ("TV Shows", True)})
+
+    # same count (2) as what we hold, but "1" is gone and "3" is new
+    swapped = {"2": "TV Shows", "3": "Documentaries"}
+    with patch(
+        "app.blueprints.admin.routes.scan_libraries_for_server",
+        return_value=(swapped, False),
+    ):
+        resp = client.post(
+            "/invite/scan-libraries", data={"server_ids": str(server.id)}
+        )
+    assert resp.status_code == 200
+
+    # "1" survives (unreliable scan), "3" is still added (adds always apply)
+    assert _enabled_map(server.id) == {"1": True, "2": True, "3": True}
+
+
+def test_authoritative_scan_reconciles_a_genuine_removal(client, session):
+    """A scan the client confirms is reliable must still reconcile removals, even
+    though it returns fewer libraries than we hold - a real removal isn't
+    distinguishable from a partial one by count and must not be blocked forever.
+    """
+    _login(client, session)
+    server = _server(session)
+    _libs(session, server, {"1": ("Movies", True), "2": ("TV Shows", True)})
+
+    with patch(
+        "app.blueprints.admin.routes.scan_libraries_for_server",
+        return_value=({"2": "TV Shows"}, True),
+    ):
+        resp = client.post(
+            "/invite/scan-libraries", data={"server_ids": str(server.id)}
+        )
+    assert resp.status_code == 200
+
+    # "1" is gone for good, not disabled-and-kept, since nothing references it
+    assert _enabled_map(server.id) == {"2": True}
+
+
 def test_empty_scan_is_a_noop(client, session):
     """An empty scan result (total plex.tv failure) must not wipe the library table."""
     _login(client, session)
@@ -172,7 +222,7 @@ def test_empty_scan_is_a_noop(client, session):
 
     with patch(
         "app.blueprints.admin.routes.scan_libraries_for_server",
-        return_value={},
+        return_value=({}, False),
     ):
         resp = client.post(
             "/invite/scan-libraries", data={"server_ids": str(server.id)}
@@ -180,6 +230,33 @@ def test_empty_scan_is_a_noop(client, session):
     assert resp.status_code == 200
 
     assert _enabled_map(server.id) == {"1": True, "3": False}
+
+
+def test_malformed_scan_result_does_not_abort_other_servers(client, session):
+    """A malformed scan result (e.g. ``None``) for one server must not raise out
+    of the reconciliation loop and discard already-processed servers in the same
+    multi-server scan request.
+    """
+    _login(client, session)
+    bad_server = _server(session, name="Bad")
+    good_server = _server(session, name="Good")
+
+    def fake_scan(server):
+        if server.id == bad_server.id:
+            return None, True
+        return SCAN_RESULT, True
+
+    with patch(
+        "app.blueprints.admin.routes.scan_libraries_for_server",
+        side_effect=fake_scan,
+    ):
+        resp = client.post(
+            "/invite/scan-libraries",
+            data={"server_ids": [str(bad_server.id), str(good_server.id)]},
+        )
+    assert resp.status_code == 200
+
+    assert _enabled_map(good_server.id) == {"1": True, "2": True, "3": True}
 
 
 def test_legacy_settings_scan_does_not_delete_other_servers_libraries(client, session):

--- a/tests/test_library_scanning.py
+++ b/tests/test_library_scanning.py
@@ -85,7 +85,7 @@ def test_api_libraries_without_existing_libraries(client, api_key, test_server):
     mock_libraries = {"lib1": "Movies", "lib2": "TV Shows", "lib3": "Music"}
 
     with patch("app.services.media.service.scan_libraries_for_server") as mock_scan:
-        mock_scan.return_value = mock_libraries
+        mock_scan.return_value = (mock_libraries, True)
 
         response = client.get("/api/libraries", headers={"X-API-Key": api_key})
 
@@ -174,7 +174,7 @@ def test_api_libraries_scan_failure_continues(client, api_key, test_server):
     def side_effect(server):
         if server.name == "Test Server":
             raise Exception("Connection failed")
-        return mock_libraries
+        return mock_libraries, True
 
     with patch("app.services.media.service.scan_libraries_for_server") as mock_scan:
         mock_scan.side_effect = side_effect


### PR DESCRIPTION
Fixes #1354. Root cause for #1032 and #1269.

`Library.enabled` decides which libraries a new invite starts with. The server edit form writes it, `library_checkboxes.html` renders `checked` from it, and `_invite_user` uses it as the fallback set for invites that carry no libraries of their own.

Both scan handlers reset every existing row to `True`, and the invite modal scans when it opens, so the saved selection got overwritten immediately before the checkboxes were rendered from it. That's why the modal always shows everything selected no matter what you saved. It also means unchecking every box produces an invite with no libraries, which the fallback turns back into every enabled library.

Existing rows now keep their `enabled` value. New libraries still default to enabled, so a newly added library isn't silently withheld.

## The legacy settings scan

`settings.scan_libraries` had a worse version of the same problem:

```python
Library.query.delete()
```

No server filter. `modals/create-server.html` posts to it, so scanning libraries while adding a second server destroyed the rows belonging to servers that were already configured. Those rows are referenced by `invite_libraries` and the cascade took the associations with them.

Measured on a copy of my own install, running the real route against a real Plex server:

| | bound libraries | unbound (staging) | invite_library rows |
|---|---|---|---|
| before | 12 | 11 | 4 |
| after, stock | **0** | 12 | **0** |
| after, patched | 12 | 12 | 4 |

So on stock, previously restricted invites come out the other side with no scoping at all, and then hit the "no libraries means all enabled libraries" fallback. The patch deletes only the unbound rows that route actually owns, which is what it managed before multi-server support existed. Staging rows are still replaced, so the add-server flow is unchanged.

## Tests

`tests/test_library_enabled_persistence.py`, 7 cases: both scan routes preserve disabled libraries, the rendered form pre-checks only enabled ones, newly discovered libraries still default to enabled, the legacy scan leaves bound rows and their invite associations alone, and a short or empty scan leaves existing rows untouched (see the partial-scan commit below).

6 of the 7 fail on main and pass with this change. The remaining one is the regression guard for new-library defaults and passes either way. Full suite green locally apart from `tests/e2e`, which needs a browser I don't have.

I've been running the two `enabled` changes on my own instance since before opening this, verified from the HTTP side: `POST /invite/scan-libraries` returns 12 libraries with exactly 2 checked and leaves the flags identical before and after.


## Follow-up commits

Three more commits on the same branch, all on code this PR already touches.

**Deduplicate the scan handlers.** `invite_scan_libraries` and `scan_server_libraries` carried an identical copy of the scan-result reconciliation (upsert rows, preserve `enabled`, disable-if-referenced-else-delete the vanished ones). Moved to `service.upsert_scanned_libraries` so the enabled-preservation fix lives in one place. Behaviour is unchanged: each route keeps its own handling of a failed scan and its own commit, and the persistence tests above still pass.

**Guard the cleared-picker invite.** This is the "unchecking every box produces an invite with no libraries, which the fallback turns back into every enabled library" case noted above. The media backends can't actually represent "grant nothing" (an empty list means *all* on Jellyfin/Emby/Audiobookshelf/Komga), so rather than provision a locked-out state the invite form now rejects a cleared selection and asks for at least one library. `server_library_picker.html` emits a hidden marker when the picker renders, so `create_invite` can tell "opened it and cleared it" (reject) from "never opened it" (no marker, keep the all-enabled fallback for unattended and API invites). `tests/test_invite_library_selection.py` covers reject / keep-a-selection / untouched.

**Don't disable libraries on a partial or empty scan.** Found while testing this on a live 12-library Plex. `_get_all_library_global_ids` reads sections from `plex.tv/api/v2/servers`, and that endpoint can transiently return a partial or empty `librarySections` list. `upsert_scanned_libraries` trusted it and disabled or deleted every library missing from the response, so a scan that came back with 7 of 12 silently disabled Movies and TV Shows out of the saved defaults, then the next modal open rendered from that. Removal reconciliation is now skipped when the scan returns nothing, or fewer libraries than we already have on record; adds and name updates still apply, so genuinely new libraries always show up. Two regression tests (partial scan, empty scan) both fail on main.

