### PR TITLE
fix: close the Plex OAuth popup so the token isn't lost and the user reaches the wizard

### DIFF
--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -103,6 +103,9 @@
                   </div>
                 </div>
               {% endif %}
+              <div id="plex-oauth-error"
+                   class="hidden flex items-center space-x-2 text-red-400 text-sm"
+                   role="alert"></div>
               <button onClick="oauth(); return false;"
                       class="w-full py-4 px-6 text-white font-semibold text-lg bg-gradient-to-r from-primary to-primary_hover hover:from-primary_hover hover:to-primary rounded-xl transition-all duration-200 transform hover:scale-[1.02] focus:ring-4 focus:ring-primary/30 focus:outline-none shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed">
                 {{ _("Join Server") }}
@@ -393,9 +396,32 @@
       // nanoid package, for generating client-identifier in plexHeaders
       let nanoid = (t = 21) => crypto.getRandomValues(new Uint8Array(t)).reduce(((t, e) => t += (e &= 63) < 36 ? e.toString(36) : e < 62 ? (e - 26).toString(36).toUpperCase() : e > 62 ? "-" : "_"), "");
 
+      const PLEX_MSG = {
+          blocked: {{ _("Pop-up blocked. Allow pop-ups for this site and try again.")|tojson }},
+          cancelled: {{ _("Sign-in cancelled. Hit Join Server to try again.")|tojson }},
+          failed: {{ _("Plex sign-in failed. Try again, or contact your server admin.")|tojson }},
+      };
+
+      function showPlexError(message) {
+          const box = document.querySelector("#plex-oauth-error");
+          if (!box) return;
+          box.textContent = message;
+          box.classList.remove("hidden");
+      }
+
       // adapted from overseerr
       async function oauth() {
-          let popup = window.open("", "Plex", 'width=600, height=700, toolbar=no, menubar=no');
+          const errorBox = document.querySelector("#plex-oauth-error");
+          if (errorBox) errorBox.classList.add("hidden");
+
+          const popup = window.open("", "Plex", 'width=600, height=700, toolbar=no, menubar=no');
+          if (!popup) {
+              // Popup blocker. Without this the next line throws and the user
+              // is left staring at a button that appears to do nothing.
+              showPlexError(PLEX_MSG.blocked);
+              return;
+          }
+
           const browser = window.bowser.getParser(window.navigator.userAgent);
           const plexHeaders = {
               Accept: 'application/json',
@@ -430,24 +456,58 @@
 
           popup.location.href = `https://app.plex.tv/auth/#!?${params}`;
 
-          const authToken = await new Promise((resolve, reject) => {
-              const currentTime = Date.now()
-              const interval = setInterval(async () => {
-                  if (popup.closed) return location.reload();
-                  const resp = await fetch(`https://plex.tv/api/v2/pins/${pin.id}`, {
-                      headers: plexHeaders
-                  }).then(r => r.json())
+          // Plex does not redirect the popup back to us, so the token arrives by
+          // polling the PIN. Once we have it we are responsible for closing the
+          // popup — otherwise it sits in front of the wizard and the user never
+          // sees the next step.
+          const PIN_TIMEOUT_MS = 5 * 60 * 1000;
 
-                  if (resp?.errors?.length) return location.reload();
-                  if (resp?.authToken) {
-                      clearInterval(interval)
-                      resolve(resp.authToken);
-                      return;
-                  }
-              }, 1000)
-          });
+          let authToken;
+          try {
+              authToken = await new Promise((resolve, reject) => {
+                  const deadline = Date.now() + PIN_TIMEOUT_MS;
+                  const interval = setInterval(async () => {
+                      try {
+                          const resp = await fetch(`https://plex.tv/api/v2/pins/${pin.id}`, {
+                              headers: plexHeaders
+                          }).then(r => r.json())
+
+                          if (resp?.errors?.length) {
+                              clearInterval(interval);
+                              return reject(new Error(resp.errors[0]?.message || "Plex returned an error"));
+                          }
+                          if (resp?.authToken) {
+                              clearInterval(interval);
+                              return resolve(resp.authToken);
+                          }
+                          // Checked *after* the poll on purpose: a user who approves
+                          // and then immediately closes the popup has still been
+                          // granted a token, and the poll above has just claimed it.
+                          if (popup.closed) {
+                              clearInterval(interval);
+                              return reject(new Error("cancelled"));
+                          }
+                          if (Date.now() > deadline) {
+                              clearInterval(interval);
+                              return reject(new Error("timed out"));
+                          }
+                      } catch (err) {
+                          clearInterval(interval);
+                          reject(err);
+                      }
+                  }, 1000)
+              });
+          } catch (err) {
+              if (!popup.closed) popup.close();
+              window.focus();
+              showPlexError(err?.message === "cancelled" ? PLEX_MSG.cancelled : PLEX_MSG.failed);
+              return;
+          }
+
+          if (!popup.closed) popup.close();
+          window.focus();
+
           document.querySelector("#token").value = authToken;
-
           document.forms[0].submit();
       }
   </script>


### PR DESCRIPTION
## Problem

After a user authenticates with Plex during the invite/wizard flow, the OAuth popup never closes:

1. The parent page receives the token, but the popup stays open **in front of** the wizard — the user sees a dead Plex page and assumes the flow stalled.
2. If they close the popup by hand, a token granted just before closing is **discarded**: the poll loop checks `popup.closed` *before* polling, and that branch calls `location.reload()`, throwing the auth away. No error is shown.

Net effect: invited Plex users authenticate successfully but are never provisioned downstream.

## Root cause

The OAuth JS in `user-plex-login.html` is, per its own comment, "adapted from Overseerr." Overseerr's `PlexOAuth` calls `closePopup()` as soon as the PIN poll yields a token — **that call was dropped in the adaptation.** `main` has no `popup.close()` anywhere in this file; it only has `if (popup.closed) return location.reload();`.

This isn't a regression in the file itself. Pre-`8fe6b22` (Feb 2023) Wizarr used a `forwardUrl`, so Plex redirected the popup back to the app. `8fe6b22` correctly moved OAuth client-side (to avoid leaking the user's IP) and replaced the redirect with PIN polling — but without the popup-close that made polling viable.

## Fix

- Close the popup once the token is in hand, then `window.focus()` back to the wizard.
- Poll **before** checking `popup.closed`, so a token granted just before the user closes the window is never lost.
- Fail loudly — an inline error box covers user-cancel, the 5-minute timeout, and Plex-side errors — instead of silently reloading.
- Handle `window.open` returning `null` (popup blocker), which previously threw and left the button inert.

## Testing

Verified end-to-end against a stubbed Plex PIN/token flow (popup → PIN poll → token → popup close → token POSTed to the join handler). All four failure modes above fail without this change and pass with it. Happy to add a test in whatever form fits your CI if you'd like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
