### PR TITLE
Return the user to Wizarr after Plex sign-in

### DIFF
--- a/app/blueprints/public/routes.py
+++ b/app/blueprints/public/routes.py
@@ -94,6 +94,27 @@ def invite(code):
     return result.to_flask_response()
 
 
+# ─── Plex OAuth return target  /plex/callback ───────────────────────────────
+@public_bp.route("/plex/callback")
+@limiter.limit("50 per minute")
+def plex_callback():
+    """Page Plex forwards the browser back to once the user has signed in.
+
+    The invite page hands Plex a ``forwardUrl`` pointing here so the browser
+    leaves app.plex.tv by itself. Usually the window that started the sign-in is
+    still open and polling, and this page just closes itself. When that window
+    is gone - the normal outcome on mobile, where the sign-in window is a whole
+    tab and the one behind it may be discarded - this page finishes the sign-in
+    instead, using state left in localStorage. It needs no session and reads no
+    invitation rows.
+    """
+    name_setting = Settings.query.filter_by(key="server_name").first()
+    return render_template(
+        "plex-oauth-callback.html",
+        server_name=name_setting.value if name_setting else "Wizarr",
+    )
+
+
 # ─── Unified invitation processing ─────────────────────────────────────────
 @public_bp.route("/invitation/process", methods=["POST"])
 @limiter.limit("20 per minute")

