### PR TITLE
fix: don't delete every local user when a media server returns an empty user list

### DIFF
--- a/app/services/media/audiobookshelf.py
+++ b/app/services/media/audiobookshelf.py
@@ -369,8 +369,12 @@ class AudiobookshelfClient(RestApiMixin):
 
         abs_users_by_id = {u["id"]: u for u in raw_users}
 
+        known_users = self._get_server_users()
+        if self._skip_prune_on_empty_remote(not abs_users_by_id, known_users):
+            return known_users
+
         # Remove users no longer in Audiobookshelf, add new users
-        for db_user in self._get_server_users():
+        for db_user in known_users:
             if db_user.token not in abs_users_by_id:
                 db.session.delete(db_user)
 

--- a/app/services/media/client_base.py
+++ b/app/services/media/client_base.py
@@ -117,6 +117,30 @@ class MediaClient(ABC):
         self.url = row.url  # type: ignore
         self.token = row.api_key  # type: ignore
 
+    def _skip_prune_on_empty_remote(
+        self, remote_is_empty: bool, known_users: list[User]
+    ) -> bool:
+        """Return True when an empty remote user set must NOT prune local users.
+
+        ``list_users`` runs automatically when the Users page loads. A
+        successful fetch that yields no users is far more likely to be a
+        transient upstream condition or an identity/filter mismatch than the
+        admin genuinely removing everyone, so pruning here would silently delete
+        every local user (and cascade to their activity sessions) with no
+        confirmation. When this returns True the caller should return its
+        existing users unchanged; explicit deletion from the UI is unaffected.
+        """
+        if remote_is_empty and known_users:
+            logging.warning(
+                "%s returned no users for server_id=%s but %d are known locally; "
+                "skipping prune to avoid deleting them.",
+                type(self).__name__,
+                getattr(self, "server_id", None),
+                len(known_users),
+            )
+            return True
+        return False
+
     def generate_image_proxy_url(self, image_url: str) -> str:
         """
         Generate a secure proxy URL for an image.

--- a/app/services/media/drop.py
+++ b/app/services/media/drop.py
@@ -105,6 +105,12 @@ class DropClient(RestApiMixin):
 
             remote_by_id = {str(u.get("id")): u for u in remote_users if u.get("id")}
 
+            known_users = User.query.filter(
+                User.server_id == getattr(self, "server_id", None)
+            ).all()
+            if self._skip_prune_on_empty_remote(not remote_by_id, known_users):
+                return known_users
+
             # Upsert user rows in local DB
             for user_id, drop_user in remote_by_id.items():
                 db_row: User | None = User.query.filter_by(

--- a/app/services/media/jellyfin.py
+++ b/app/services/media/jellyfin.py
@@ -430,8 +430,12 @@ class JellyfinClient(RestApiMixin):
 
         jf_users_by_id = {u["Id"]: u for u in raw_users}
 
+        known_users = self._get_server_users()
+        if self._skip_prune_on_empty_remote(not jf_users_by_id, known_users):
+            return known_users
+
         # Remove users no longer in Jellyfin, add new users
-        for db_user in self._get_server_users():
+        for db_user in known_users:
             if db_user.token not in jf_users_by_id:
                 db.session.delete(db_user)
 

--- a/app/services/media/kavita.py
+++ b/app/services/media/kavita.py
@@ -659,6 +659,12 @@ class KavitaClient(RestApiMixin):
 
             users_dict = {str(u["id"]): u for u in kavita_users}
 
+            known_users = User.query.filter(
+                User.server_id == getattr(self, "server_id", None)
+            ).all()
+            if self._skip_prune_on_empty_remote(not users_dict, known_users):
+                return known_users
+
             for kavita_user in users_dict.values():
                 existing = User.query.filter_by(token=str(kavita_user["id"])).first()
                 if not existing:

--- a/app/services/media/komga.py
+++ b/app/services/media/komga.py
@@ -219,6 +219,12 @@ class KomgaClient(RestApiMixin):
             response = self.get("/api/v2/users")
             komga_users = {u["id"]: u for u in response.json()}
 
+            known_users = User.query.filter(
+                User.server_id == getattr(self, "server_id", None)
+            ).all()
+            if self._skip_prune_on_empty_remote(not komga_users, known_users):
+                return known_users
+
             for komga_user in komga_users.values():
                 existing = User.query.filter_by(token=komga_user["id"]).first()
                 if not existing:

--- a/app/services/media/navidrome.py
+++ b/app/services/media/navidrome.py
@@ -147,6 +147,10 @@ class NavidromeClient(RestApiMixin):
 
         users_by_name = {u["username"]: u for u in users_data}
 
+        known_users = User.query.filter(User.server_id == server_id).all()
+        if self._skip_prune_on_empty_remote(not users_by_name, known_users):
+            return known_users
+
         try:
             # Add new users or update existing ones
             for username, remote in users_by_name.items():

--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -910,24 +910,12 @@ class PlexClient(MediaClient):
         )
 
         known_users = self._get_server_users()
-        if not plex_users_by_email and known_users:
-            # We hold users locally but the remote set came back empty. That is far
-            # more likely to be a transient upstream condition or a machineIdentifier
-            # mismatch than the admin genuinely unsharing everyone, and this sync runs
-            # automatically when the Users page loads. Pruning here would delete every
-            # local user (and cascade to their activity sessions) with no confirmation,
-            # so skip the prune. Explicit deletion from the UI is unaffected.
-            logging.warning(
-                "Plex returned no users for server_id=%s but %d are known locally; "
-                "skipping prune to avoid deleting them.",
-                self.server_id,
-                len(known_users),
-            )
+        if self._skip_prune_on_empty_remote(not plex_users_by_email, known_users):
             return known_users
 
         # Remove users no longer in Plex, add new users
         known_emails = set(plex_users_by_email.keys())
-        for db_user in self._get_server_users():
+        for db_user in known_users:
             if db_user.email not in known_emails:
                 db.session.delete(db_user)
 

--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -909,6 +909,22 @@ class PlexClient(MediaClient):
             admin_users, self.server.machineIdentifier
         )
 
+        known_users = self._get_server_users()
+        if not plex_users_by_email and known_users:
+            # We hold users locally but the remote set came back empty. That is far
+            # more likely to be a transient upstream condition or a machineIdentifier
+            # mismatch than the admin genuinely unsharing everyone, and this sync runs
+            # automatically when the Users page loads. Pruning here would delete every
+            # local user (and cascade to their activity sessions) with no confirmation,
+            # so skip the prune. Explicit deletion from the UI is unaffected.
+            logging.warning(
+                "Plex returned no users for server_id=%s but %d are known locally; "
+                "skipping prune to avoid deleting them.",
+                self.server_id,
+                len(known_users),
+            )
+            return known_users
+
         # Remove users no longer in Plex, add new users
         known_emails = set(plex_users_by_email.keys())
         for db_user in self._get_server_users():

--- a/app/services/media/romm.py
+++ b/app/services/media/romm.py
@@ -149,6 +149,12 @@ class RommClient(RestApiMixin):
 
         remote_by_id = {str(u.get("id") or u["username"]): u for u in remote_users}
 
+        known_users = User.query.filter(
+            User.server_id == getattr(self, "server_id", None)
+        ).all()
+        if self._skip_prune_on_empty_remote(not remote_by_id, known_users):
+            return known_users
+
         # 1) upsert basic user rows so Wizarr UI has something to show
         for romm_id, ru in remote_by_id.items():
             db_row: User | None = User.query.filter_by(

--- a/tests/test_user_sync_empty_response.py
+++ b/tests/test_user_sync_empty_response.py
@@ -8,8 +8,18 @@ everyone" and pruned every local row.
 
 from unittest.mock import Mock, PropertyMock, patch
 
+import pytest
+
 from app.models import MediaServer, User
+from app.services.media.audiobookshelf import AudiobookshelfClient
+from app.services.media.drop import DropClient
+from app.services.media.emby import EmbyClient
+from app.services.media.jellyfin import JellyfinClient
+from app.services.media.kavita import KavitaClient
+from app.services.media.komga import KomgaClient
+from app.services.media.navidrome import NavidromeClient
 from app.services.media.plex import PlexClient
+from app.services.media.romm import RommClient
 
 
 def _server(session):
@@ -94,3 +104,111 @@ def test_genuine_removal_still_prunes(session):
         PlexClient.list_users.__wrapped__(client)
 
     assert _emails(server) == {"keep@example.com"}
+
+
+# ─── The same bug was latent in every other backend ─────────────────────────
+#
+# They all share one shape: build a dict of remote users, then prune every local
+# user whose key is absent from it. A successful-but-empty fetch made that dict
+# empty and deleted everyone. The base-class guard (_skip_prune_on_empty_remote)
+# now covers them all; these tests drive each real list_users with an empty
+# remote set and assert the local rows survive.
+
+
+class _EmptyResp:
+    """A successful HTTP response whose body is an empty user list."""
+
+    status_code = 200
+    text = "[]"
+
+    def json(self):
+        return []
+
+    def raise_for_status(self):
+        return None
+
+
+def _make_server(session, server_type):
+    server = MediaServer(
+        name=server_type,
+        server_type=server_type,
+        url="http://media.local",
+        api_key="token",
+    )
+    session.add(server)
+    session.commit()
+    return server
+
+
+def _seed(session, server, names):
+    for name in names:
+        session.add(
+            User(
+                token=name,
+                username=name,
+                email=f"{name}@example.com",
+                code="empty",
+                server_id=server.id,
+            )
+        )
+    session.commit()
+
+
+def _rest_client(cls, server):
+    """Build a client without running __init__ (no network/credentials)."""
+    client = cls.__new__(cls)
+    client.server_id = server.id
+    return client
+
+
+def _usernames(server):
+    return {u.username for u in User.query.filter_by(server_id=server.id).all()}
+
+
+@pytest.mark.parametrize(
+    ("cls", "server_type"),
+    [
+        (JellyfinClient, "jellyfin"),
+        (EmbyClient, "emby"),
+        (AudiobookshelfClient, "audiobookshelf"),
+        (KomgaClient, "komga"),
+        (KavitaClient, "kavita"),
+        (RommClient, "romm"),
+        (DropClient, "drop"),
+    ],
+)
+def test_empty_remote_preserves_local_users(session, cls, server_type):
+    """A successful but empty user fetch must not wipe the local rows."""
+    server = _make_server(session, server_type)
+    _seed(session, server, ["alice", "bob"])
+    client = _rest_client(cls, server)
+    client.get = lambda *args, **kwargs: _EmptyResp()
+
+    client.list_users()
+
+    assert _usernames(server) == {"alice", "bob"}
+
+
+def test_empty_remote_preserves_local_users_navidrome(session):
+    """Navidrome fetches over Subsonic rather than .get(), but the guard still applies."""
+    server = _make_server(session, "navidrome")
+    _seed(session, server, ["alice", "bob"])
+    client = _rest_client(NavidromeClient, server)
+
+    with patch.object(
+        NavidromeClient, "_subsonic_request", return_value={"users": {"user": []}}
+    ):
+        client.list_users()
+
+    assert _usernames(server) == {"alice", "bob"}
+
+
+def test_skip_prune_helper_decision(session):
+    """The guard skips only when the remote set is empty AND local users exist."""
+    server = _make_server(session, "jellyfin")
+    client = _rest_client(JellyfinClient, server)
+    present = [Mock()]
+
+    assert client._skip_prune_on_empty_remote(True, present) is True
+    assert client._skip_prune_on_empty_remote(False, present) is False
+    assert client._skip_prune_on_empty_remote(True, []) is False

--- a/tests/test_user_sync_empty_response.py
+++ b/tests/test_user_sync_empty_response.py
@@ -1,0 +1,96 @@
+"""An empty remote user list must not delete every local user.
+
+list_users() runs automatically when the Users page loads (admin/users.html has a
+hidden hx-get with hx-trigger="load"). It guards against the request raising, but
+a successful response that yields no users was treated as "the admin unshared
+everyone" and pruned every local row.
+"""
+
+from unittest.mock import Mock, PropertyMock, patch
+
+from app.models import MediaServer, User
+from app.services.media.plex import PlexClient
+
+
+def _server(session):
+    server = MediaServer(
+        name="Plex", server_type="plex", url="http://plex.local", api_key="token"
+    )
+    session.add(server)
+    session.commit()
+    return server
+
+
+def _users(session, server, emails):
+    for email in emails:
+        session.add(
+            User(
+                email=email,
+                username=email.split("@")[0],
+                token="None",
+                code="None",
+                server_id=server.id,
+            )
+        )
+    session.commit()
+
+
+def _client(server):
+    """Build a PlexClient without touching the network."""
+    client = PlexClient.__new__(PlexClient)
+    client.server_id = server.id
+    return client
+
+
+def _emails(server):
+    return {u.email for u in User.query.filter_by(server_id=server.id).all()}
+
+
+def test_empty_remote_list_does_not_delete_local_users(session):
+    """The reported failure: a successful response with zero users wiped the table."""
+    server = _server(session)
+    _users(session, server, ["a@example.com", "b@example.com"])
+    client = _client(server)
+
+    # spec'd deliberately: a bare Mock auto-creates any attribute, which hides
+    # typos like self.server.name (PlexServer exposes friendlyName, not name)
+    fake_server = Mock(spec=["machineIdentifier", "friendlyName"])
+    fake_server.machineIdentifier = "mid"
+    with (
+        patch.object(PlexClient, "admin", new_callable=PropertyMock) as admin,
+        patch.object(PlexClient, "server", new_callable=PropertyMock) as srv,
+        patch.object(PlexClient, "_filter_users_for_server", return_value={}),
+    ):
+        admin.return_value.users.return_value = []
+        srv.return_value = fake_server
+        PlexClient.list_users.__wrapped__(client)
+
+    assert _emails(server) == {"a@example.com", "b@example.com"}
+
+
+def test_genuine_removal_still_prunes(session):
+    """A non-empty remote set must still drop users that are no longer shared."""
+    server = _server(session)
+    _users(session, server, ["keep@example.com", "gone@example.com"])
+    client = _client(server)
+
+    # spec'd deliberately: a bare Mock auto-creates any attribute, which hides
+    # typos like self.server.name (PlexServer exposes friendlyName, not name)
+    fake_server = Mock(spec=["machineIdentifier", "friendlyName"])
+    fake_server.machineIdentifier = "mid"
+    keeper = Mock(title="keep")
+    with (
+        patch.object(PlexClient, "admin", new_callable=PropertyMock) as admin,
+        patch.object(PlexClient, "server", new_callable=PropertyMock) as srv,
+        patch.object(
+            PlexClient,
+            "_filter_users_for_server",
+            return_value={"keep@example.com": keeper},
+        ),
+        patch.object(PlexClient, "_sync_user_permissions", return_value=None),
+    ):
+        admin.return_value.users.return_value = [keeper]
+        srv.return_value = fake_server
+        PlexClient.list_users.__wrapped__(client)
+
+    assert _emails(server) == {"keep@example.com"}


### PR DESCRIPTION
Fixes #1356.

`list_users()` prunes local users missing from the remote set. It guards against the request raising, but not against a successful response that yields nothing, and treats that as "the admin unshared everyone".

The sync isn't opt-in. `admin/users.html` has a hidden `hx-get="/hx/users/sync"` with `hx-trigger="load delay:2s"`, and the server filter defaults to empty, so opening the Users page syncs every configured server.

Two ways the set goes empty without an exception: plex.tv returns a successful response with no accounts, or `_filter_users_for_server` matches nothing because the `machineIdentifier` doesn't line up, which happens even when plex.tv returned a full list.

Reproduced against a copy of my own install, real plex.tv, transport not mocked:

```
plex.tv returned 5 accounts
  filtered with correct machineIdentifier: 5
  filtered with wrong   machineIdentifier: 0
before: users=5
after : users=0     <- stock
after : users=5     <- with this change
```

The change skips the prune when the remote set is empty but local users exist, and logs it. Explicit deletion from the UI is unaffected, so an admin who really did unshare everyone can still clear them out.

## Every backend, one guard

It's the same bug in every backend, not just Plex. They all share one shape: build a dict of remote users, then delete each local user whose key is absent from it. A successful but empty fetch makes that set empty and deletes everyone, and the sync runs on page load.

The decision now lives in `MediaClient._skip_prune_on_empty_remote` and is called from `plex.py`, `jellyfin.py` (inherited by `emby.py`), `audiobookshelf.py`, `komga.py`, `kavita.py`, `romm.py`, `navidrome.py` and `drop.py`. Plex also reuses its already-fetched user list for the prune loop instead of re-querying.

The guard is subtractive: `if remote_is_empty and known_users` can never fire on a non-empty fetch, so it only ever prevents a delete, never causes one. Plex is still the backend I run against a live server; the others are covered by tests that stub the fetch and run the real prune path.

## Tests

`tests/test_user_sync_empty_response.py`:

- the original Plex pair: an empty remote set leaves local users alone, a non-empty one still prunes users that are genuinely gone
- each other backend (jellyfin, emby, audiobookshelf, komga, kavita, romm, navidrome, drop) drives its real `list_users` with an empty remote set and asserts the local rows survive
- a direct test of the shared guard's decision in all three states

Every empty-remote case fails on main, where the backend deletes the seeded users, and passes here. The non-empty Plex case is the regression guard and passes both ways.

The Plex `server` mock is `spec`'d on purpose. My first version used a bare `Mock`, which auto-creates any attribute and happily hid a real typo in my own patch (`self.server.name`, where `PlexServer` exposes `friendlyName`). The container run caught it; the spec'd mock now catches it in the suite.

Full suite green locally apart from `tests/e2e`, which needs a browser I don't have.
