### PR TITLE
Create the request-system account for invited Plex users

### DIFF
--- a/app/blueprints/connections/routes.py
+++ b/app/blueprints/connections/routes.py
@@ -89,6 +89,7 @@ def create_connection():
             api_key=form.api_key.data,
             media_server_id=form.media_server_id.data,
             provision_plex_users=form.provision_plex_users.data,
+            enable_watchlist_sync=form.enable_watchlist_sync.data,
         )
         db.session.add(connection)
         db.session.commit()
@@ -120,6 +121,7 @@ def edit_connection(connection_id: int):
         connection.api_key = form.api_key.data
         connection.media_server_id = form.media_server_id.data
         connection.provision_plex_users = form.provision_plex_users.data
+        connection.enable_watchlist_sync = form.enable_watchlist_sync.data
 
         db.session.commit()
 

--- a/app/blueprints/connections/routes.py
+++ b/app/blueprints/connections/routes.py
@@ -88,6 +88,7 @@ def create_connection():
             url=form.url.data,
             api_key=form.api_key.data,
             media_server_id=form.media_server_id.data,
+            provision_plex_users=form.provision_plex_users.data,
         )
         db.session.add(connection)
         db.session.commit()
@@ -118,6 +119,7 @@ def edit_connection(connection_id: int):
         connection.url = form.url.data
         connection.api_key = form.api_key.data
         connection.media_server_id = form.media_server_id.data
+        connection.provision_plex_users = form.provision_plex_users.data
 
         db.session.commit()
 

--- a/app/blueprints/connections/routes.py
+++ b/app/blueprints/connections/routes.py
@@ -179,6 +179,7 @@ def test_connection():
         url=form.url.data,
         api_key=form.api_key.data,
         media_server_id=form.media_server_id.data,
+        provision_plex_users=form.provision_plex_users.data,
     )
 
     try:

--- a/app/forms/connections.py
+++ b/app/forms/connections.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import SelectField, StringField
+from wtforms import BooleanField, SelectField, StringField
 from wtforms.validators import URL, DataRequired, Optional
 
 from app.models import MediaServer
@@ -15,6 +15,15 @@ class ConnectionForm(FlaskForm):
     api_key = StringField("API Key", validators=[Optional()])
     media_server_id = SelectField(
         "Media Server", coerce=int, validators=[DataRequired()]
+    )
+    provision_plex_users = BooleanField(
+        "Create accounts for invited Plex users",
+        description=(
+            "Sign invited users in to this service during the Plex invite, so "
+            "they do not have to visit it and log in themselves. Requires a "
+            "Service URL."
+        ),
+        default=False,
     )
 
     def __init__(self, *args, **kwargs):

--- a/app/forms/connections.py
+++ b/app/forms/connections.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms import BooleanField, SelectField, StringField
-from wtforms.validators import URL, DataRequired, Optional
+from wtforms.validators import URL, DataRequired, Optional, ValidationError
 
 from app.models import MediaServer
 from app.services.companions import list_companion_types
@@ -25,6 +25,32 @@ class ConnectionForm(FlaskForm):
         ),
         default=False,
     )
+    enable_watchlist_sync = BooleanField(
+        "Turn on watchlist syncing for those accounts",
+        description=(
+            "Switch on the new account's own Plex watchlist syncing, which "
+            "starts off unset, so titles they watchlist become requests "
+            "without them finding the setting first. Only applies while "
+            "creating accounts, above. The service still decides what they may "
+            "request: to have watchlisted titles requested automatically, "
+            "include Auto-Request in its default permissions."
+        ),
+        default=False,
+    )
+
+    def validate_enable_watchlist_sync(self, field):
+        """Refuse the combination that would quietly do nothing.
+
+        The setting is written during account creation, on the session that
+        creating the account returns. Without account creation there is no such
+        moment, so the box would stay ticked and never take effect, which is the
+        same silent nothing it exists to prevent.
+        """
+        if field.data and not self.provision_plex_users.data:
+            raise ValidationError(
+                "Turn on account creation as well, or watchlist syncing has "
+                "no account to set it on."
+            )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/app/models.py
+++ b/app/models.py
@@ -406,6 +406,15 @@ class Connection(db.Model):
     provision_plex_users = db.Column(
         db.Boolean, nullable=False, default=False, server_default="0"
     )
+    # Opt-in: turn on the user's own watchlist syncing while provisioning them.
+    # Overseerr leaves both watchlist flags unset for a new account and skips
+    # anyone whose flags are unset, so a watchlist added on day one otherwise
+    # requests nothing and reports no error. Separate from provisioning because
+    # this changes a preference that belongs to the user, not just whether the
+    # account exists.
+    enable_watchlist_sync = db.Column(
+        db.Boolean, nullable=False, default=False, server_default="0"
+    )
     created_at = db.Column(
         db.DateTime, default=lambda: datetime.now(UTC), nullable=False
     )

--- a/app/models.py
+++ b/app/models.py
@@ -399,6 +399,13 @@ class Connection(db.Model):
     media_server_id = db.Column(
         db.Integer, db.ForeignKey("media_server.id", ondelete="CASCADE"), nullable=False
     )
+    # Opt-in: create the account on this service during a Plex invite, instead of
+    # leaving the user to go and sign in by hand. Off by default so an existing
+    # connection never changes behaviour on upgrade, and so instances without the
+    # service are unaffected.
+    provision_plex_users = db.Column(
+        db.Boolean, nullable=False, default=False, server_default="0"
+    )
     created_at = db.Column(
         db.DateTime, default=lambda: datetime.now(UTC), nullable=False
     )

--- a/app/services/companions/__init__.py
+++ b/app/services/companions/__init__.py
@@ -43,7 +43,7 @@ def list_companion_types() -> list[tuple[str, str]]:
     """Return list of (value, label) tuples for all registered companion types."""
     return [
         ("ombi", "Ombi"),
-        ("overseerr", "Overseerr/Jellyseerr (Info Only)"),
+        ("overseerr", "Overseerr/Jellyseerr"),
         ("audiobookrequest", "Audiobookrequest"),
     ]
 

--- a/app/services/companions/base.py
+++ b/app/services/companions/base.py
@@ -63,3 +63,31 @@ class CompanionClient(ABC):
         Returns:
             Dict with 'status' and 'message' keys
         """
+
+    def provision_plex_user(
+        self,
+        auth_token: str,  # noqa: ARG002
+        connection: Connection,  # noqa: ARG002
+    ) -> dict[str, str]:
+        """
+        Create the user on the companion service using their Plex token.
+
+        Services that sign users in with Plex only create the account on first
+        login, so an invited user has no account until they visit and log in by
+        hand. Given the token from the Plex OAuth invite, a companion can create
+        that account up front instead.
+
+        Only meaningful for Plex; the default is to do nothing so companions that
+        provision another way are unaffected.
+
+        Args:
+            auth_token: The invited user's Plex auth token
+            connection: Connection object with URL and API key
+
+        Returns:
+            Dict with 'status' and 'message' keys
+        """
+        return {
+            "status": "not_supported",
+            "message": f"{self.display_name} does not provision Plex users",
+        }

--- a/app/services/companions/overseerr.py
+++ b/app/services/companions/overseerr.py
@@ -2,9 +2,51 @@
 Overseerr/Jellyseerr companion client implementation.
 """
 
+import logging
+import time
+
+import requests
+
 from app.models import Connection
 
 from .base import CompanionClient
+
+# Overseerr checks the user can reach the media server before it will accept
+# them, and plex.tv does not necessarily publish a brand new share the instant it
+# is created. How long that takes has not been measured here, so retry over a few
+# minutes rather than assuming it is immediate. This runs off the request thread,
+# so a long tail costs the invited user nothing.
+_PROVISION_BACKOFF_SECONDS = (10, 30, 60, 120, 240)
+
+
+def _open_session(base_url: str) -> tuple[requests.Session, dict[str, str]]:
+    """Open a session carrying Overseerr's CSRF cookie, if it wants one.
+
+    Overseerr can be configured to reject state-changing requests that do not
+    echo its XSRF cookie back as a header, and that applies to API callers, not
+    just browsers - without it every POST comes back 403 "invalid csrf token"
+    no matter how valid the payload is. A GET first hands us the cookie.
+    Instances with the protection off simply never set one, and we send no
+    header.
+
+    Returns:
+        The session to post with, and the headers it needs
+    """
+    session = requests.Session()
+    headers: dict[str, str] = {}
+
+    try:
+        session.get(f"{base_url}/api/v1/status", timeout=10)
+    except Exception as exc:
+        # Not fatal on its own: let the POST report the real failure.
+        logging.debug("Could not prime Overseerr CSRF cookie: %s", exc)
+        return session, headers
+
+    token = session.cookies.get("XSRF-TOKEN")
+    if token:
+        headers["X-XSRF-TOKEN"] = token
+
+    return session, headers
 
 
 class OverseerrClient(CompanionClient):
@@ -72,3 +114,104 @@ class OverseerrClient(CompanionClient):
             "status": "info_only",
             "message": "Overseerr connections are informational only - no API testing required",
         }