--- a/app/static/js/plex-oauth.js
+++ b/app/static/js/plex-oauth.js
@@ -1,0 +1,67 @@
+// Shared state for the Plex OAuth sign-in flow.
+//
+// Signing in happens on app.plex.tv in a second window, so two contexts can end
+// up racing to finish the same join: the invite page that opened it, and the
+// /plex/callback page that Plex forwards that window back to. The invite page
+// stays the authority for as long as it is alive; the callback page only takes
+// over when it is not, which is the normal outcome on mobile where the second
+// window is a background tab the OS is free to freeze or discard.
+//
+// State lives in localStorage rather than sessionStorage because the two
+// contexts are separate tabs and sessionStorage is per-tab.
+
+const WIZARR_PLEX_OAUTH_KEY = "wizarr.plexOAuth";
+
+function plexOAuthRead() {
+    try {
+        return JSON.parse(localStorage.getItem(WIZARR_PLEX_OAUTH_KEY)) || null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function plexOAuthWrite(state) {
+    try {
+        localStorage.setItem(WIZARR_PLEX_OAUTH_KEY, JSON.stringify(state));
+    } catch (e) {
+        // Storage can be unavailable (private mode, storage disabled). The flow
+        // still works in the window that started it, it just is not resumable.
+    }
+}
+
+function plexOAuthClear() {
+    try {
+        localStorage.removeItem(WIZARR_PLEX_OAUTH_KEY);
+    } catch (e) {
+        /* nothing to clean up */
+    }
+}
+
+// Mark this context as the one finishing the join. Returns false when the other
+// context claimed it first, so only one POST /join is ever sent.
+function plexOAuthClaim(who) {
+    const state = plexOAuthRead();
+    // No stored state means storage is unavailable, so there is no second
+    // context to coordinate with and the caller is the only one who can finish.
+    if (!state) return true;
+    if (state.claimedBy && state.claimedBy !== who) return false;
+    state.claimedBy = who;
+    plexOAuthWrite(state);
+    return true;
+}
+
+// Ask plex.tv whether the pin has been linked yet. Resolves to the auth token,
+// or null while the user is still signing in.
+async function plexOAuthPollToken(state) {
+    const resp = await fetch(`https://plex.tv/api/v2/pins/${state.pinId}`, {
+        headers: {
+            Accept: "application/json",
+            "X-Plex-Client-Identifier": state.clientId,
+        },
+    }).then((r) => r.json());
+
+    if (resp && resp.errors && resp.errors.length) {
+        throw new Error(resp.errors[0].message || "Plex rejected the sign-in.");
+    }
+    return (resp && resp.authToken) || null;
+}

--- a/app/static/js/plex-oauth.js
+++ b/app/static/js/plex-oauth.js
@@ -37,17 +37,35 @@ function plexOAuthClear() {
     }
 }
 
-// Mark this context as the one finishing the join. Returns false when the other
-// context claimed it first, so only one POST /join is ever sent.
+// Mark this context as the one finishing the join. Resolves false when the
+// other context claimed it first, so only one POST /join is ever sent.
+//
+// localStorage has no compare-and-swap, so a plain read-modify-write can let
+// both contexts pass the "is it claimed?" check and each believe it won. The
+// claim is therefore two-phase: write a token unique to this call, wait a
+// beat for a concurrent writer to overwrite it, then re-read and proceed only
+// if our own token survived. The last write wins, and both contexts agree on
+// who that was.
 function plexOAuthClaim(who) {
     const state = plexOAuthRead();
     // No stored state means storage is unavailable, so there is no second
     // context to coordinate with and the caller is the only one who can finish.
-    if (!state) return true;
-    if (state.claimedBy && state.claimedBy !== who) return false;
+    if (!state) return Promise.resolve(true);
+    if (state.claimedBy && state.claimedBy !== who) {
+        return Promise.resolve(false);
+    }
+    const token = who + ":" + Math.random().toString(36).slice(2);
     state.claimedBy = who;
+    state.claimToken = token;
     plexOAuthWrite(state);
-    return true;
+    return new Promise((resolve) => {
+        setTimeout(function () {
+            const confirmed = plexOAuthRead();
+            // State gone mid-claim means the other context finished and
+            // cleared it; anything but our own token still standing is a loss.
+            resolve(!!confirmed && confirmed.claimToken === token);
+        }, 75);
+    });
 }
 
 // Ask plex.tv whether the pin has been linked yet. Resolves to the auth token,

--- a/app/templates/plex-oauth-callback.html
+++ b/app/templates/plex-oauth-callback.html
@@ -97,7 +97,7 @@
           }
 
           async function finish() {
-              if (!plexOAuthClaim("callback")) {
+              if (!(await plexOAuthClaim("callback"))) {
                   // The opener redeemed the invite first. It shares our session,
                   // so the wizard is reachable from here too - go there rather
                   // than tell the user to find another window. The short wait lets
@@ -119,9 +119,12 @@
                       return;
                   }
                   if (token) {
-                      plexOAuthClear();
                       document.getElementById("plex-callback-code").value = state.code;
                       document.getElementById("plex-callback-token").value = token;
+                      // Clear only when leaving this page actually commits. If
+                      // the submit fails to navigate, the stored state is the
+                      // only thing that lets the sign-in be retried.
+                      window.addEventListener("pagehide", plexOAuthClear);
                       // Submitting navigates THIS window to the wizard, so the
                       // user lands there in the window they are looking at. This
                       // page never closes itself: closing a tab lets the browser

--- a/app/templates/plex-oauth-callback.html
+++ b/app/templates/plex-oauth-callback.html
@@ -63,38 +63,49 @@
                    false);
           }
 
-          // The sign-in window was opened at 600x700. A real popup is much
-          // smaller than the screen around it, while on a phone it is a whole
-          // tab that fills the screen. Compare against the available screen
-          // rather than a fixed size so a big phone and a small laptop both
-          // classify correctly, and assume "not a popup" when the browser will
-          // not say: finishing in a window we could have closed is untidy,
-          // closing a tab we should have kept strands the user.
-          function isPopupWindow() {
+          function goToWizard() {
+              window.location.href = "{{ url_for('wizard.start') }}";
+          }
+
+          // Is the window that opened us still on screen for the user?
+          //
+          // This is the whole question, and it is not "what kind of device is
+          // this". On a desktop the invite page is a separate window sitting
+          // behind this popup: still visible. On a phone the invite page is a
+          // background tab: hidden. The Page Visibility API reports exactly that,
+          // and the opener is same-origin (our own invite page) so we can read
+          // it directly. Touch screens, window size and zoom do not come into
+          // it - a visible window is a visible window.
+          //
+          // When the opener is visible it is already polling and will submit the
+          // sign-in in its own window and close this popup, so we do nothing and
+          // let it. When the opener is hidden or gone, this page is the only
+          // thing the user can see, so we finish here.
+          function openerIsVisible() {
               try {
-                  if (!window.outerWidth || !window.outerHeight) {
-                      return false;
-                  }
+                  const o = window.opener;
                   return (
-                      window.outerWidth <= screen.availWidth * 0.9 &&
-                      window.outerHeight <= screen.availHeight * 0.9
+                      !!o && !o.closed && o.document.visibilityState === "visible"
                   );
               } catch (e) {
+                  // Opener navigated away or is otherwise unreadable. Treat it as
+                  // gone and finish here, which is the safe default: better to
+                  // finish in a window we did not need to than to wait on a window
+                  // that is never coming back.
                   return false;
               }
           }
 
           async function finish() {
               if (!plexOAuthClaim("callback")) {
-                  // The invite page got the token first. On a phone it is behind
-                  // us and the user is looking at this tab, so follow it into the
-                  // wizard rather than telling them to go and find another tab.
+                  // The opener redeemed the invite first. It shares our session,
+                  // so the wizard is reachable from here too - go there rather
+                  // than tell the user to find another window. The short wait lets
+                  // the opener's POST establish the session before we navigate.
                   stop("{{ _('All set') }}",
                        "{{ _('Taking you to the next step...') }}",
                        false);
-                  setTimeout(function () {
-                      window.location.href = "{{ url_for('wizard.start') }}";
-                  }, 2000);
+                  setTimeout(goToWizard, 2000);
                   return;
               }
 
@@ -111,6 +122,12 @@
                       plexOAuthClear();
                       document.getElementById("plex-callback-code").value = state.code;
                       document.getElementById("plex-callback-token").value = token;
+                      // Submitting navigates THIS window to the wizard, so the
+                      // user lands there in the window they are looking at. This
+                      // page never closes itself: closing a tab lets the browser
+                      // surface whatever it likes, which is the mobile failure the
+                      // page exists to prevent. On desktop the opener closes the
+                      // popup instead.
                       document.getElementById("plex-callback-form").submit();
                       return;
                   }
@@ -121,27 +138,18 @@
                    true);
           }
 
