### PR TITLE
Add WIZARR_DISABLE_ACTIVITY_MONITORING toggle

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -76,6 +76,7 @@ def create_app(config_object=DevelopmentConfig):
     if show_startup:
         logger.step("Configuring request processing", "⚙️")
     from .context_processors import (
+        inject_activity_monitoring,
         inject_app_version,
         inject_plus_features,
         inject_server_name,
@@ -84,6 +85,7 @@ def create_app(config_object=DevelopmentConfig):
     app.context_processor(inject_server_name)
     app.context_processor(inject_plus_features)
     app.context_processor(inject_app_version)
+    app.context_processor(inject_activity_monitoring)
     register_error_handlers(app)
 
     # Register custom Jinja filters

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -45,25 +45,32 @@ def create_app(config_object=DevelopmentConfig):
     for bp in all_blueprints:
         app.register_blueprint(bp)
 
-    # Initialise activity monitoring (blueprint already registered above)
+    # Initialise activity monitoring (blueprint already registered above).
+    # Operators can disable it entirely with WIZARR_DISABLE_ACTIVITY_MONITORING
+    # for invite-only deployments that use external monitoring (#1363).
+    activity_monitoring_disabled = os.getenv(
+        "WIZARR_DISABLE_ACTIVITY_MONITORING", "false"
+    ).lower() in ("true", "1", "yes")
+
     from app.activity import init_app as init_activity
 
     init_activity(app)
 
     # Register activity scheduler tasks if the scheduler is available
-    try:
-        from .extensions import scheduler as activity_scheduler
+    if not activity_monitoring_disabled:
+        try:
+            from .extensions import scheduler as activity_scheduler
 
-        if (
-            activity_scheduler
-            and hasattr(activity_scheduler, "scheduler")
-            and activity_scheduler.scheduler
-        ):
-            from app.tasks.activity import register_activity_tasks
+            if (
+                activity_scheduler
+                and hasattr(activity_scheduler, "scheduler")
+                and activity_scheduler.scheduler
+            ):
+                from app.tasks.activity import register_activity_tasks
 
-            register_activity_tasks(app, activity_scheduler)
-    except Exception as exc:
-        app.logger.warning(f"Failed to register activity tasks: {exc}")
+                register_activity_tasks(app, activity_scheduler)
+        except Exception as exc:
+            app.logger.warning(f"Failed to register activity tasks: {exc}")
 
     # Step 5: Setup context processors and filters
     if show_startup:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,6 +7,7 @@ from .error_handlers import register_error_handlers
 from .extensions import init_extensions
 from .logging_config import configure_logging
 from .middleware import require_onboarding
+from .utils.env import env_flag
 
 
 def create_app(config_object=DevelopmentConfig):
@@ -48,9 +49,7 @@ def create_app(config_object=DevelopmentConfig):
     # Initialise activity monitoring (blueprint already registered above).
     # Operators can disable it entirely with WIZARR_DISABLE_ACTIVITY_MONITORING
     # for invite-only deployments that use external monitoring (#1363).
-    activity_monitoring_disabled = os.getenv(
-        "WIZARR_DISABLE_ACTIVITY_MONITORING", "false"
-    ).lower() in ("true", "1", "yes")
+    activity_monitoring_disabled = env_flag("WIZARR_DISABLE_ACTIVITY_MONITORING")
 
     from app.activity import init_app as init_activity
 

--- a/app/activity/__init__.py
+++ b/app/activity/__init__.py
@@ -15,6 +15,7 @@ from flask import Flask
 
 from app.models import ActivitySession, ActivitySnapshot
 from app.services.activity import ActivityService
+from app.utils.env import env_flag
 
 from .monitoring.monitor import WebSocketMonitor
 
@@ -36,11 +37,7 @@ def init_app(app: Flask) -> None:
 
     # Allow operators to disable activity monitoring entirely for invite-only
     # deployments that rely on external tooling for playback/session stats (#1363).
-    if os.environ.get("WIZARR_DISABLE_ACTIVITY_MONITORING", "false").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
+    if env_flag("WIZARR_DISABLE_ACTIVITY_MONITORING"):
         logger.info(
             "Activity monitoring disabled via WIZARR_DISABLE_ACTIVITY_MONITORING"
         )

--- a/app/activity/__init__.py
+++ b/app/activity/__init__.py
@@ -34,6 +34,18 @@ def init_app(app: Flask) -> None:
         logger.debug("Skipping activity monitoring during migrations")
         return
 
+    # Allow operators to disable activity monitoring entirely for invite-only
+    # deployments that rely on external tooling for playback/session stats (#1363).
+    if os.environ.get("WIZARR_DISABLE_ACTIVITY_MONITORING", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    ):
+        logger.info(
+            "Activity monitoring disabled via WIZARR_DISABLE_ACTIVITY_MONITORING"
+        )
+        return
+
     # Skip only in Werkzeug's reloader parent process (development mode)
     # WERKZEUG_RUN_MAIN is only set when using Flask's development server with reloader
     # In production (Gunicorn/uWSGI), this env var won't be set, so we should proceed

--- a/app/context_processors.py
+++ b/app/context_processors.py
@@ -2,6 +2,7 @@ import os
 
 from app.extensions import db
 from app.models import Settings
+from app.utils.env import env_flag
 
 
 def inject_server_name():
@@ -41,9 +42,5 @@ def inject_app_version():
 
 def inject_activity_monitoring():
     """Inject whether background activity monitoring is enabled into templates."""
-    disabled = os.getenv("WIZARR_DISABLE_ACTIVITY_MONITORING", "false").lower() in (
-        "true",
-        "1",
-        "yes",
-    )
+    disabled = env_flag("WIZARR_DISABLE_ACTIVITY_MONITORING")
     return {"activity_monitoring_enabled": not disabled}

--- a/app/context_processors.py
+++ b/app/context_processors.py
@@ -37,3 +37,13 @@ def inject_plus_features():
 def inject_app_version():
     """Inject current app version into template context for cache busting."""
     return {"app_version": os.getenv("APP_VERSION", "dev")}
+
+
+def inject_activity_monitoring():
+    """Inject whether background activity monitoring is enabled into templates."""
+    disabled = os.getenv("WIZARR_DISABLE_ACTIVITY_MONITORING", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+    return {"activity_monitoring_enabled": not disabled}

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -225,13 +225,10 @@
     <div id="content" class="flex-1 z-10 overflow-y-auto pb-16 md:pb-0"></div>
     <!-- Mobile Bottom Navigation -->
     <nav class="md:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 z-50">
-      <div class="grid {% if activity_monitoring_enabled %}grid-cols-5{% else %}grid-cols-4{% endif %} h-16">
+      {% set mobile_grid_cols = 'grid-cols-5' if activity_monitoring_enabled else 'grid-cols-4' %}
+      <div class="grid {{ mobile_grid_cols }} h-16">
         {% set activity_url = url_for('activity.activity_dashboard') %}
-        {% set mobile_tabs = [
-                  ('/home', '#', 'Home', 'm4 12 8-8 8 8M6 10.5V19a1 1 0 0 0 1 1h3v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h3a1 1 0 0 0 1-1v-8.5'),
-                  ('/invites', '#invites', 'Invitations', 'm3.5 5.5 7.893 6.036a1 1 0 0 0 1.214 0L20.5 5.5M4 19h16a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Z'),
-                  ('/users', '#users', 'Users', 'M16 19h4a1 1 0 0 0 1-1v-1a3 3 0 0 0-3-3h-2m-2.236-4a3 3 0 1 0 0-4M3 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z')
-                ] %}
+        {% set mobile_tabs = [('/home', '#', 'Home', 'm4 12 8-8 8 8M6 10.5V19a1 1 0 0 0 1 1h3v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h3a1 1 0 0 0 1-1v-8.5'), ('/invites', '#invites', 'Invitations', 'm3.5 5.5 7.893 6.036a1 1 0 0 0 1.214 0L20.5 5.5M4 19h16a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Z'), ('/users', '#users', 'Users', 'M16 19h4a1 1 0 0 0 1-1v-1a3 3 0 0 0-3-3h-2m-2.236-4a3 3 0 1 0 0-4M3 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z')] %}
         {% if activity_monitoring_enabled %}
           {% set mobile_tabs = mobile_tabs + [(activity_url, '#activity', 'Activity', 'M5 3a1 1 0 0 1 1 1v12a1 1 0 1 1-2 0V4a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v9a1 1 0 1 1-2 0V8a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1Z')] %}
         {% endif %}

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -26,7 +26,11 @@
             <!-- Main Navigation -->
             <ul class="flex flex-col md:flex-row md:items-center gap-2 md:gap-4 md:space-y-0 space-y-2">
               {% set activity_url = url_for('activity.activity_dashboard') %}
-              {% set tabs = [('/home', '#', 'Home'), ('/invites', '#invites', 'Invitations'), ('/users', '#users', 'Users'), (activity_url, '#activity', 'Activity'), ('/settings', '#settings', 'Settings')] %}
+              {% set tabs = [('/home', '#', 'Home'), ('/invites', '#invites', 'Invitations'), ('/users', '#users', 'Users')] %}
+              {% if activity_monitoring_enabled %}
+                {% set tabs = tabs + [(activity_url, '#activity', 'Activity')] %}
+              {% endif %}
+              {% set tabs = tabs + [('/settings', '#settings', 'Settings')] %}
               {% for href, hash, label in tabs %}
                 <li>
                   <button hx-get="{{ href }}"
@@ -221,15 +225,17 @@
     <div id="content" class="flex-1 z-10 overflow-y-auto pb-16 md:pb-0"></div>
     <!-- Mobile Bottom Navigation -->
     <nav class="md:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 z-50">
-      <div class="grid grid-cols-5 h-16">
+      <div class="grid {% if activity_monitoring_enabled %}grid-cols-5{% else %}grid-cols-4{% endif %} h-16">
         {% set activity_url = url_for('activity.activity_dashboard') %}
         {% set mobile_tabs = [
                   ('/home', '#', 'Home', 'm4 12 8-8 8 8M6 10.5V19a1 1 0 0 0 1 1h3v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h3a1 1 0 0 0 1-1v-8.5'),
                   ('/invites', '#invites', 'Invitations', 'm3.5 5.5 7.893 6.036a1 1 0 0 0 1.214 0L20.5 5.5M4 19h16a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Z'),
-                  ('/users', '#users', 'Users', 'M16 19h4a1 1 0 0 0 1-1v-1a3 3 0 0 0-3-3h-2m-2.236-4a3 3 0 1 0 0-4M3 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z'),
-                  (activity_url, '#activity', 'Activity', 'M5 3a1 1 0 0 1 1 1v12a1 1 0 1 1-2 0V4a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v9a1 1 0 1 1-2 0V8a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1Z'),
-                  ('/settings', '#settings', 'Settings', 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 0 1 6 0z')
+                  ('/users', '#users', 'Users', 'M16 19h4a1 1 0 0 0 1-1v-1a3 3 0 0 0-3-3h-2m-2.236-4a3 3 0 1 0 0-4M3 18v-1a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v1a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1Zm8-10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z')
                 ] %}
+        {% if activity_monitoring_enabled %}
+          {% set mobile_tabs = mobile_tabs + [(activity_url, '#activity', 'Activity', 'M5 3a1 1 0 0 1 1 1v12a1 1 0 1 1-2 0V4a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v9a1 1 0 1 1-2 0V8a1 1 0 0 1 1-1Zm7 4a1 1 0 0 1 1 1v5a1 1 0 1 1-2 0v-5a1 1 0 0 1 1-1Z')] %}
+        {% endif %}
+        {% set mobile_tabs = mobile_tabs + [('/settings', '#settings', 'Settings', 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 0 1 6 0z')] %}
         {% for href, hash, label, icon_path in mobile_tabs %}
           <button hx-get="{{ href }}"
                   hx-trigger="click"

--- a/app/utils/env.py
+++ b/app/utils/env.py
@@ -1,0 +1,18 @@
+"""Helpers for reading configuration from environment variables."""
+
+import os
+
+_TRUTHY = frozenset({"true", "1", "yes", "on"})
+
+
+def env_flag(name: str, default: bool = False) -> bool:
+    """Read a boolean flag from the environment.
+
+    An unset variable returns ``default``. A set variable is truthy when its
+    value is true/1/yes/on, compared case-insensitively with surrounding
+    whitespace ignored; any other value is falsy.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in _TRUTHY


### PR DESCRIPTION
## What

Adds an opt-in environment toggle, `WIZARR_DISABLE_ACTIVITY_MONITORING`, that disables the background activity monitoring subsystem for deployments that only need the invite UI and rely on external tooling for playback and session stats. When it is set, the Activity tab is also hidden from the admin nav so the disabled state is visible rather than showing stale data.

Closes #1363.

## Why

Activity monitoring (`app/activity/__init__.py` -> `init_app`) always starts a `WebSocketMonitor`, and `create_app` registers four recurring jobs from `app/tasks/activity.py` (cleanup, stale cleanup, a 15 minute health check, and a 5 minute heartbeat). There was previously no way to turn this off, so it runs even for invite-only setups.

## How

- `init_app()` returns early when the toggle is set, before the monitor is constructed, mirroring the existing `FLASK_SKIP_SCHEDULER` guard.
- The activity job registration in `create_app()` is skipped as well.
- A context processor exposes `activity_monitoring_enabled`, and the admin nav (desktop and mobile) drops the Activity tab when monitoring is off. The mobile nav grid shrinks from five to four columns to match.
- Value parsing matches the existing `WIZARR_DISABLE_SCHEDULER` convention (`true` / `1` / `yes`). Defaults to off, so behaviour is unchanged for existing users.
- The `/activity/*` routes themselves are left in place and still respond if hit directly; only the always-on background monitor, its jobs, and the nav entry are gated.

## Testing

Ran two containers from the same image with identical config (one Plex server), differing only by the toggle:

| | Memory | Master threads |
|---|---|---|
| monitoring on | ~154 MiB | 5 |
| monitoring off | ~142 MiB | 3 |

The app boots healthy in both cases. With the toggle set, the `WebSocketMonitor` threads are gone, no activity jobs are scheduled, and the Activity tab is hidden. The tab-building and env-parsing logic was unit checked in both states. Savings scale with the number of media servers, and Jellyfin/Emby users on persistent websockets would likely save more.

## Notes

The historical-import sub-tab under Settings is left untouched. A follow-up could add an admin UI toggle instead of an env var, but that needs runtime start/stop of the monitor plus a settings field, so this env var is a low-risk first step.