+
+    def provision_plex_user(
+        self, auth_token: str, connection: Connection
+    ) -> dict[str, str]:
+        """
+        Create the Overseerr account for a freshly invited Plex user.
+
+        Overseerr does not import Plex users in the background; it creates them
+        the first time they sign in. That leaves an invited user having to go and
+        log in by hand before anything knows who they are, and before watchlist
+        syncing has a token to work with. Posting their Plex token to the same
+        endpoint the login page uses does exactly what that visit would have.
+
+        Needs no API key: /api/v1/auth/plex is the public login route. It creates
+        the user only when they can already reach the media server and
+        newPlexLogin is enabled, so this cannot grant access Overseerr would have
+        refused. The session cookie it returns is discarded.
+
+        Args:
+            auth_token: The invited user's Plex auth token
+            connection: Connection object with URL and API key
+
+        Returns:
+            Dict with 'status' and 'message' keys
+        """
+        if not connection.url:
+            return {
+                "status": "skipped",
+                "message": "No Overseerr URL configured",
+            }
+
+        base_url = connection.url.rstrip("/")
+        url = f"{base_url}/api/v1/auth/plex"
+        total = len(_PROVISION_BACKOFF_SECONDS) + 1
+        last_message = "Unknown error"
+
+        session, headers = _open_session(base_url)
+
+        for attempt in range(1, total + 1):
+            try:
+                resp = session.post(
+                    url,
+                    json={"authToken": auth_token},
+                    headers=headers,
+                    timeout=10,
+                )
+            except Exception as exc:
+                last_message = str(exc)
+                logging.warning(
+                    "Overseerr provisioning attempt %s/%s failed: %s",
+                    attempt,
+                    total,
+                    exc,
+                )
+            else:
+                if resp.ok:
+                    logging.info(
+                        "Overseerr provisioned Plex user via %s on attempt %s",
+                        url,
+                        attempt,
+                    )
+                    return {
+                        "status": "success",
+                        "message": "User created in Overseerr",
+                    }
+
+                # Carry the body, not just the status: a bare "HTTP 403" reads
+                # like a rejected user when it can just as easily be a rejected
+                # request, and the two need completely different fixes.
+                body = (resp.text or "").strip()[:200]
+                last_message = f"HTTP {resp.status_code} {body}".strip()
+
+                if resp.status_code == 403 and "csrf" in body.lower():
+                    # Overseerr's CSRF cookies are Secure, so they are never sent
+                    # back over plain HTTP and the token can never validate. No
+                    # amount of retrying fixes a configuration problem.
+                    logging.warning(
+                        "Overseerr rejected the request as CSRF-invalid. Its CSRF "
+                        "cookies are Secure, so an http:// connection URL can "
+                        "never satisfy them - configure %s over https, or turn "
+                        "off CSRF protection in Overseerr.",
+                        base_url,
+                    )
+                    break
+
+                # A plain 403 is Overseerr saying the user cannot reach the media
+                # server, which right after an invite may just mean plex.tv has
+                # not published the share yet. Anything else will not fix itself.
+                if resp.status_code != 403:
+                    break
+                logging.info(
+                    "Overseerr does not see the share yet (attempt %s/%s)",
+                    attempt,
+                    total,
+                )
+
+            if attempt <= len(_PROVISION_BACKOFF_SECONDS):
+                time.sleep(_PROVISION_BACKOFF_SECONDS[attempt - 1])
+
+        logging.warning("Overseerr provisioning gave up: %s", last_message)
+        return {"status": "error", "message": last_message}

--- a/app/services/companions/overseerr.py
+++ b/app/services/companions/overseerr.py
@@ -19,7 +19,9 @@ from .base import CompanionClient
 _PROVISION_BACKOFF_SECONDS = (10, 30, 60, 120, 240)
 
 
-def _open_session(base_url: str) -> tuple[requests.Session, dict[str, str]]:
+def _open_session(
+    base_url: str,
+) -> tuple[requests.Session, dict[str, str], requests.Response | None]:
     """Open a session carrying Overseerr's CSRF cookie, if it wants one.
 
     Overseerr can be configured to reject state-changing requests that do not
@@ -30,27 +32,33 @@ def _open_session(base_url: str) -> tuple[requests.Session, dict[str, str]]:
     header.
 
     Returns:
-        The session to post with, and the headers it needs
+        The session to post with, the headers it needs, and the status
+        response, which the caller may want for its own reasons
     """
     session = requests.Session()
     headers: dict[str, str] = {}
 
     try:
-        session.get(f"{base_url}/api/v1/status", timeout=10)
+        resp = session.get(f"{base_url}/api/v1/status", timeout=10)
     except Exception as exc:
         # Not fatal on its own: let the POST report the real failure.
         logging.debug("Could not prime Overseerr CSRF cookie: %s", exc)
-        return session, headers
+        return session, headers, None
 
     token = session.cookies.get("XSRF-TOKEN")
     if token:
         headers["X-XSRF-TOKEN"] = token
 
-    return session, headers
+    return session, headers, resp
 
 
 class OverseerrClient(CompanionClient):
-    """Client for integrating with Overseerr/Jellyseerr (info-only)."""
+    """Client for integrating with Overseerr/Jellyseerr.
+
+    Informational by default: they import nobody in the background and
+    creates an account on first sign-in. With account creation turned on, an
+    invite provisions that account up front instead.
+    """
 
     @property
     def requires_api_call(self) -> bool:
@@ -100,20 +108,161 @@ class OverseerrClient(CompanionClient):
             "message": "Overseerr users managed automatically",
         }
 
-    def test_connection(self, connection: Connection) -> dict[str, str]:  # noqa: ARG002
+    def test_connection(self, connection: Connection) -> dict[str, str]:
         """
-        Test connection for Overseerr (info-only).
+        Check everything account creation depends on, without credentials.
+
+        Every prerequisite is readable anonymously, so this exercises the real
+        provisioning path rather than approximating it: the same session helper,
+        the same CSRF handshake, and the setting Overseerr refuses the sign-in
+        without. The point is to surface a broken invite here rather than
+        silently, minutes later, in a background thread the admin never sees.
 
         Args:
-            connection: Connection object with URL and API key (unused - info-only)
+            connection: Connection object with URL and API key
 
         Returns:
             Dict with 'status' and 'message' keys
         """
+        name = self.display_name
+
+        if not connection.url:
+            return {
+                "status": "info_only",
+                "message": (
+                    "No Service URL set, so this connection is informational "
+                    "and Wizarr makes no calls to " + name + "."
+                ),
+            }
+
+        base_url = connection.url.rstrip("/")
+
+        try:
+            session, headers, status = _open_session(base_url)
+        except Exception as exc:
+            return {"status": "error", "message": f"Could not reach {base_url}: {exc}"}
+
+        if status is None:
+            return {
+                "status": "error",
+                "message": f"Could not reach {base_url}. Check the URL and that {name} is running.",
+            }
+        if not status.ok:
+            return {
+                "status": "error",
+                "message": f"{base_url}/api/v1/status returned HTTP {status.status_code}.",
+            }
+
+        try:
+            version = str(status.json()["version"])
+        except Exception:
+            return {
+                "status": "error",
+                "message": (
+                    f"{base_url} answered, but not with {name}'s API. Check the URL "
+                    f"points at {name} itself rather than a login page or proxy error."
+                ),
+            }
+
+        if not self._csrf_handshake_works(session, headers, base_url):
+            return {
+                "status": "error",
+                "message": (
+                    f"Reached {name} {version}, but it rejected a test request as "
+                    "CSRF-invalid. Its CSRF cookies are Secure, so an http:// URL "
+                    "can never satisfy them. Use https here, or turn off CSRF "
+                    f"protection in {name}."
+                ),
+            }
+
+        new_plex_login = self._new_plex_login_enabled(session, base_url)
+        if new_plex_login is False:
+            return {
+                "status": "error",
+                "message": (
+                    f"Reached {name} {version}, but 'Enable New Plex Sign-In' is off "
+                    "under its Settings → Users, so it will refuse to create the "
+                    "account. Turn it on, or leave account creation off here."
+                ),
+            }
+
+        if not connection.provision_plex_users:
+            return {
+                "status": "info_only",
+                "message": (
+                    f"Reached {name} {version}. Account creation is off, so this "
+                    "connection is informational and invited users will sign in "
+                    f"to {name} themselves."
+                ),
+            }
+
+        if new_plex_login is None:
+            return {
+                "status": "success",
+                "message": (
+                    f"Reached {name} {version} and the CSRF handshake worked. Could "
+                    "not read its settings to confirm 'Enable New Plex Sign-In' is "
+                    "on, which account creation needs."
+                ),
+            }
+
         return {
-            "status": "info_only",
-            "message": "Overseerr connections are informational only - no API testing required",
+            "status": "success",
+            "message": (
+                f"Reached {name} {version}. CSRF handshake worked and 'Enable New "
+                "Plex Sign-In' is on, so account creation should succeed."
+            ),
         }