-          let opener = null;
-          try {
-              opener = window.opener && !window.opener.closed ? window.opener : null;
-          } catch (e) {
-              opener = null;
-          }
-
-          // Closing the popup does not lose the token: the invite page polls
-          // before it checks whether the popup went away, so a token granted
-          // just before we close is still claimed on the next tick.
-
-          // Only get out of the way when we really are a popup sitting on top of
-          // the page that opened us. Closing a tab does not let us choose what
-          // the browser surfaces next - it picks, and on a phone that can be any
-          // unrelated tab - so a full-size tab finishes the job here instead,
-          // where the user is actually looking.
-          if (opener && isPopupWindow()) {
-              window.close();
-              // close() is a request, not a guarantee. If we are still here a
-              // moment later, finish the job rather than sit on a dead page.
-              setTimeout(state ? finish : nothingToFinish, 1500);
+          if (openerIsVisible()) {
+              // The invite page is on screen and finishing the job; it will close
+              // this popup. Sit tight. If it somehow never does - it died, or Plex
+              // returned here but the opener stopped polling - take over rather
+              // than leave the user on a spinner forever.
+              setTimeout(function () {
+                  if (state) {
+                      finish();
+                  } else {
+                      nothingToFinish();
+                  }
+              }, 60000);
               return;
           }
 

--- a/app/templates/plex-oauth-callback.html
+++ b/app/templates/plex-oauth-callback.html
@@ -1,0 +1,156 @@
+{% extends "base.html" %}
+{% block title %}
+  Signing you in
+{% endblock title %}
+{% block main %}
+  <section class="min-h-screen bg-gradient-to-br from-slate-900 via-orange-900 to-slate-900 flex items-center justify-center px-6">
+    <div class="w-full max-w-md">
+      <div class="bg-gray-800/40 backdrop-blur-xl rounded-2xl shadow-2xl border border-gray-700/50 p-8 text-center space-y-4">
+        <svg id="plex-callback-spinner"
+             class="animate-spin h-8 w-8 text-primary mx-auto"
+             fill="none"
+             viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+        </svg>
+        <h1 id="plex-callback-heading" class="text-2xl font-bold text-white">{{ _("Signing you in") }}</h1>
+        <p id="plex-callback-message" class="text-gray-300 text-sm">
+          {{ _("Finishing up with Plex. This only takes a moment.") }}
+        </p>
+        <button id="plex-callback-retry"
+                type="button"
+                class="hidden w-full py-3 px-6 text-white font-semibold bg-gradient-to-r from-primary to-primary_hover rounded-xl transition-all duration-200">
+          {{ _("Back to your invitation") }}
+        </button>
+      </div>
+    </div>
+  </section>
+  <form id="plex-callback-form"
+        action="{{ url_for('public.join') }}"
+        method="post"
+        class="hidden">
+    <input type="hidden" name="code" id="plex-callback-code">
+    <input type="hidden" name="token" id="plex-callback-token">
+  </form>
+  <script src="{{ url_for('static', filename='js/plex-oauth.js', v=app_version) }}"></script>
+  <script>
+      (function () {
+          const spinner = document.getElementById("plex-callback-spinner");
+          const heading = document.getElementById("plex-callback-heading");
+          const message = document.getElementById("plex-callback-message");
+          const retry = document.getElementById("plex-callback-retry");
+
+          const state = plexOAuthRead();
+          const inviteBase = "{{ url_for('public.invite', code='') }}";
+
+          function stop(title, text, showRetry) {
+              spinner.classList.add("hidden");
+              heading.textContent = title;
+              message.textContent = text;
+              if (showRetry && state && state.code) {
+                  retry.onclick = function () {
+                      window.location.href = inviteBase + encodeURIComponent(state.code);
+                  };
+                  retry.classList.remove("hidden");
+              }
+          }
+
+          function nothingToFinish() {
+              // A bookmarked or directly opened callback URL, or storage we
+              // could not write to when the sign-in started.
+              stop("{{ _('Nothing to finish') }}",
+                   "{{ _('Open your invitation link again to sign in with Plex.') }}",
+                   false);
+          }
+
+          // The sign-in window was opened at 600x700. A real popup is much
+          // smaller than the screen around it, while on a phone it is a whole
+          // tab that fills the screen. Compare against the available screen
+          // rather than a fixed size so a big phone and a small laptop both
+          // classify correctly, and assume "not a popup" when the browser will
+          // not say: finishing in a window we could have closed is untidy,
+          // closing a tab we should have kept strands the user.
+          function isPopupWindow() {
+              try {
+                  if (!window.outerWidth || !window.outerHeight) {
+                      return false;
+                  }
+                  return (
+                      window.outerWidth <= screen.availWidth * 0.9 &&
+                      window.outerHeight <= screen.availHeight * 0.9
+                  );
+              } catch (e) {
+                  return false;
+              }
+          }
+
+          async function finish() {
+              if (!plexOAuthClaim("callback")) {
+                  // The invite page got the token first. On a phone it is behind
+                  // us and the user is looking at this tab, so follow it into the
+                  // wizard rather than telling them to go and find another tab.
+                  stop("{{ _('All set') }}",
+                       "{{ _('Taking you to the next step...') }}",
+                       false);
+                  setTimeout(function () {
+                      window.location.href = "{{ url_for('wizard.start') }}";
+                  }, 2000);
+                  return;
+              }
+
+              const deadline = Date.now() + 120000;
+              while (Date.now() < deadline) {
+                  let token;
+                  try {
+                      token = await plexOAuthPollToken(state);
+                  } catch (e) {
+                      stop("{{ _('Sign-in failed') }}", e.message, true);
+                      return;
+                  }
+                  if (token) {
+                      plexOAuthClear();
+                      document.getElementById("plex-callback-code").value = state.code;
+                      document.getElementById("plex-callback-token").value = token;
+                      document.getElementById("plex-callback-form").submit();
+                      return;
+                  }
+                  await new Promise((r) => setTimeout(r, 1000));
+              }
+              stop("{{ _('That took too long') }}",
+                   "{{ _('We did not hear back from Plex. Please try signing in again.') }}",
+                   true);
+          }
+
+          let opener = null;
+          try {
+              opener = window.opener && !window.opener.closed ? window.opener : null;
+          } catch (e) {
+              opener = null;
+          }
+
+          // Closing the popup does not lose the token: the invite page polls
+          // before it checks whether the popup went away, so a token granted
+          // just before we close is still claimed on the next tick.
+
+          // Only get out of the way when we really are a popup sitting on top of
+          // the page that opened us. Closing a tab does not let us choose what
+          // the browser surfaces next - it picks, and on a phone that can be any
+          // unrelated tab - so a full-size tab finishes the job here instead,
+          // where the user is actually looking.
+          if (opener && isPopupWindow()) {
+              window.close();
+              // close() is a request, not a guarantee. If we are still here a
+              // moment later, finish the job rather than sit on a dead page.
+              setTimeout(state ? finish : nothingToFinish, 1500);
+              return;
+          }
+
+          if (!state) {
+              nothingToFinish();
+              return;
+          }
+
+          finish();
+      })();
+  </script>
+{% endblock main %}

--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -537,7 +537,7 @@
 
           // Only one of us may redeem the invite. If the callback page got there
           // first it is already submitting, so leave it to finish.
-          if (!plexOAuthClaim("opener")) return;
+          if (!(await plexOAuthClaim("opener"))) return;
           plexOAuthClear();
 
           if (!popup.closed) popup.close();

--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -278,6 +278,7 @@
       }
   </style>
   <script src="{{ url_for('static', filename='js/vendor/bowser.min.js', v=app_version) }}"></script> <!-- needed for plexHeaders -->
