### PR TITLE
fix: allow deleting invitations whose code contains whitespace

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -239,11 +239,15 @@ def invite_table():
     # ------------------------------------------------------------------
     server_filter = request.form.get("server") or request.args.get("server")
 
-    if code := request.args.get("delete"):
-        # Find the invitation to delete
-        invitation = Invitation.query.filter_by(code=code).first()
+    if delete_id := request.args.get("delete"):
+        # Delete by primary key. Deleting by code broke when a code contained a
+        # trailing space: the browser strips it from the query string, so the
+        # exact-match lookup never matched and the invitation became undeletable.
+        invitation = (
+            db.session.get(Invitation, int(delete_id)) if delete_id.isdigit() else None
+        )
         if invitation:
-            # Delete the invitation - CASCADE will handle association table cleanup
+            # CASCADE handles association-table cleanup
             db.session.delete(invitation)
             db.session.commit()
 

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -230,7 +230,7 @@ def invite_table():
 
     Accepts:
       - server filter via POST form data (preferred) or querystring (?server=ID)
-      - delete action via querystring (?delete=CODE)
+      - delete action via querystring (?delete_id=ID)
 
     Returns the 'tables/invite_card.html' partial.
     """
@@ -239,17 +239,30 @@ def invite_table():
     # ------------------------------------------------------------------
     server_filter = request.form.get("server") or request.args.get("server")
 
-    if delete_id := request.args.get("delete"):
+    if raw_delete_id := request.args.get("delete_id"):
         # Delete by primary key. Deleting by code broke when a code contained a
         # trailing space: the browser strips it from the query string, so the
         # exact-match lookup never matched and the invitation became undeletable.
-        invitation = (
-            db.session.get(Invitation, int(delete_id)) if delete_id.isdigit() else None
-        )
-        if invitation:
-            # CASCADE handles association-table cleanup
-            db.session.delete(invitation)
-            db.session.commit()
+        #
+        # Use an explicit ?delete_id= parameter rather than reusing the old
+        # ?delete= (which carried an invite *code*): a stale numeric code from a
+        # cached page could otherwise be read as an unrelated invitation *id* and
+        # delete the wrong row. Old cached ?delete= requests now simply no-op.
+        #
+        # Parse defensively — str.isdigit() accepts values int() rejects (e.g.
+        # "²") and over-long digit strings hit Python's int-conversion limit,
+        # so an unguarded int() would raise and 500. Treat anything unparseable as
+        # a no-op.
+        try:
+            delete_pk = int(raw_delete_id)
+        except (TypeError, ValueError):
+            delete_pk = None
+        if delete_pk is not None:
+            invitation = db.session.get(Invitation, delete_pk)
+            if invitation:
+                # CASCADE handles association-table cleanup
+                db.session.delete(invitation)
+                db.session.commit()
 
     # ------------------------------------------------------------------
     # 2. Base query (libraries + servers)

--- a/app/services/invites.py
+++ b/app/services/invites.py
@@ -68,7 +68,7 @@ def _get_form_list(form: Any, key: str) -> list[str]:
 def create_invite(form: Any) -> Invitation:
     """Takes a WTForms or dict-like `form` with the same keys as your old version."""
     # generate or validate provided code
-    code = (form.get("code") or _generate_code()).upper()
+    code = (form.get("code") or _generate_code()).strip().upper()
 
     if (
         not (MIN_CODESIZE <= len(code) <= MAX_CODESIZE)

--- a/app/templates/tables/invite_card.html
+++ b/app/templates/tables/invite_card.html
@@ -180,7 +180,7 @@
                 </button>
                 <!-- Delete invitation button -->
                 <button class="h-8 w-8 p-0 inline-flex items-center justify-center text-white bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 rounded-md transition-colors"
-                        hx-post="/invite/table?delete={{ invite.code }}"
+                        hx-post="/invite/table?delete={{ invite.id }}"
                         hx-trigger="click"
                         hx-target="#invite_table"
                         hx-swap="outerHTML swap:0.5s"

--- a/app/templates/tables/invite_card.html
+++ b/app/templates/tables/invite_card.html
@@ -180,7 +180,7 @@
                 </button>
                 <!-- Delete invitation button -->
                 <button class="h-8 w-8 p-0 inline-flex items-center justify-center text-white bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 rounded-md transition-colors"
-                        hx-post="/invite/table?delete={{ invite.id }}"
+                        hx-post="/invite/table?delete_id={{ invite.id }}"
                         hx-trigger="click"
                         hx-target="#invite_table"
                         hx-swap="outerHTML swap:0.5s"
@@ -255,7 +255,7 @@
 
     // Fade out on delete before htmx swap
     document.addEventListener("htmx:beforeRequest", function(evt) {
-        if (evt.target.hasAttribute('hx-post') && evt.target.getAttribute('hx-post').includes('delete=')) {
+        if (evt.target.hasAttribute('hx-post') && evt.target.getAttribute('hx-post').includes('delete_id=')) {
             const card = evt.target.closest(".animate__animated");
             if (card) card.classList.add("animate__fadeOut");
         }

--- a/tests/test_invite_delete_by_id.py
+++ b/tests/test_invite_delete_by_id.py
@@ -1,0 +1,79 @@
+"""
+Regression test: invitations must be deletable by primary key.
+
+Deleting by ``code`` broke when a code contained a trailing space. The browser
+strips trailing spaces from the query string, so the exact-match lookup never
+matched the stored code and the invitation became impossible to delete from the
+UI (it appeared to "respawn" after every delete). The delete action now uses the
+invitation id, and ``create_invite`` strips surrounding whitespace so such codes
+can't be stored in the first place.
+"""
+
+import pytest
+
+from app.extensions import db
+from app.models import AdminAccount, Invitation, MediaServer
+from app.services.invites import create_invite
+
+
+@pytest.fixture
+def admin_user(app):
+    """Create an admin account for authenticated requests."""
+    with app.app_context():
+        created = False
+        previous_hash = None
+        admin = AdminAccount.query.filter_by(username="testadmin").first()
+        if not admin:
+            admin = AdminAccount(username="testadmin")
+            admin.set_password("TestPass123")
+            db.session.add(admin)
+            db.session.commit()
+            created = True
+        else:
+            previous_hash = admin.password_hash
+            admin.set_password("TestPass123")
+            db.session.commit()
+        yield admin
+        if created:
+            db.session.delete(admin)
+            db.session.commit()
+        elif previous_hash is not None:
+            admin = AdminAccount.query.filter_by(username="testadmin").first()
+            if admin:
+                admin.password_hash = previous_hash
+                db.session.commit()
+
+
+def test_delete_invite_with_trailing_space_in_code(client, app, admin_user):
+    """An invite whose code has a trailing space is deletable via its id."""
+    with app.app_context():
+        invite = Invitation(code="ABC123 ", used=False, unlimited=False)
+        db.session.add(invite)
+        db.session.commit()
+        invite_id = invite.id
+
+    client.post("/login", data={"username": "testadmin", "password": "TestPass123"})
+
+    response = client.post(f"/invite/table?delete={invite_id}")
+    assert response.status_code == 200
+
+    with app.app_context():
+        assert db.session.get(Invitation, invite_id) is None
+
+
+def test_create_invite_strips_whitespace_from_code(app):
+    """create_invite() strips surrounding whitespace before storing the code."""
+    with app.app_context():
+        server = MediaServer(
+            name="Strip Test Server",
+            server_type="jellyfin",
+            url="http://localhost:8096",
+            api_key="test-key",
+        )
+        db.session.add(server)
+        db.session.flush()
+
+        invite = create_invite(
+            {"code": "STRIP01 ", "expires": "never", "server_ids": [str(server.id)]}
+        )
+        assert invite.code == "STRIP01"

--- a/tests/test_invite_delete_by_id.py
+++ b/tests/test_invite_delete_by_id.py
@@ -54,11 +54,59 @@ def test_delete_invite_with_trailing_space_in_code(client, app, admin_user):
 
     client.post("/login", data={"username": "testadmin", "password": "TestPass123"})
 
-    response = client.post(f"/invite/table?delete={invite_id}")
+    response = client.post(f"/invite/table?delete_id={invite_id}")
     assert response.status_code == 200
 
     with app.app_context():
         assert db.session.get(Invitation, invite_id) is None
+
+
+def test_stale_delete_by_code_param_is_ignored(client, app, admin_user):
+    """A cached ?delete= request (old code-based contract) must not delete a row.
+
+    The delete action moved to an explicit ?delete_id= parameter. Old cached
+    markup can still post ?delete=<code>, where the code may be numeric and
+    collide with an unrelated invitation's id. Such requests must now no-op so
+    they can never delete the wrong invitation.
+    """
+    with app.app_context():
+        invite = Invitation(code="123", used=False, unlimited=False)
+        db.session.add(invite)
+        db.session.commit()
+        invite_id = invite.id
+
+    client.post("/login", data={"username": "testadmin", "password": "TestPass123"})
+
+    # Old contract: ?delete=<numeric code that happens to equal a real id>.
+    response = client.post(f"/invite/table?delete={invite_id}")
+    assert response.status_code == 200
+
+    with app.app_context():
+        # Still present — the legacy parameter no longer deletes anything.
+        assert db.session.get(Invitation, invite_id) is not None
+
+
+@pytest.mark.parametrize("bad_id", ["²", "abc", "9" * 5000, "", "1.5", "-"])
+def test_delete_with_unparseable_id_is_noop_not_500(client, app, admin_user, bad_id):
+    """Non-integer delete_id values must no-op with 200, never raise a 500.
+
+    str.isdigit() accepts values int() rejects ("²"), and digit strings longer
+    than Python's conversion limit raise ValueError. The handler parses in a
+    try/except and treats anything unparseable as a no-op.
+    """
+    with app.app_context():
+        invite = Invitation(code="KEEPME", used=False, unlimited=False)
+        db.session.add(invite)
+        db.session.commit()
+        invite_id = invite.id
+
+    client.post("/login", data={"username": "testadmin", "password": "TestPass123"})
+
+    response = client.post(f"/invite/table?delete_id={bad_id}")
+    assert response.status_code == 200
+
+    with app.app_context():
+        assert db.session.get(Invitation, invite_id) is not None
 
 
 def test_create_invite_strips_whitespace_from_code(app):


### PR DESCRIPTION
## Problem

An invitation whose `code` contains a trailing space cannot be deleted from the admin UI — it reappears after every attempt.

**Repro:** create an invite with a custom code that ends in a space (e.g. `"ABC123 "`), then click delete on the Invitations page. The card fades out, then comes back.

## Cause

The delete button posts `/invite/table?delete={{ invite.code }}`. The browser's URL parser strips trailing spaces from the query string, so the server receives the code **without** the trailing space. `invite_table()` then does an exact match:

```python
invitation = Invitation.query.filter_by(code=code).first()
```

which never matches the stored code, so nothing is deleted. The client-side fade-out hides the card, and the re-rendered grid brings it right back.

## Fix

- Delete by primary key instead of by code (matching the existing REST API `DELETE /invitations/<id>`), so the lookup is robust to whitespace and other URL-sensitive characters.
- Strip surrounding whitespace from codes in `create_invite()` so such codes can't be stored in the first place.
- Add regression tests for the delete-by-id path and the code strip.

## Testing

```
pytest tests/test_invite_delete_by_id.py
```

Both tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