+
+    @staticmethod
+    def _csrf_handshake_works(
+        session: requests.Session, headers: dict[str, str], base_url: str
+    ) -> bool:
+        """Prove a POST survives CSRF, without provisioning anyone.
+
+        Logout is the one state-changing route that clears the CSRF middleware
+        before it needs credentials, so it answers the only question worth
+        asking here. Sending no session cookie, it has nothing to log out and
+        returns 401, which is the pass condition: the request got past CSRF.
+        Posting a throwaway token to the real sign-in route would test the same
+        thing while making Overseerr call plex.tv and log a failure.
+
+        Returns:
+            Whether a POST gets past Overseerr's CSRF check
+        """
+        try:
+            resp = session.post(
+                f"{base_url}/api/v1/auth/logout", headers=headers, timeout=10
+            )
+        except Exception as exc:
+            # Reachability is already established, so this is not the check
+            # failing so much as the check being unable to run. Do not block on
+            # it: provisioning reports its own CSRF failures with the same text.
+            logging.debug("Overseerr CSRF probe could not run: %s", exc)
+            return True
+
+        body = (resp.text or "").lower()
+        return not (resp.status_code == 403 and "csrf" in body)
+
+    @staticmethod
+    def _new_plex_login_enabled(
+        session: requests.Session, base_url: str
+    ) -> bool | None:
+        """Read the setting Overseerr refuses a new Plex sign-in without.
+
+        Returns:
+            Whether new Plex sign-in is enabled, or None if it could not be read
+        """
+        try:
+            resp = session.get(f"{base_url}/api/v1/settings/public", timeout=10)
+            if not resp.ok:
+                return None
+            value = resp.json().get("newPlexLogin")
+        except Exception as exc:
+            logging.debug("Could not read Overseerr public settings: %s", exc)
+            return None
+
+        return bool(value) if isinstance(value, bool) else None
 
     def provision_plex_user(
         self, auth_token: str, connection: Connection
@@ -150,7 +299,7 @@ class OverseerrClient(CompanionClient):
         total = len(_PROVISION_BACKOFF_SECONDS) + 1
         last_message = "Unknown error"
 
-        session, headers = _open_session(base_url)
+        session, headers, _ = _open_session(base_url)
 
         for attempt in range(1, total + 1):
             try:

--- a/app/services/companions/overseerr.py
+++ b/app/services/companions/overseerr.py
@@ -52,6 +52,67 @@ def _open_session(
     return session, headers, resp
 
 
+def _enable_watchlist_sync(
+    session: requests.Session,
+    headers: dict[str, str],
+    base_url: str,
+    user_id: int,
+) -> str | None:
+    """Switch on the newly created user's own watchlist syncing.
+
+    Overseerr stores both watchlist flags as nullable columns with no default
+    and creates no settings row with the account, then skips any user whose
+    flags are unset. A watchlist added straight after being invited therefore
+    requests nothing and reports no error anywhere, which is the failure this
+    avoids.
+
+    Posted as the user, on the session their sign-in just returned, so it needs
+    no API key and can only touch the account we created.
+
+    Args:
+        session: The session left logged in as the user by /api/v1/auth/plex
+        headers: Headers that session needs, including its CSRF token
+        base_url: Overseerr base URL, no trailing slash
+        user_id: The provisioned user's Overseerr ID
+
+    Returns:
+        None on success, or a message describing what went wrong
+    """
+    url = f"{base_url}/api/v1/user/{user_id}/settings/main"
+
+    try:
+        current = session.get(url, timeout=10)
+        if not current.ok:
+            return f"HTTP {current.status_code} reading settings"
+        settings = current.json()
+    except Exception as exc:
+        return str(exc)
+
+    # This POST is a read-modify-write over the whole profile: it assigns
+    # username and the regions straight from the body, so anything left out is
+    # blanked rather than kept. Echo back what was just read and change only the
+    # two flags.
+    body = dict(settings)
+    body["watchlistSyncMovies"] = True
+    body["watchlistSyncTv"] = True
+
+    # A user with no settings row yet has no locale to echo, and the column is
+    # NOT NULL - posting the missing value back is a 500. Empty string is what
+    # rows created through the UI hold.
+    if body.get("locale") is None:
+        body["locale"] = ""
+
+    try:
+        resp = session.post(url, json=body, headers=headers, timeout=10)
+    except Exception as exc:
+        return str(exc)
+
+    if not resp.ok:
+        return f"HTTP {resp.status_code} {(resp.text or '').strip()[:200]}".strip()
+
+    return None
+
+
 class OverseerrClient(CompanionClient):
     """Client for integrating with Overseerr/Jellyseerr.
 
@@ -279,7 +340,8 @@ class OverseerrClient(CompanionClient):
         Needs no API key: /api/v1/auth/plex is the public login route. It creates
         the user only when they can already reach the media server and
         newPlexLogin is enabled, so this cannot grant access Overseerr would have
-        refused. The session cookie it returns is discarded.
+        refused. The session cookie it returns is discarded, unless the
+        connection also asked for watchlist syncing, which is set as that user.
 
         Args:
             auth_token: The invited user's Plex auth token
@@ -324,9 +386,60 @@ class OverseerrClient(CompanionClient):
                         url,
                         attempt,
                     )
+                    if not connection.enable_watchlist_sync:
+                        return {
+                            "status": "success",
+                            "message": "User created in Overseerr",
+                        }
+
+                    # Signing in rotates the CSRF token, so the one primed
+                    # before the POST no longer validates.
+                    rotated = session.cookies.get("XSRF-TOKEN")
+                    if rotated:
+                        headers["X-XSRF-TOKEN"] = rotated
+
+                    try:
+                        user_id = (resp.json() or {}).get("id")
+                    except ValueError:
+                        user_id = None
+
+                    if not user_id:
+                        # The account exists either way; only the follow-up
+                        # setting is lost, and saying so beats a bare success.
+                        logging.warning(
+                            "Overseerr did not return a user id, so watchlist "
+                            "syncing was left unset"
+                        )
+                        return {
+                            "status": "success",
+                            "message": (
+                                "User created in Overseerr, but watchlist "
+                                "syncing could not be turned on: no user id in "
+                                "the response"
+                            ),
+                        }
+
+                    problem = _enable_watchlist_sync(
+                        session, headers, base_url, user_id
+                    )
+                    if problem:
+                        logging.warning(
+                            "Overseerr user %s created, but watchlist syncing "
+                            "could not be turned on: %s",
+                            user_id,
+                            problem,
+                        )
+                        return {
+                            "status": "success",
+                            "message": (
+                                "User created in Overseerr, but watchlist "
+                                f"syncing could not be turned on: {problem}"
+                            ),
+                        }
+
                     return {
                         "status": "success",
-                        "message": "User created in Overseerr",
+                        "message": "User created in Overseerr, watchlist syncing on",
                     }
 
                 # Carry the body, not just the status: a bare "HTTP 403" reads

--- a/app/services/media/plex.py
+++ b/app/services/media/plex.py
@@ -1280,6 +1280,21 @@ class PlexClient(MediaClient):
 # ─── Invite & onboarding ────────────────────────────────────────────────
 
 
+def _provision_companions(app, token: str, server_id: int) -> None:
+    """Create the invited Plex user on opted-in companions, in the background.
+
+    Needs its own app context: the request that started it is long gone by the
+    time this finishes.
+    """
+    with app.app_context():
+        try:
+            from app.services.ombi_client import provision_plex_user_on_connections
+
+            provision_plex_user_on_connections(token, server_id)
+        except Exception as exc:
+            logging.warning("Companion provisioning failed: %s", exc)
+
+
 def handle_oauth_token(app, token: str, code: str) -> None:
     with app.app_context():
         account = MyPlexAccount(token=token)
@@ -1334,6 +1349,28 @@ def handle_oauth_token(app, token: str, code: str) -> None:
             db.session.commit()
 
             _invite_user(email, code, new_user.id, server)
+
+            # Create the user on any request system that asked for it, while we
+            # still hold their token. Otherwise their first visit there is a
+            # login screen, and watchlist syncing has no token to work with
+            # until they get to it.
+            #
+            # Off the request thread so a slow or unreachable companion cannot
+            # hold up the invite, and best effort throughout: a companion
+            # failing must never break an invite the user just accepted.
+            try:
+                from app.services.ombi_client import (
+                    has_plex_provisioning_connections,
+                )
+
+                if has_plex_provisioning_connections(server_id):
+                    threading.Thread(
+                        target=_provision_companions,
+                        args=(current_app._get_current_object(), token, server_id),  # type: ignore
+                        daemon=True,
+                    ).start()
+            except Exception as exc:
+                logging.warning("Companion provisioning failed: %s", exc)
 
             # Mark invitation as used for this server
             if inv:

--- a/app/services/ombi_client.py
+++ b/app/services/ombi_client.py
@@ -9,7 +9,9 @@ __all__ = [
     "delete_user",
     "delete_user_from_connections",
     "get_connection_for_server",
+    "has_plex_provisioning_connections",
     "invite_user_to_connections",
+    "provision_plex_user_on_connections",
     "run_user_importer",
 ]
 
@@ -82,6 +84,68 @@ def invite_user_to_connections(
                     "message": f"Unknown connection type: {connection.connection_type}",
                 }
             )
+
+    return results
+
+
+def has_plex_provisioning_connections(server_id: int) -> bool:
+    """Whether any companion for this server has opted in to provisioning."""
+    return (
+        Connection.query.filter_by(
+            media_server_id=server_id, provision_plex_users=True
+        ).count()
+        > 0
+    )
+
+
+def provision_plex_user_on_connections(auth_token: str, server_id: int) -> list[dict]:
+    """
+    Create the freshly invited Plex user on every companion for this server.
+
+    Called once the Plex share exists, since request systems check that the user
+    can reach the media server before accepting them. Best effort by design: a
+    companion being down must never fail the invite the user just accepted, so
+    every failure is logged and returned rather than raised.
+
+    Args:
+        auth_token: The invited user's Plex auth token
+        server_id: Media server ID to check for connections
+
+    Returns:
+        List of results with connection details and status
+    """
+    results = []
+
+    # Opt-in only. Most instances have no request system attached, and an
+    # existing connection predating the flag must not change behaviour.
+    connections = Connection.query.filter_by(
+        media_server_id=server_id, provision_plex_users=True
+    ).all()
+
+    for connection in connections:
+        try:
+            client = get_companion_client(connection.connection_type)()
+            result = client.provision_plex_user(auth_token, connection)
+        except ValueError as exc:
+            logging.error(
+                "Unknown connection type %s: %s", connection.connection_type, exc
+            )
+            result = {
+                "status": "error",
+                "message": f"Unknown connection type: {connection.connection_type}",
+            }
+        except Exception as exc:
+            logging.error("Provisioning %s failed: %s", connection.connection_type, exc)
+            result = {"status": "error", "message": str(exc)}
+
+        results.append(
+            {
+                "connection_name": connection.name,
+                "connection_type": connection.connection_type,
+                "status": result["status"],
+                "message": result["message"],
+            }
+        )
 
     return results
 

--- a/app/templates/modals/connection-form.html
+++ b/app/templates/modals/connection-form.html
@@ -75,17 +75,28 @@
               <div>
                 <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-2">{{ _("Overseerr/Jellyseerr Information") }}</h4>
                 <p class="text-sm text-gray-600 dark:text-gray-300 mb-3">
-                  {{ _("Overseerr and Jellyseerr automatically import new users by default. No API connection is required for Wizarr integration.") }}
+                  {{ _("Overseerr and Jellyseerr create a user the first time that user signs in, so someone you invite has no account there until they visit and log in themselves.") }}
                 </p>
                 <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-md p-3">
                   <p class="text-sm text-blue-800 dark:text-blue-200">
-                    <strong>{{ _("To enable auto-import:") }}</strong>
-                    <br>
-                    {{ _("Go to your Overseerr/Jellyseerr Settings → Users → Enable 'Auto-approve new users' and 'Import Jellyfin/Plex users'") }}
+                    {{ _("Set the Service URL below and turn on account creation to have Wizarr do that for them during the invite. An API key is not needed.") }}
                   </p>
                 </div>
               </div>
             </div>
+          </div>
+          <!-- URL -->
+          <div>
+            {{ form.url.label(class="block mb-2 text-sm font-medium text-gray-900 dark:text-white") }}
+            {{ form.url(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary", placeholder="https://requests.example.com") }}
+            {% if form.url.errors %}
+              <div class="mt-1 text-sm text-red-600 dark:text-red-400">
+                {% for error in form.url.errors %}<p>{{ error }}</p>{% endfor %}
+              </div>
+            {% endif %}
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {{ _("Must be https if the service has CSRF protection enabled, which sets its cookies Secure.") }}
+            </p>
           </div>
         {% else %}
           <!-- URL -->
@@ -123,6 +134,14 @@
             {% endif %}
           </div>
         {% endif %}
+        <!-- Create accounts for invited users -->
+        <div>
+          <div class="flex items-center">
+            {{ form.provision_plex_users(class="w-4 h-4 text-primary bg-gray-50 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600") }}
+            {{ form.provision_plex_users.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-white") }}
+          </div>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _(form.provision_plex_users.description) }}</p>
+        </div>
         <!-- Test Result Area -->
         <div id="test-result-area" class="mt-4"></div>
         <!-- Test Spinner -->

--- a/app/templates/modals/connection-form.html
+++ b/app/templates/modals/connection-form.html
@@ -143,6 +143,19 @@
             </div>
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ form.provision_plex_users.description }}</p>
           </div>
+          <!-- Turn on watchlist syncing for those accounts -->
+          <div>
+            <div class="flex items-center">
+              {{ form.enable_watchlist_sync(class="w-4 h-4 text-primary bg-gray-50 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600") }}
+              {{ form.enable_watchlist_sync.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-white") }}
+            </div>
+            {% if form.enable_watchlist_sync.errors %}
+              <div class="mt-1 text-sm text-red-600 dark:text-red-400">
+                {% for error in form.enable_watchlist_sync.errors %}<p>{{ error }}</p>{% endfor %}
+              </div>
+            {% endif %}
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ form.enable_watchlist_sync.description }}</p>
+          </div>
         {% endif %}
         <!-- Test Result Area -->
         <div id="test-result-area" class="mt-4"></div>

--- a/app/templates/modals/connection-form.html
+++ b/app/templates/modals/connection-form.html
@@ -168,14 +168,12 @@
               {{ _("Update Connection") }}
             {% endif %}
           </button>
-          {% if form.connection_type.data != 'overseerr' %}
-            <button type="button"
-                    class="py-2.5 px-5 ms-3 text-sm font-medium text-blue-700 focus:outline-none bg-blue-50 rounded-lg border border-blue-200 hover:bg-blue-100 focus:z-10 focus:ring-4 focus:ring-blue-100 dark:focus:ring-blue-700 dark:bg-blue-900 dark:text-blue-400 dark:border-blue-600 dark:hover:text-white dark:hover:bg-blue-800"
-                    hx-post="{{ url_for('connections.test_connection') }}"
-                    hx-target="#test-result-area"
-                    hx-include="form"
-                    hx-indicator="#test-spinner">{{ _("Test Connection") }}</button>
-          {% endif %}
+          <button type="button"
+                  class="py-2.5 px-5 ms-3 text-sm font-medium text-blue-700 focus:outline-none bg-blue-50 rounded-lg border border-blue-200 hover:bg-blue-100 focus:z-10 focus:ring-4 focus:ring-blue-100 dark:focus:ring-blue-700 dark:bg-blue-900 dark:text-blue-400 dark:border-blue-600 dark:hover:text-white dark:hover:bg-blue-800"
+                  hx-post="{{ url_for('connections.test_connection') }}"
+                  hx-target="#test-result-area"
+                  hx-include="form"
+                  hx-indicator="#test-spinner">{{ _("Test Connection") }}</button>
           <button type="button"
                   class="py-2.5 px-5 ms-3 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700"
                   onclick="document.getElementById('connection-modal-backdrop').remove()">{{ _("Cancel") }}</button>

--- a/app/templates/modals/connection-form.html
+++ b/app/templates/modals/connection-form.html
@@ -44,8 +44,8 @@
         </div>
         <!-- Connection Name -->
         <div>
-          {{ form.name.label(class="block mb-2 text-sm font-medium " + ("text-gray-500 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "text-gray-900 dark:text-white") ) }}
-          {{ form.name(class="text-sm rounded-lg block w-full p-2.5 " + ("bg-gray-100 border-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") , disabled=(form.connection_type.data == 'overseerr')) }}
+          {{ form.name.label(class="block mb-2 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.name(class="text-sm rounded-lg block w-full p-2.5 bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") }}
           {% if form.name.errors %}
             <div class="mt-1 text-sm text-red-600 dark:text-red-400">
               {% for error in form.name.errors %}<p>{{ error }}</p>{% endfor %}
@@ -54,8 +54,8 @@
         </div>
         <!-- Media Server -->
         <div>
-          {{ form.media_server_id.label(class="block mb-2 text-sm font-medium " + ("text-gray-500 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "text-gray-900 dark:text-white") ) }}
-          {{ form.media_server_id(class="text-sm rounded-lg block w-full p-2.5 " + ("bg-gray-100 border-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") , disabled=(form.connection_type.data == 'overseerr')) }}
+          {{ form.media_server_id.label(class="block mb-2 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.media_server_id(class="text-sm rounded-lg block w-full p-2.5 bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") }}
           {% if form.media_server_id.errors %}
             <div class="mt-1 text-sm text-red-600 dark:text-red-400">
               {% for error in form.media_server_id.errors %}<p>{{ error }}</p>{% endfor %}

--- a/app/templates/modals/connection-form.html
+++ b/app/templates/modals/connection-form.html
@@ -75,11 +75,11 @@
               <div>
                 <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-2">{{ _("Overseerr/Jellyseerr Information") }}</h4>
                 <p class="text-sm text-gray-600 dark:text-gray-300 mb-3">
-                  {{ _("Overseerr and Jellyseerr create a user the first time that user signs in, so someone you invite has no account there until they visit and log in themselves.") }}
+                  {{ _("Overseerr and Jellyseerr create an account the first time someone signs in, so by default an invited user has no account there until they visit and log in themselves.") }}
                 </p>
                 <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-md p-3">
                   <p class="text-sm text-blue-800 dark:text-blue-200">
-                    {{ _("Set the Service URL below and turn on account creation to have Wizarr do that for them during the invite. An API key is not needed.") }}
+                    {{ _("Set the Service URL and turn on account creation below, and Wizarr signs them in during the invite so their account exists before they arrive. This uses the service's own sign-in route rather than an API key, so it needs 'Enable New Plex Sign-In' under its Settings → Users.") }}
                   </p>
                 </div>
               </div>

--- a/app/templates/modals/connection-form.html
+++ b/app/templates/modals/connection-form.html
@@ -134,14 +134,16 @@
             {% endif %}
           </div>
         {% endif %}
-        <!-- Create accounts for invited users -->
-        <div>
-          <div class="flex items-center">
-            {{ form.provision_plex_users(class="w-4 h-4 text-primary bg-gray-50 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600") }}
-            {{ form.provision_plex_users.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-white") }}
+        {% if form.connection_type.data == 'overseerr' %}
+          <!-- Create accounts for invited users; only the Overseerr/Jellyseerr client acts on this flag -->
+          <div>
+            <div class="flex items-center">
+              {{ form.provision_plex_users(class="w-4 h-4 text-primary bg-gray-50 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600") }}
+              {{ form.provision_plex_users.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-white") }}
+            </div>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ form.provision_plex_users.description }}</p>
           </div>
-          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _(form.provision_plex_users.description) }}</p>
-        </div>
+        {% endif %}
         <!-- Test Result Area -->
         <div id="test-result-area" class="mt-4"></div>
         <!-- Test Spinner -->

--- a/app/templates/settings/connections.html
+++ b/app/templates/settings/connections.html
@@ -45,13 +45,29 @@
                   <td class="px-6 py-4 font-medium text-gray-900 dark:text-white">{{ connection.name }}</td>
                   <td class="px-6 py-4">
                     {% if connection.connection_type == 'overseerr' %}
-                      <span class="inline-flex items-center px-2 py-1 text-xs font-medium text-orange-800 bg-orange-100 rounded-full dark:bg-orange-900 dark:text-orange-300">
-                        <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
-                          <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd">
-                          </path>
-                        </svg>
-                        {{ _("Overseerr (Info)") }}
-                      </span>
+                      {# Info-only until account creation is turned on: with it, every
+                      Plex invite posts to the service's sign-in route. #}
+                      {% if connection.provision_plex_users %}
+                        <span class="inline-flex items-center px-2 py-1 text-xs font-medium text-blue-800 bg-blue-100 rounded-full dark:bg-blue-900 dark:text-blue-300">
+                          <svg xmlns="http://www.w3.org/2000/svg"
+                               fill="none"
+                               viewBox="0 0 24 24"
+                               stroke-width="1.5"
+                               stroke="currentColor"
+                               class="w-3 h-3 mr-1">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
+                          </svg>
+                          {{ _("Overseerr") }}
+                        </span>
+                      {% else %}
+                        <span class="inline-flex items-center px-2 py-1 text-xs font-medium text-orange-800 bg-orange-100 rounded-full dark:bg-orange-900 dark:text-orange-300">
+                          <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd">
+                            </path>
+                          </svg>
+                          {{ _("Overseerr (Info)") }}
+                        </span>
+                      {% endif %}
                     {% elif connection.connection_type == 'ombi' %}
                       <span class="inline-flex items-center px-2 py-1 text-xs font-medium text-green-800 bg-green-100 rounded-full dark:bg-green-900 dark:text-green-300">
                         <svg xmlns="http://www.w3.org/2000/svg"

--- a/app/templates/settings/connections/form.html
+++ b/app/templates/settings/connections/form.html
@@ -202,6 +202,19 @@
                 </div>
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ form.provision_plex_users.description }}</p>
               </div>
+              <!-- Turn on watchlist syncing for those accounts -->
+              <div>
+                <div class="flex items-center">
+                  {{ form.enable_watchlist_sync(class="w-4 h-4 text-primary bg-gray-50 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600") }}
+                  {{ form.enable_watchlist_sync.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-white") }}
+                </div>
+                {% if form.enable_watchlist_sync.errors %}
+                  <div class="mt-1 text-sm text-red-600 dark:text-red-400">
+                    {% for error in form.enable_watchlist_sync.errors %}<p>{{ error }}</p>{% endfor %}
+                  </div>
+                {% endif %}
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ form.enable_watchlist_sync.description }}</p>
+              </div>
             {% endif %}
             <!-- Form Actions -->
             <div class="flex items-center justify-end space-x-4 pt-4 border-t border-gray-200 dark:border-gray-700">

--- a/app/templates/settings/connections/form.html
+++ b/app/templates/settings/connections/form.html
@@ -193,14 +193,16 @@
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _("API key from your external service settings") }}</p>
               </div>
             {% endif %}
-            <!-- Provision Plex users -->
-            <div>
-              <div class="flex items-center">
-                {{ form.provision_plex_users(class="w-4 h-4 text-primary bg-gray-50 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600") }}
-                {{ form.provision_plex_users.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-white") }}
+            {% if form.connection_type.data == 'overseerr' %}
+              <!-- Provision Plex users; only the Overseerr/Jellyseerr client acts on this flag -->
+              <div>
+                <div class="flex items-center">
+                  {{ form.provision_plex_users(class="w-4 h-4 text-primary bg-gray-50 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600") }}
+                  {{ form.provision_plex_users.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-white") }}
+                </div>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ form.provision_plex_users.description }}</p>
               </div>
-              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _(form.provision_plex_users.description) }}</p>
-            </div>
+            {% endif %}
             <!-- Form Actions -->
             <div class="flex items-center justify-end space-x-4 pt-4 border-t border-gray-200 dark:border-gray-700">
               <a href="{{ url_for('settings.page') }}#connections"

--- a/app/templates/settings/connections/form.html
+++ b/app/templates/settings/connections/form.html
@@ -176,6 +176,14 @@
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _("API key from your external service settings") }}</p>
               </div>
             {% endif %}
+            <!-- Provision Plex users -->
+            <div>
+              <div class="flex items-center">
+                {{ form.provision_plex_users(class="w-4 h-4 text-primary bg-gray-50 border-gray-300 rounded focus:ring-primary dark:bg-gray-700 dark:border-gray-600") }}
+                {{ form.provision_plex_users.label(class="ml-2 text-sm font-medium text-gray-900 dark:text-white") }}
+              </div>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ _(form.provision_plex_users.description) }}</p>
+            </div>
             <!-- Form Actions -->
             <div class="flex items-center justify-end space-x-4 pt-4 border-t border-gray-200 dark:border-gray-700">
               <a href="{{ url_for('settings.page') }}#connections"

--- a/app/templates/settings/connections/form.html
+++ b/app/templates/settings/connections/form.html
@@ -124,19 +124,36 @@
                   <div>
                     <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-3">{{ _("Overseerr/Jellyseerr Information") }}</h3>
                     <p class="text-gray-600 dark:text-gray-300 mb-4">
-                      {{ _("Overseerr and Jellyseerr automatically import new users by default. No API connection is required for Wizarr integration.") }}
+                      {{ _("Overseerr and Jellyseerr create an account the first time someone signs in, so by default an invited user has no account there until they visit and log in themselves.") }}
                     </p>
                     <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-                      <h4 class="text-sm font-semibold text-blue-900 dark:text-blue-200 mb-2">{{ _("To enable auto-import:") }}</h4>
+                      <h4 class="text-sm font-semibold text-blue-900 dark:text-blue-200 mb-2">
+                        {{ _("To have Wizarr create the account instead:") }}
+                      </h4>
                       <ol class="text-sm text-blue-800 dark:text-blue-200 space-y-1 list-decimal list-inside">
-                        <li>{{ _("Open your Overseerr/Jellyseerr admin panel") }}</li>
-                        <li>{{ _("Navigate to Settings → Users") }}</li>
-                        <li>{{ _("Enable 'Auto-approve new users'") }}</li>
-                        <li>{{ _("Enable 'Import Jellyfin/Plex users'") }}</li>
+                        <li>{{ _("Set the Service URL below") }}</li>
+                        <li>{{ _("Turn on account creation below") }}</li>
+                        <li>{{ _("In the service, enable Settings → Users → 'Enable New Plex Sign-In'") }}</li>
                       </ol>
+                      <p class="mt-2 text-sm text-blue-800 dark:text-blue-200">
+                        {{ _("This uses the service's own sign-in route, so there is no API key to configure.") }}
+                      </p>
                     </div>
                   </div>
                 </div>
+              </div>
+              <!-- URL -->
+              <div>
+                {{ form.url.label(class="block mb-2 text-sm font-medium text-gray-900 dark:text-white") }}
+                {{ form.url(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary", placeholder="https://requests.example.com") }}
+                {% if form.url.errors %}
+                  <div class="mt-1 text-sm text-red-600 dark:text-red-400">
+                    {% for error in form.url.errors %}<p>{{ error }}</p>{% endfor %}
+                  </div>
+                {% endif %}
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  {{ _("Must be https if the service has CSRF protection enabled, which sets its cookies Secure.") }}
+                </p>
               </div>
             {% else %}
               <!-- URL -->

--- a/migrations/versions/20260809_add_connection_enable_watchlist_sync.py
+++ b/migrations/versions/20260809_add_connection_enable_watchlist_sync.py
@@ -1,0 +1,36 @@
+"""Add opt-in flag for enabling watchlist sync on a connection
+
+Revision ID: f4a2b81c60d7
+Revises: b7d1c93f4a26
+Create Date: 2026-08-09 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f4a2b81c60d7"
+down_revision = "b7d1c93f4a26"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Off for existing rows, for the same reason provision_plex_users was: a
+    # connection configured before this flag existed must keep behaving exactly
+    # as it did.
+    with op.batch_alter_table("ombi_connection", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "enable_watchlist_sync",
+                sa.Boolean(),
+                nullable=False,
+                server_default="0",
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("ombi_connection", schema=None) as batch_op:
+        batch_op.drop_column("enable_watchlist_sync")

--- a/migrations/versions/b7d1c93f4a26_add_connection_provision_plex_users.py
+++ b/migrations/versions/b7d1c93f4a26_add_connection_provision_plex_users.py
@@ -1,7 +1,7 @@
 """Add opt-in flag for provisioning Plex users on a connection
 
 Revision ID: b7d1c93f4a26
-Revises: e6155a91eb50
+Revises: 20260401_repair
 Create Date: 2026-07-22 17:05:11.402913
 
 """

--- a/migrations/versions/b7d1c93f4a26_add_connection_provision_plex_users.py
+++ b/migrations/versions/b7d1c93f4a26_add_connection_provision_plex_users.py
@@ -1,0 +1,35 @@
+"""Add opt-in flag for provisioning Plex users on a connection
+
+Revision ID: b7d1c93f4a26
+Revises: e6155a91eb50
+Create Date: 2026-07-22 17:05:11.402913
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b7d1c93f4a26"
+down_revision = "20260401_repair"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Off for existing rows: a connection configured before this flag existed
+    # must keep behaving exactly as it did.
+    with op.batch_alter_table("ombi_connection", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "provision_plex_users",
+                sa.Boolean(),
+                nullable=False,
+                server_default="0",
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("ombi_connection", schema=None) as batch_op:
+        batch_op.drop_column("provision_plex_users")

--- a/tests/test_connection_form.py
+++ b/tests/test_connection_form.py
@@ -1,0 +1,32 @@
+"""The connection form has to submit the fields it requires.
+
+Issue #1343: creating an Overseerr/Jellyseerr connection silently did nothing.
+Clicking Create Connection returned HTTP 200 and no row appeared.
+"""
+
+from pathlib import Path
+
+MODAL = (
+    Path(__file__).resolve().parents[1] / "app/templates/modals/connection-form.html"
+)
+
+
+def test_required_fields_are_not_rendered_disabled():
+    """Connection Name and Media Server were disabled for the overseerr type.
+
+    Disabled inputs are not submitted, and both fields carry DataRequired, so
+    validate_on_submit() failed on fields the user had no way to fill. The route
+    then re-rendered the form without surfacing an error, which is why this
+    looked like nothing happening rather than a validation failure.
+    """
+    modal = MODAL.read_text()
+
+    assert "disabled=(form.connection_type.data == 'overseerr')" not in modal
+
+
+def test_every_form_field_that_is_required_is_editable():
+    """Guards the general shape rather than the one type that regressed."""
+    for line in MODAL.read_text().splitlines():
+        for field in ("form.name(", "form.media_server_id("):
+            if field in line:
+                assert "disabled" not in line, f"{field} rendered disabled"

--- a/tests/test_overseerr_connection_test.py
+++ b/tests/test_overseerr_connection_test.py
@@ -1,0 +1,147 @@
+"""Testing an Overseerr connection checks what account creation actually needs.
+
+Provisioning runs on a background thread minutes after the invite, so when a
+prerequisite is missing nobody finds out - the invited user just never gets an
+account. Every prerequisite is readable anonymously, so the test button can
+check the whole chain up front: the instance is Overseerr, a POST survives its CSRF
+middleware, and new Plex sign-in is allowed.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+from app.services.companions.overseerr import OverseerrClient
+
+BASE = "https://overseerr.local"
+STATUS_URL = f"{BASE}/api/v1/status"
+LOGOUT_URL = f"{BASE}/api/v1/auth/logout"
+SETTINGS_URL = f"{BASE}/api/v1/settings/public"
+
+
+def _connection(url=BASE, provision=True):
+    # spec'd so a typo'd attribute fails loudly instead of auto-vivifying.
+    conn = Mock(
+        spec=["url", "api_key", "name", "connection_type", "provision_plex_users"]
+    )
+    conn.url = url
+    conn.api_key = None
+    conn.name = "Overseerr"
+    conn.connection_type = "overseerr"
+    conn.provision_plex_users = provision
+    return conn
+
+
+def _resp(status=200, payload=None, text=""):
+    resp = Mock(spec=["ok", "status_code", "text", "json"])
+    resp.ok = 200 <= status < 300
+    resp.status_code = status
+    resp.text = text
+    resp.json = (
+        Mock(return_value=payload)
+        if payload is not None
+        else Mock(side_effect=ValueError("no json"))
+    )
+    return resp
+
+
+@contextmanager
+def _overseerr(status=None, logout=None, settings=None, xsrf="csrf-token-value"):
+    """Stand in for the HTTP session, answering each URL the test walks."""
+    status = status if status is not None else _resp(200, {"version": "3.3.0"})
+    logout = logout if logout is not None else _resp(401, text="connect.sid required")
+    settings = settings if settings is not None else _resp(200, {"newPlexLogin": True})
+
+    session = Mock(spec=["get", "post", "cookies"])
+    session.cookies = Mock(spec=["get"])
+    session.cookies.get.return_value = xsrf
+    session.get.side_effect = lambda url, **_: status if url == STATUS_URL else settings
+    session.post.return_value = logout
+
+    with patch(
+        "app.services.companions.overseerr.requests.Session", return_value=session
+    ):
+        yield session
+
+
+def test_no_url_is_informational_and_calls_nothing():
+    with _overseerr() as overseerr:
+        result = OverseerrClient().test_connection(_connection(url=""))
+
+    assert result["status"] == "info_only"
+    assert not overseerr.get.called
+    assert not overseerr.post.called
+
+
+def test_unreachable_instance_reports_the_url():
+    with _overseerr() as overseerr:
+        overseerr.get.side_effect = OSError("connection refused")
+        result = OverseerrClient().test_connection(_connection())
+
+    assert result["status"] == "error"
+    assert BASE in result["message"]
+
+
+def test_something_that_is_not_overseerr_is_not_a_pass():
+    """A proxy error page or login screen answers 200 with no version."""
+    with _overseerr(status=_resp(200, payload=None, text="<html>hello</html>")):
+        result = OverseerrClient().test_connection(_connection())
+
+    assert result["status"] == "error"
+    assert "not with Overseerr/Jellyseerr's API" in result["message"]
+
+
+def test_csrf_rejection_points_at_https():
+    """The one failure that never fixes itself: Overseerr's CSRF cookies are
+    Secure, so over http they are never sent back and no retry can help."""
+    with _overseerr(logout=_resp(403, text='{"message":"invalid csrf token"}')):
+        result = OverseerrClient().test_connection(_connection())
+
+    assert result["status"] == "error"
+    assert "https" in result["message"]
+
+
+def test_csrf_probe_uses_logout_not_the_sign_in_route():
+    """Posting a throwaway token to /auth/plex would prove the same thing while
+    making Overseerr call plex.tv and log a failed sign-in."""
+    with _overseerr() as overseerr:
+        OverseerrClient().test_connection(_connection())
+
+    (posted,) = overseerr.post.call_args[0]
+    assert posted == LOGOUT_URL
+    assert overseerr.post.call_args[1]["headers"]["X-XSRF-TOKEN"] == "csrf-token-value"
+
+
+def test_new_plex_login_off_is_an_error_naming_the_setting():
+    with _overseerr(settings=_resp(200, {"newPlexLogin": False})):
+        result = OverseerrClient().test_connection(_connection())
+
+    assert result["status"] == "error"
+    assert "Enable New Plex Sign-In" in result["message"]
+
+
+def test_everything_in_place_passes():
+    with _overseerr() as overseerr:
+        result = OverseerrClient().test_connection(_connection())
+
+    assert result["status"] == "success"
+    assert "3.3.0" in result["message"]
+    # The status GET is what primes the CSRF cookie, so it has to come first.
+    assert [c[0][0] for c in overseerr.get.call_args_list] == [STATUS_URL, SETTINGS_URL]
+
+
+def test_provisioning_off_is_informational_not_a_pass():
+    """Nothing is wrong, but nothing is being called either, and saying
+    "success" would imply Wizarr creates accounts when it does not."""
+    with _overseerr():
+        result = OverseerrClient().test_connection(_connection(provision=False))
+
+    assert result["status"] == "info_only"
+
+
+def test_unreadable_settings_pass_but_say_so():
+    """Don't fail a working instance over a setting we could not read."""
+    with _overseerr(settings=_resp(403)):
+        result = OverseerrClient().test_connection(_connection())
+
+    assert result["status"] == "success"
+    assert "Could not read" in result["message"]

--- a/tests/test_overseerr_plex_provisioning.py
+++ b/tests/test_overseerr_plex_provisioning.py
@@ -21,20 +21,31 @@ from app.services.ombi_client import (
 )
 
 
-def _connection(url="http://seerr.local:5055"):
+def _connection(url="http://seerr.local:5055", watchlist_sync=False):
     # spec'd so a typo'd attribute fails loudly instead of auto-vivifying,
     # which is how a broken patch once passed its tests.
-    conn = Mock(spec=["url", "api_key", "name", "connection_type"])
+    conn = Mock(
+        spec=[
+            "url",
+            "api_key",
+            "name",
+            "connection_type",
+            "enable_watchlist_sync",
+        ]
+    )
     conn.url = url
     conn.api_key = None
     conn.name = "Seerr"
     conn.connection_type = "overseerr"
+    conn.enable_watchlist_sync = watchlist_sync
     return conn
 
 
-def _resp(status=200, text=""):
+def _resp(status=200, text="", json=None):
     """Overseerr replies carry a body we now read, so mocks must have one."""
-    return Mock(ok=200 <= status < 300, status_code=status, text=text)
+    resp = Mock(ok=200 <= status < 300, status_code=status, text=text)
+    resp.json.return_value = {} if json is None else json
+    return resp
 
 
 @contextmanager
@@ -224,4 +235,172 @@ def test_both_connection_forms_offer_the_opt_in(app):
         "app/templates/modals/connection-form.html",
         "app/templates/settings/connections/form.html",
     ):
-        assert "provision_plex_users" in Path(path).read_text(), path
+        body = Path(path).read_text()
+        assert "provision_plex_users" in body, path
+        assert "enable_watchlist_sync" in body, path
+
+
+# ─── Watchlist syncing ──────────────────────────────────────────────────
+
+
+def _provisioned(user_id=42, settings=None):
+    """The two replies a provisioning run reads when watchlist sync is on."""
+    login = _resp(200, json={"id": user_id})
+    read = _resp(200, json=settings if settings is not None else {"locale": "en"})
+    return login, read
+
+
+def test_watchlist_sync_is_left_alone_unless_asked_for():
+    """It changes a preference belonging to the user, so it stays opt-in and
+    separate from merely creating the account."""
+    with _seerr() as (seerr, _):
+        seerr.post.return_value = _resp(200, json={"id": 42})
+        result = OverseerrClient().provision_plex_user("t", _connection())
+
+    assert result["status"] == "success"
+    # Only the sign-in, no settings write.
+    assert seerr.post.call_count == 1
+
+
+def test_turns_on_both_watchlist_flags_for_the_new_user():
+    """Overseerr leaves both unset on a new account and skips users whose flags
+    are unset, so a watchlist added on day one requests nothing, silently."""
+    login, read = _provisioned(user_id=42)
+    with _seerr() as (seerr, _):
+        seerr.post.side_effect = [login, _resp(200)]
+        seerr.get.return_value = read
+
+        result = OverseerrClient().provision_plex_user(
+            "t", _connection(watchlist_sync=True)
+        )
+
+    assert result["status"] == "success"
+    (url,) = seerr.post.call_args[0]
+    assert url == "http://seerr.local:5055/api/v1/user/42/settings/main"
+    body = seerr.post.call_args[1]["json"]
+    assert body["watchlistSyncMovies"] is True
+    assert body["watchlistSyncTv"] is True
+
+
+def test_the_settings_write_echoes_back_what_it_read():
+    """The endpoint assigns username and the regions straight from the body, so
+    anything left out is blanked rather than kept."""
+    login, read = _provisioned(
+        settings={
+            "username": "invited-user",
+            "locale": "en",
+            "discoverRegion": "US",
+            "streamingRegion": "US",
+            "originalLanguage": "en",
+        }
+    )
+    with _seerr() as (seerr, _):
+        seerr.post.side_effect = [login, _resp(200)]
+        seerr.get.return_value = read
+
+        OverseerrClient().provision_plex_user("t", _connection(watchlist_sync=True))
+
+    body = seerr.post.call_args[1]["json"]
+    assert body["username"] == "invited-user"
+    assert body["discoverRegion"] == "US"
+    assert body["streamingRegion"] == "US"
+    assert body["originalLanguage"] == "en"
+
+
+def test_a_missing_locale_is_sent_as_empty_not_null():
+    """A user with no settings row yet has no locale to echo, and the column is
+    NOT NULL - posting the missing value back is a 500."""
+    login, read = _provisioned(settings={"username": "invited-user"})
+    with _seerr() as (seerr, _):
+        seerr.post.side_effect = [login, _resp(200)]
+        seerr.get.return_value = read
+
+        OverseerrClient().provision_plex_user("t", _connection(watchlist_sync=True))
+
+    assert seerr.post.call_args[1]["json"]["locale"] == ""
+
+
+def test_the_settings_write_uses_the_token_signing_in_rotated_to():
+    """Signing in rotates the CSRF token; the one primed beforehand no longer
+    validates and every settings write would come back 403."""
+    login, read = _provisioned()
+    with _seerr(xsrf="primed-token") as (seerr, _):
+        seerr.post.side_effect = [login, _resp(200)]
+        seerr.get.return_value = read
+        seerr.cookies.get.side_effect = ["primed-token", "rotated-token"]
+
+        OverseerrClient().provision_plex_user("t", _connection(watchlist_sync=True))
+
+    assert seerr.post.call_args[1]["headers"]["X-XSRF-TOKEN"] == "rotated-token"
+
+
+def test_the_account_still_counts_when_the_setting_does_not_take():
+    """The user exists either way; reporting the whole thing failed would send
+    the next person looking for an account that is already there."""
+    login, _read = _provisioned()
+    with _seerr() as (seerr, _):
+        seerr.post.side_effect = [login, _resp(500, "boom")]
+        seerr.get.return_value = _resp(200, json={"locale": "en"})
+
+        result = OverseerrClient().provision_plex_user(
+            "t", _connection(watchlist_sync=True)
+        )
+
+    assert result["status"] == "success"
+    assert "watchlist" in result["message"].lower()
+    assert "500" in result["message"]
+
+
+def test_no_settings_write_without_a_user_id():
+    """Posting to /user/None/settings/main would be a confusing 404 at best."""
+    with _seerr() as (seerr, _):
+        seerr.post.side_effect = [_resp(200, json={}), _resp(200)]
+        seerr.get.return_value = _resp(200, json={"locale": "en"})
+
+        result = OverseerrClient().provision_plex_user(
+            "t", _connection(watchlist_sync=True)
+        )
+
+    assert result["status"] == "success"
+    assert seerr.post.call_count == 1
+
+
+def test_the_form_refuses_watchlist_sync_without_account_creation(app):
+    """The setting is written during account creation, on the session creating
+    the account returns. Without it the box stays ticked and never takes effect,
+    which is the same silent nothing the flag exists to prevent."""
+    from app.forms.connections import ConnectionForm
+
+    with app.test_request_context():
+        form = ConnectionForm(
+            connection_type="overseerr",
+            name="Seerr",
+            url="https://seerr.local",
+            media_server_id=1,
+            provision_plex_users=False,
+            enable_watchlist_sync=True,
+            meta={"csrf": False},
+        )
+        form.media_server_id.choices = [(1, "Plex")]
+
+        assert form.validate() is False
+        assert form.enable_watchlist_sync.errors
+
+        form.provision_plex_users.data = True
+
+        assert form.validate() is True
+
+
+def test_watchlist_failures_are_reported_not_raised():
+    """Best effort throughout: this runs off an invite the user already accepted."""
+    login, _read = _provisioned()
+    with _seerr() as (seerr, _):
+        seerr.post.side_effect = [login, OSError("connection refused")]
+        seerr.get.return_value = _resp(200, json={"locale": "en"})
+
+        result = OverseerrClient().provision_plex_user(
+            "t", _connection(watchlist_sync=True)
+        )
+
+    assert result["status"] == "success"
+    assert "connection refused" in result["message"]

--- a/tests/test_overseerr_plex_provisioning.py
+++ b/tests/test_overseerr_plex_provisioning.py
@@ -1,0 +1,227 @@
+"""Invited Plex users get their Overseerr account made for them.
+
+Overseerr does not import Plex users in the background - it creates them the
+first time they sign in. So an invited user lands on a login screen before
+anything knows who they are, and watchlist syncing has no token to work with
+until they get around to it. Wizarr holds their Plex token during the invite,
+which is everything that first sign-in would have supplied.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+from app.services.companions import get_companion_client
+from app.services.companions.overseerr import (
+    _PROVISION_BACKOFF_SECONDS,
+    OverseerrClient,
+)
+from app.services.ombi_client import (
+    has_plex_provisioning_connections,
+    provision_plex_user_on_connections,
+)
+
+
+def _connection(url="http://seerr.local:5055"):
+    # spec'd so a typo'd attribute fails loudly instead of auto-vivifying,
+    # which is how a broken patch once passed its tests.
+    conn = Mock(spec=["url", "api_key", "name", "connection_type"])
+    conn.url = url
+    conn.api_key = None
+    conn.name = "Seerr"
+    conn.connection_type = "overseerr"
+    return conn
+
+
+def _resp(status=200, text=""):
+    """Overseerr replies carry a body we now read, so mocks must have one."""
+    return Mock(ok=200 <= status < 300, status_code=status, text=text)
+
+
+@contextmanager
+def _seerr(xsrf="csrf-token-value"):
+    """Stand in for the HTTP session, handing back a primed CSRF cookie."""
+    session = Mock(spec=["get", "post", "cookies"])
+    session.cookies = Mock(spec=["get"])
+    session.cookies.get.return_value = xsrf
+
+    with (
+        patch(
+            "app.services.companions.overseerr.requests.Session",
+            return_value=session,
+        ),
+        patch("app.services.companions.overseerr.time.sleep") as sleep,
+    ):
+        yield session, sleep
+
+
+def test_posts_the_plex_token_to_the_login_route():
+    with _seerr() as (seerr, _):
+        seerr.post.return_value = _resp(200)
+        result = OverseerrClient().provision_plex_user("plex-token-abc", _connection())
+
+    assert result["status"] == "success"
+    (url,) = seerr.post.call_args[0]
+    assert url == "http://seerr.local:5055/api/v1/auth/plex"
+    assert seerr.post.call_args[1]["json"] == {"authToken": "plex-token-abc"}
+
+
+def test_sends_the_csrf_token_overseerr_handed_us():
+    """Without this every POST comes back 403 "invalid csrf token", whatever the
+    payload. Overseerr applies CSRF to API callers, not just browsers."""
+    with _seerr(xsrf="the-expected-token") as (seerr, _):
+        seerr.post.return_value = _resp(200)
+        OverseerrClient().provision_plex_user("t", _connection())
+
+    # The cookie only arrives on a response, so a GET has to come first.
+    (primed_url,) = seerr.get.call_args[0]
+    assert primed_url == "http://seerr.local:5055/api/v1/status"
+    assert seerr.post.call_args[1]["headers"]["X-XSRF-TOKEN"] == "the-expected-token"
+
+
+def test_no_csrf_header_when_the_instance_does_not_use_one():
+    """CSRF protection is optional; inventing a header would be wrong."""
+    with _seerr(xsrf=None) as (seerr, _):
+        seerr.post.return_value = _resp(200)
+        OverseerrClient().provision_plex_user("t", _connection())
+
+    assert seerr.post.call_args[1]["headers"] == {}
+
+
+def test_no_api_key_is_sent():
+    """/api/v1/auth/plex is the public login route; an API key would be wrong."""
+    with _seerr() as (seerr, _):
+        seerr.post.return_value = _resp(200)
+        OverseerrClient().provision_plex_user("plex-token-abc", _connection())
+
+    headers = seerr.post.call_args[1]["headers"]
+    assert "ApiKey" not in headers
+    assert "X-Api-Key" not in headers
+
+
+def test_trailing_slash_on_the_url_does_not_double_up():
+    with _seerr() as (seerr, _):
+        seerr.post.return_value = _resp(200)
+        OverseerrClient().provision_plex_user(
+            "t", _connection("http://seerr.local:5055/")
+        )
+
+    (url,) = seerr.post.call_args[0]
+    assert url == "http://seerr.local:5055/api/v1/auth/plex"
+
+
+def test_retries_while_the_share_is_not_visible_yet():
+    """403 can mean plex.tv has not published the brand new share yet."""
+    with _seerr() as (seerr, _):
+        seerr.post.side_effect = [
+            _resp(403, "Access denied."),
+            _resp(200),
+        ]
+        result = OverseerrClient().provision_plex_user("t", _connection())
+
+    assert result["status"] == "success"
+    assert seerr.post.call_count == 2
+
+
+def test_does_not_retry_a_csrf_rejection():
+    """A CSRF 403 is the request being refused, not the user. Overseerr's CSRF
+    cookies are Secure, so an http:// URL can never satisfy them and retrying
+    just burns eight minutes before reporting the wrong thing."""
+    with _seerr() as (seerr, _):
+        seerr.post.return_value = _resp(403, '{"message":"invalid csrf token"}')
+        result = OverseerrClient().provision_plex_user("t", _connection())
+
+    assert seerr.post.call_count == 1
+    assert result["status"] == "error"
+    # The body has to survive into the message, or this looks like a rejected
+    # user and sends the next person debugging in the wrong direction.
+    assert "csrf" in result["message"].lower()
+
+
+def test_keeps_retrying_for_minutes_not_seconds():
+    with _seerr() as (seerr, sleep):
+        seerr.post.return_value = _resp(403, "Access denied.")
+        OverseerrClient().provision_plex_user("t", _connection())
+
+    waited = sum(call[0][0] for call in sleep.call_args_list)
+    assert waited >= 300, f"only retried across {waited}s"
+    assert seerr.post.call_count == len(_PROVISION_BACKOFF_SECONDS) + 1
+
+
+def test_gives_up_immediately_on_errors_that_will_not_fix_themselves():
+    with _seerr() as (seerr, _):
+        seerr.post.return_value = _resp(500, "Unable to authenticate.")
+        result = OverseerrClient().provision_plex_user("t", _connection())
+
+    assert result["status"] == "error"
+    assert seerr.post.call_count == 1
+
+
+def test_skipped_when_no_url_is_configured():
+    """Info-only connections carry no URL and must stay a no-op."""
+    with _seerr() as (seerr, _):
+        result = OverseerrClient().provision_plex_user("t", _connection(url=None))
+
+    assert result["status"] == "skipped"
+    seerr.post.assert_not_called()
+
+
+def test_a_companion_that_cannot_provision_is_a_no_op():
+    """Ombi provisions its own way; the hook must not change its behaviour."""
+    result = get_companion_client("ombi")().provision_plex_user("t", _connection())
+
+    assert result["status"] == "not_supported"
+
+
+def test_connection_failure_is_reported_not_raised():
+    """A companion being down must never fail an invite the user just accepted."""
+    with _seerr() as (seerr, _):
+        seerr.post.side_effect = OSError("connection refused")
+        result = OverseerrClient().provision_plex_user("t", _connection())
+
+    assert result["status"] == "error"
+    assert "connection refused" in result["message"]
+
+
+def test_only_opted_in_connections_are_queried(app):
+    """Most instances have no request system, and an existing connection that
+    predates the flag must not start provisioning on upgrade."""
+    with (
+        app.app_context(),
+        patch("app.services.ombi_client.Connection") as connection_model,
+    ):
+        connection_model.query.filter_by.return_value.all.return_value = []
+
+        results = provision_plex_user_on_connections("t", server_id=7)
+
+    assert results == []
+    connection_model.query.filter_by.assert_called_once_with(
+        media_server_id=7, provision_plex_users=True
+    )
+
+
+def test_no_background_work_when_nothing_opted_in(app):
+    """Gates spawning the retry thread, so instances without a request system
+    pay nothing on every invite."""
+    with (
+        app.app_context(),
+        patch("app.services.ombi_client.Connection") as connection_model,
+    ):
+        connection_model.query.filter_by.return_value.count.return_value = 0
+
+        assert has_plex_provisioning_connections(7) is False
+
+        connection_model.query.filter_by.return_value.count.return_value = 1
+
+        assert has_plex_provisioning_connections(7) is True
+
+
+def test_both_connection_forms_offer_the_opt_in(app):
+    """Connections are edited from two templates; a toggle present in only one
+    is a toggle half the users cannot find."""
+    from pathlib import Path
+
+    for path in (
+        "app/templates/modals/connection-form.html",
+        "app/templates/settings/connections/form.html",
+    ):
+        assert "provision_plex_users" in Path(path).read_text(), path


### PR DESCRIPTION
Closes #1343.

### The problem

Overseerr and Jellyseerr do not import users in the background. They create a
user the first time that user signs in. So someone invited through Wizarr has no
account there until they go and log in themselves, and until they do, nothing
knows who they are and watchlist syncing has no token to work with.

The connection form currently states the opposite:

> Overseerr and Jellyseerr automatically import new users by default. No API
> connection is required for Wizarr integration.

That is where the expectation comes from, and it is why the type is labelled
"(Info Only)".

### The change

Wizarr already holds the invited user's Plex token during the invite, which is
everything that first sign-in would have supplied. Post it to
`/api/v1/auth/plex`, the same public route the login page uses, once the share
exists.

This cannot grant access the service would have refused. It still requires the
user to reach the media server and `newPlexLogin` to be enabled, which is
exactly what would have been checked had they signed in by hand. No API key is
involved, and the session it returns is discarded unless the connection also
asked for watchlist syncing, below.

### Off by default

Connections carry a new `provision_plex_users` flag defaulting to false, with a
migration that leaves existing rows off. Instances with no request system are
unaffected, and an existing connection does not change behaviour on upgrade.

I deliberately did not infer intent from "a URL is configured": the client was
information-only until now, so that would have switched this on for people who
never asked for it.

### Watchlist syncing

Creating the account turns out to be only two thirds of what an invited user
needs. Watchlist syncing is gated on three things: the user having signed in at
least once, holding the Auto-Request permission, and their own
`watchlistSyncMovies` and `watchlistSyncTv` settings. Provisioning covers the
first. Default permissions cover the second, since a new user is created with
whatever the instance configured. Nothing covers the third.

Both watchlist columns are nullable with no default, and a new account gets no
settings row at all, so both read as unset, and the sync job skips any user whose
flags are unset. An invited user who watchlists something on day one therefore
gets nothing requested, and nothing anywhere reports a problem: not the job, not
the user, not the log. They have to find a setting they were never told about.

So a second flag, `enable_watchlist_sync`, offers to turn it on while we are
already there. The sign-in that creates the account returns a session belonging
to that user, so the write needs no API key and cannot touch anyone else's
account.

Kept separate from provisioning rather than folded into it: creating an account
someone asked to be created is not the same as deciding a preference on their
behalf, and an admin may reasonably want the account without the setting. Also
off by default, and the form refuses it without account creation, since there
would be no moment to write it and the box would never take effect.

Three things this gets wrong if written the obvious way, all found against a real
instance. The settings endpoint is a read-modify-write over the whole profile,
assigning username and the regions straight from the body, so a minimal payload
silently blanks them. A user with no settings row has no locale to echo and the
column is NOT NULL, so the missing value has to go back as the empty string that
rows created through the UI hold. Signing in rotates the CSRF token, so the one
primed beforehand no longer validates.

Failing to set it leaves the account in place and says so, rather than reporting
the whole run as failed and sending someone looking for an account that already
exists.

Worth stating for anyone enabling it: this turns on the user's syncing, but the
service still decides what they may request. For watchlisted titles to be
requested automatically, Auto-Request has to be in the instance's default
permissions.

### Two commits

The first fixes #1343 on its own and stands without the rest: the modal rendered
Connection Name and Media Server as `disabled` for this connection type,
disabled inputs are not submitted, both fields carry `DataRequired`, so
validation failed on fields the user could not fill and the connection was
silently never created. Two files, eight lines of template. Cherry-pick it
separately if you would rather take that first, or ask and I will move it to its
own PR.

That bug is a large part of why this connection type looked information-only,
and it would have left this feature's opt-in unreachable.

The second adds the provisioning. It also offers the Service URL for this
connection type, which was previously not rendered at all, because provisioning
needs somewhere to post to. The opt-in appears in both connection form
templates, and the blurb describes what the service actually does.

### Failure behaviour

Provisioning runs off the request thread, so a slow or unreachable companion
cannot hold up an invite, and it never raises: failing to provision must not
break an invite the user has just accepted.

The response body is logged rather than the bare status. A 403 from this
endpoint can mean the user was rejected, which may be worth retrying, or that
the request was rejected, which never is, and the two are indistinguishable from
the status alone. A CSRF rejection stops immediately and says what to change:
these services set their CSRF cookies `Secure`, so an `http://` connection URL
can never satisfy them.

### Scope

Plex only. The hook is a no-op on the companion base class, so companions that
provision another way are untouched.

Related: #332 and #869 describe the neighbouring problem of Jellyseerr accounts
missing emails. This does not address those.

Verified end to end on a real instance against a real Plex and Overseerr pair:
the account appears a second or two after the invite completes, with the token
stored and default permissions applied, and the invited user never visits the
request site.

### Tests

`tests/test_overseerr_plex_provisioning.py`, 25 cases: the token goes to the
login route with no API key, the CSRF token is echoed back and omitted when the
instance does not use one, trailing slashes do not double up, a CSRF rejection
is not retried and keeps its body in the message, transport failures are
reported rather than raised, a missing URL is a no-op, a companion that cannot
provision stays a no-op, only opted-in connections are queried, no background
work happens when nothing opted in, and both form templates offer the toggles.

For watchlist syncing: it is left alone unless asked for, both flags are set for
the new user, the write echoes back what it read, a missing locale goes as empty
rather than null, the write uses the token signing in rotated to, no write is
attempted without a user id, the account still counts when the setting does not
take, failures are reported rather than raised, and the form refuses the setting
without account creation.

I am happy to split the #1343 fix into its own PR if you would rather take that
separately.