+  <script src="{{ url_for('static', filename='js/plex-oauth.js', v=app_version) }}"></script> <!-- defines plexOAuth* helpers used by oauth() -->
   <script>
       // Load movie posters for flowing grid background with progressive loading
       async function loadCinemaPosters() {

--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -451,15 +451,30 @@
               'context[device][model]': plexHeaders['X-Plex-Model'],
               'context[device][screenResolution]': plexHeaders['X-Plex-Device-Screen-Resolution'],
               'context[device][layout]': 'desktop',
-              code: pin.code
+              code: pin.code,
+              // Ask Plex to send the browser back to us when it is done. On a
+              // phone the sign-in window is a whole tab, so without somewhere to
+              // return to the user is simply left on Plex's page. Path from
+              // Flask so a prefixed mount resolves, origin from the browser so
+              // it is the one the user actually arrived on.
+              forwardUrl: window.location.origin + "{{ url_for('public.plex_callback') }}"
+          });
+
+          // Everything the callback needs to finish the sign-in without us. The
+          // tab that opened it may be frozen or discarded by the time Plex comes
+          // back, which is normal on mobile.
+          plexOAuthWrite({
+              pinId: pin.id,
+              clientId: plexHeaders['X-Plex-Client-Identifier'],
+              code: document.querySelector("#code")?.value || "",
           });
 
           popup.location.href = `https://app.plex.tv/auth/#!?${params}`;
 
-          // Plex does not redirect the popup back to us, so the token arrives by
-          // polling the PIN. Once we have it we are responsible for closing the
-          // popup — otherwise it sits in front of the wizard and the user never
-          // sees the next step.
+          // The token still arrives by polling the PIN: forwardUrl returns the
+          // browser to us but carries nothing. Once we have it we are
+          // responsible for closing the popup - otherwise it sits in front of
+          // the wizard and the user never sees the next step.
           const PIN_TIMEOUT_MS = 5 * 60 * 1000;
 
           let authToken;
@@ -479,6 +494,12 @@
                           if (resp?.authToken) {
                               clearInterval(interval);
                               return resolve(resp.authToken);
+                          }
+                          // The callback page took over because this window
+                          // looked gone. Stand down rather than race it.
+                          if (plexOAuthRead()?.claimedBy === "callback") {
+                              clearInterval(interval);
+                              return;
                           }
                           // Checked *after* the poll on purpose: a user who approves
                           // and then immediately closes the popup has still been
@@ -503,6 +524,11 @@
               showPlexError(err?.message === "cancelled" ? PLEX_MSG.cancelled : PLEX_MSG.failed);
               return;
           }
+
+          // Only one of us may redeem the invite. If the callback page got there
+          // first it is already submitting, so leave it to finish.
+          if (!plexOAuthClaim("opener")) return;
+          plexOAuthClear();
 
           if (!popup.closed) popup.close();
           window.focus();

--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -525,6 +525,15 @@
               return;
           }
 
+          // Only finish here if this window is the one the user is looking at.
+          // On a phone the sign-in happens in a whole tab and this invite page is
+          // a background tab the browser may still run for a while. Finishing
+          // from here would submit in a tab the user cannot see and, worse, close
+          // the callback tab they ARE looking at, which on Safari drops them onto
+          // whatever tab it surfaces next. The visible callback tab finishes
+          // instead; leave it to it.
+          if (document.visibilityState !== "visible") return;
+
           // Only one of us may redeem the invite. If the callback page got there
           // first it is already submitting, so leave it to finish.
           if (!plexOAuthClaim("opener")) return;

--- a/tests/test_plex_oauth_callback.py
+++ b/tests/test_plex_oauth_callback.py
@@ -105,3 +105,13 @@ def test_only_one_context_redeems_the_invite(client):
 
     assert 'plexOAuthClaim("opener")' in html
     assert 'claimedBy === "callback"' in html
+
+
+def test_a_hidden_invite_page_does_not_close_the_callback_tab(client):
+    """On mobile the invite page is a background tab the browser may still run.
+    If it finished from there it would close the callback tab the user is
+    looking at, and the browser then surfaces some unrelated tab - observed on
+    Safari. A hidden invite page must stand down and let the callback finish."""
+    html = client.post("/join", data={}).get_data(as_text=True)
+
+    assert 'document.visibilityState !== "visible"' in html

--- a/tests/test_plex_oauth_callback.py
+++ b/tests/test_plex_oauth_callback.py
@@ -1,0 +1,89 @@
+"""Plex OAuth returns the user to Wizarr instead of stranding them on plex.tv.
+
+Sign-in happens on app.plex.tv in a second window. Without a ``forwardUrl`` the
+browser has nowhere to go once Plex is done, so the user is left sitting on
+Plex's own screen while the invite page waits behind it - on mobile, where the
+second window is a whole tab, there is no way back at all.
+"""
+
+from pathlib import Path
+
+PLEX_OAUTH_JS = Path(__file__).resolve().parents[1] / "app/static/js/plex-oauth.js"
+
+
+def test_callback_route_is_public(client):
+    """Plex forwards the browser here with no session of its own to present."""
+    resp = client.get("/plex/callback")
+    assert resp.status_code == 200
+
+
+def test_callback_page_can_complete_the_join_on_its_own(client):
+    """The callback carries the form it needs when the opener is gone."""
+    html = client.get("/plex/callback").get_data(as_text=True)
+
+    assert 'action="/join"' in html
+    assert 'name="code"' in html
+    assert 'name="token"' in html
+
+
+def test_only_closes_itself_when_it_is_really_a_popup(client):
+    """Closing a tab does not let us choose what the browser surfaces next, and
+    on a phone it can be any unrelated tab - which is exactly what happened in
+    testing. A full-size tab has to finish the job where the user is looking."""
+    html = client.get("/plex/callback").get_data(as_text=True)
+
+    assert "isPopupWindow" in html
+    # The close must be gated on that check, never unconditional.
+    assert "opener && isPopupWindow()" in html
+    # And a tab that loses the race still needs somewhere to go.
+    assert "/wizard/" in html
+
+
+def test_callback_page_loads_the_shared_oauth_helpers(client):
+    """Guards against the template referencing a script that is not shipped."""
+    html = client.get("/plex/callback").get_data(as_text=True)
+
+    assert "js/plex-oauth.js" in html
+    assert PLEX_OAUTH_JS.exists()
+
+
+def test_shared_helpers_expose_the_coordination_api():
+    """The invite page and the callback page share this state via localStorage."""
+    source = PLEX_OAUTH_JS.read_text()
+
+    for helper in (
+        "function plexOAuthRead",
+        "function plexOAuthWrite",
+        "function plexOAuthClear",
+        "function plexOAuthClaim",
+        "async function plexOAuthPollToken",
+    ):
+        assert helper in source
+
+
+def test_invite_page_asks_plex_to_forward_back(client):
+    """The regression itself: without forwardUrl the user never comes back."""
+    # No code renders the invite page with an error, which is enough to get the
+    # Plex sign-in markup without standing up an invitation.
+    html = client.post("/join", data={}).get_data(as_text=True)
+
+    assert "forwardUrl" in html
+    assert "/plex/callback" in html
+
+
+def test_invite_page_stashes_what_the_callback_needs(client):
+    """The callback can only finish the sign-in if the pin id was left behind
+    before the browser went to Plex."""
+    html = client.post("/join", data={}).get_data(as_text=True)
+
+    assert "plexOAuthWrite" in html
+    assert "pinId" in html
+
+
+def test_only_one_context_redeems_the_invite(client):
+    """Both the invite page and the callback can end up holding the token, and
+    an invite must not be redeemed twice."""
+    html = client.post("/join", data={}).get_data(as_text=True)
+
+    assert 'plexOAuthClaim("opener")' in html
+    assert 'claimedBy === "callback"' in html

--- a/tests/test_plex_oauth_callback.py
+++ b/tests/test_plex_oauth_callback.py
@@ -26,16 +26,34 @@ def test_callback_page_can_complete_the_join_on_its_own(client):
     assert 'name="token"' in html
 
 
-def test_only_closes_itself_when_it_is_really_a_popup(client):
-    """Closing a tab does not let us choose what the browser surfaces next, and
-    on a phone it can be any unrelated tab - which is exactly what happened in
-    testing. A full-size tab has to finish the job where the user is looking."""
+def test_hands_back_only_when_the_opener_is_visible(client):
+    """Whether to step aside is decided by whether the window that opened us is
+    still on screen, read from the opener's own visibilityState - not from the
+    device, the window size, or the pointer type, all of which misjudge cases
+    like a touchscreen laptop."""
     html = client.get("/plex/callback").get_data(as_text=True)
 
-    assert "isPopupWindow" in html
-    # The close must be gated on that check, never unconditional.
-    assert "opener && isPopupWindow()" in html
-    # And a tab that loses the race still needs somewhere to go.
+    assert 'visibilityState === "visible"' in html
+    assert "openerIsVisible()" in html
+    # It must be the opener's visibility, not this window's.
+    assert "window.opener" in html
+
+
+def test_callback_never_closes_itself(client):
+    """Closing a tab lets the browser surface whatever it likes, which is the
+    mobile failure this page exists to prevent. It only ever navigates; the
+    opener is what closes the desktop popup."""
+    html = client.get("/plex/callback").get_data(as_text=True)
+
+    assert "window.close()" not in html
+
+
+def test_a_tab_that_loses_the_race_still_reaches_the_wizard(client):
+    """If the opener redeems the invite first, the session is shared, so the
+    visible window follows it to the wizard rather than stranding the user."""
+    html = client.get("/plex/callback").get_data(as_text=True)
+
+    assert "goToWizard" in html
     assert "/wizard/" in html
 
 


### PR DESCRIPTION
Fixes #1364.

Follows #1361, which closes the popup once the token arrives and fixes the
desktop case. This is the other half.

### The problem

On a phone there is no popup. `window.open` produces a whole tab, so the invite
page is backgrounded and may be frozen or discarded. Nothing is left running to
close anything or submit the form, and Plex has nowhere to send the browser
because no `forwardUrl` is passed. The user is left on Plex's page. The fix in
#1361 cannot help, because it depends on the opener still running.

### The change

Pass `forwardUrl` so Plex returns the browser to a new `/plex/callback` page.

- If the invite page is still open and visible, the callback closes nothing and
  that window finishes exactly as it does today. Nothing about the desktop path
  changes.
- If the invite page is gone or hidden, the callback completes the sign-in
  itself, from the pin id and invite code left in `localStorage` before the
  redirect.

### Deciding which window finishes, without sniffing the device

The hard part is knowing whether the sign-in happened in a popup (desktop) or a
tab (mobile). Window size, and the pointer type, are both unreliable proxies for
this - a small laptop, a zoomed page, or a touchscreen laptop each fool them.

The reliable question is not what kind of device this is, but whether the window
that started the sign-in is still visible to the user, and that is answerable
directly. On desktop the invite page is a separate window behind the popup:
`document.visibilityState === "visible"`. On a phone it is a background tab:
`hidden`. The opener is same-origin, so both pages can read it.

Both sides use the same signal, symmetrically:

- The callback hands back to the invite page only when the invite page is
  visible. Otherwise it finishes here, in the window the user is looking at.
- The invite page finishes and closes the popup only when it is itself visible.
  This guard matters: mobile browsers do not reliably freeze a background tab,
  and without it an invite page running in the background can win the token and
  close the callback tab the user is actually looking at - which then drops them
  onto whatever tab the browser surfaces next. Observed on iOS Safari.

So each side acts only from the window the user can see, and neither closes a
tab the other is showing. The callback never calls `window.close()` at all:
closing a tab hands tab selection to the browser, which is the failure this
whole change exists to prevent.

Both contexts can still end up holding the token, so a single claim in
`localStorage` decides which one posts to `/join`; the invite is never redeemed
twice. If the invite page wins, the callback tab follows it to the wizard using
the now-shared session rather than being stranded.

### Notes

`forwardUrl` is additive. If Plex ignores it the existing polling still
completes, so nothing regresses. It is a documented parameter on the Plex auth
page and is what Ombi and the plex-oauth library use.

`/plex/callback` needs no session and reads no invitation rows. The route is
built as `window.location.origin` plus a Flask `url_for`, so a prefixed mount
resolves and the origin is the public one the user arrived on rather than an
internal hostname.

### Verification

Run end to end on a real instance against a real Plex server, on both mobile
Chrome and mobile Safari: after sign-in the user lands on the wizard in the tab
they are looking at, with no stray tab surfacing. Desktop popup behaviour is
unchanged from #1361.

### Tests

`tests/test_plex_oauth_callback.py`: the callback route is public and renders,
carries the form it needs to finish alone, loads the shared helpers; the invite
page asks Plex to forward back and stashes what the callback needs; hand-off is
gated on the opener's visibility rather than geometry; the callback never closes
itself; a hidden invite page stands down instead of closing the callback tab;
and only one context can redeem the invite.
