### PR TITLE
Route the startup library scan through the shared upsert

### DIFF
--- a/app/services/library_scanner.py
+++ b/app/services/library_scanner.py
@@ -3,10 +3,9 @@
 This service handles scanning and synchronizing library metadata from media servers
 into the local database during application startup.
 
-This implementation performs an upsert (update existing, insert new) and soft-deletes
-(or removes) libraries that no longer exist on the remote server. Libraries that are
-referenced by invitations are preserved (disabled) instead of being hard-deleted so
-invite<->library associations remain intact.
+Reconciliation itself is delegated to ``media.service.upsert_scanned_libraries``,
+the same helper the invite modal and the server edit form use, so every scan path
+treats ``Library.enabled`` (the admin's saved invite default) identically.
 """
 
 import logging
@@ -32,8 +31,11 @@ def scan_all_server_libraries(show_logs: bool = True) -> tuple[int, list[str]]:
     from sqlalchemy import inspect
 
     from app.extensions import db
-    from app.models import Library, MediaServer, invite_libraries
-    from app.services.media.service import get_client_for_media_server
+    from app.models import Library, MediaServer
+    from app.services.media.service import (
+        scan_libraries_for_server,
+        upsert_scanned_libraries,
+    )
 
     # Check if the library table exists (in case migrations haven't run yet)
     inspector = inspect(db.engine)
@@ -48,78 +50,24 @@ def scan_all_server_libraries(show_logs: bool = True) -> tuple[int, list[str]]:
 
     for server in servers:
         try:
-            client = get_client_for_media_server(server)
-            libraries_dict = client.libraries()  # {external_id: name}
+            before = Library.query.filter_by(server_id=server.id).count()
 
-            # Normalize to dict if client returned list-like
-            if not isinstance(libraries_dict, dict):
-                libraries_dict = {
-                    str(k): str(v)
-                    for k, v in (
-                        libraries_dict.items()
-                        if hasattr(libraries_dict, "items")
-                        else libraries_dict
-                    )
-                }
-
-            # Load existing libraries for this server keyed by external_id
-            existing_libs = {
-                lib.external_id: lib
-                for lib in Library.query.filter_by(server_id=server.id).all()
-            }
-            old_count = len(existing_libs)
-
-            incoming_ids = set()
-            updated_count = 0
-            inserted_count = 0
-            disabled_count = 0
-            deleted_count = 0
-
-            # Upsert incoming libraries: update existing, insert new
-            for external_id, name in libraries_dict.items():
-                incoming_ids.add(str(external_id))
-                if external_id in existing_libs:
-                    lib = existing_libs[external_id]
-                    # Update mutable attributes while preserving primary key
-                    lib.name = name
-                    lib.enabled = True
-                    updated_count += 1
-                else:
-                    lib = Library(
-                        external_id=external_id,
-                        name=name,
-                        server_id=server.id,
-                        enabled=True,
-                    )
-                    db.session.add(lib)
-                    inserted_count += 1
-                total_scanned += 1
-
-            # Handle libraries that used to exist but weren't returned by the server
-            for ext, lib in existing_libs.items():
-                if ext not in incoming_ids:
-                    # If this library is referenced by any invitation, disable it to preserve associations
-                    referenced = db.session.execute(
-                        invite_libraries.select().where(
-                            invite_libraries.c.library_id == lib.id
-                        )
-                    ).first()
-                    if referenced:
-                        if lib.enabled:
-                            lib.enabled = False
-                            disabled_count += 1
-                    else:
-                        # Safe to remove since no invites reference it
-                        db.session.delete(lib)
-                        deleted_count += 1
-
+            scan_result, authoritative = scan_libraries_for_server(server)
+            upsert_scanned_libraries(server, scan_result, authoritative=authoritative)
             db.session.commit()
 
+            try:
+                scanned = len(scan_result)
+            except TypeError:
+                # Malformed result; upsert_scanned_libraries already no-opped.
+                scanned = 0
+            total_scanned += scanned
+
             if show_logs:
+                after = Library.query.filter_by(server_id=server.id).count()
                 logger.info(
-                    f"Refreshed {len(libraries_dict)} libraries for {server.name} "
-                    f"(existing={old_count}, updated={updated_count}, inserted={inserted_count}, "
-                    f"disabled={disabled_count}, deleted={deleted_count})"
+                    f"Refreshed {scanned} libraries for {server.name} "
+                    f"(rows {before} -> {after}, authoritative={authoritative})"
                 )
         except Exception as server_exc:
             # Rollback on error to keep session clean

--- a/tests/test_library_enabled_persistence.py
+++ b/tests/test_library_enabled_persistence.py
@@ -6,7 +6,7 @@ set for invites that carry none of their own. Library scans must therefore not
 reset it, and the legacy settings scan must not delete rows it does not own.
 """
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from app.models import AdminAccount, Library, MediaServer
 
@@ -291,3 +291,77 @@ def test_legacy_settings_scan_does_not_delete_other_servers_libraries(client, se
     # the unbound staging rows are still replaced, which is this route's job
     unbound = {lib.external_id for lib in Library.query.filter_by(server_id=None).all()}
     assert unbound == {"9"}
+
+
+# --- startup scan -----------------------------------------------------------
+# scan_all_server_libraries runs from create_app on every boot. It used to carry
+# its own copy of the upsert, which re-enabled every existing library it saw, so
+# a disabled library came back on the next restart. It now delegates to
+# upsert_scanned_libraries like the admin-triggered scans do.
+
+
+def _startup_scan(scan_result, authoritative=True):
+    """Drive the startup scan with a stubbed media client.
+
+    Patches the client factory rather than scan_libraries_for_server so the test
+    exercises whatever path the scanner takes internally, and fails on behaviour
+    rather than on which helper happens to be called.
+    """
+    from app.services.library_scanner import scan_all_server_libraries
+
+    client = Mock()
+    client.libraries.return_value = scan_result
+    client.libraries_scan_authoritative.return_value = authoritative
+
+    with patch(
+        "app.services.media.service.get_client_for_media_server",
+        return_value=client,
+    ):
+        return scan_all_server_libraries(show_logs=False)
+
+
+def test_startup_scan_preserves_disabled_libraries(session):
+    """A restart must not re-share a library the admin excluded."""
+    server = _server(session)
+    _libs(
+        session,
+        server,
+        {"1": ("Movies", True), "2": ("TV Shows", True), "3": ("Home Video", False)},
+    )
+
+    total, errors = _startup_scan(SCAN_RESULT)
+
+    assert errors == []
+    assert total == 3
+    assert _enabled_map(server.id) == {"1": True, "2": True, "3": False}
+
+
+def test_startup_scan_renames_without_re_enabling(session):
+    server = _server(session)
+    _libs(session, server, {"3": ("Old Name", False)})
+
+    _startup_scan({"3": "New Name"})
+
+    lib = Library.query.filter_by(external_id="3").one()
+    assert lib.name == "New Name"
+    assert lib.enabled is False
+
+
+def test_startup_scan_inserts_new_libraries_enabled(session):
+    server = _server(session)
+    _libs(session, server, {"1": ("Movies", True)})
+
+    _startup_scan(SCAN_RESULT)
+
+    assert _enabled_map(server.id) == {"1": True, "2": True, "3": True}
+
+
+def test_startup_scan_ignores_an_empty_result(session):
+    """An empty scan must not wipe the admin's defaults, as Plex can transiently
+    return no sections. The old inline upsert disabled or deleted everything."""
+    server = _server(session)
+    _libs(session, server, {"1": ("Movies", True), "3": ("Home Video", False)})
+
+    _startup_scan({})
+
+    assert _enabled_map(server.id) == {"1": True, "3": False}


### PR DESCRIPTION
## Problem

`scan_all_server_libraries` in `app/services/library_scanner.py` carries its own copy of the library upsert. #1355 consolidated the admin-triggered scans behind `upsert_scanned_libraries`, but this one was left behind, so the startup path still has the behaviour that PR removed everywhere else:

```python
if external_id in existing_libs:
    lib = existing_libs[external_id]
    lib.name = name
    lib.enabled = True   # <- clobbers the admin's saved default
```

That scan runs from `create_app` on every start, and `_invite_user` falls back to all enabled libraries for an invite that carries none of its own. So an admin who disabled a private library got it re-enabled on the next restart, and silently re-shared through the next invite. On my own server this meant personal photo and video libraries were back in the default invite scope every time the container restarted.

It is easy to miss because grepping for the fix lands on the correct shared helper, which documents that it preserves the flag. Only the startup path was wrong.

## Change

Delegate to `scan_libraries_for_server` and `upsert_scanned_libraries`. Beyond preserving `enabled`, this picks up two guards the inline copy never had:

- An empty scan no longer wipes everything. Plex's global-id source can transiently return no sections, and the inline version treated that as every library having been removed.
- The client's `libraries_scan_authoritative` flag is honoured, so removals are not reconciled from a scan that may be partial.

Return contract is unchanged. The log line now reports row counts before and after plus the authoritative flag.

## Tests

`tests/test_library_enabled_persistence.py` covered the invite modal, the server edit form and the legacy settings scan, but nothing reached the startup scan, which is why this survived. Four cases added there.

Against the previous implementation three of them fail. The fourth covers new libraries still arriving enabled, so it passes either way and keeps the fix from overreaching. The stub is applied at the client factory rather than at `scan_libraries_for_server`, so the tests assert behaviour rather than which helper gets called.

Full suite passes.

## Verification

Also verified on a live instance against a real Plex server with 12 libraries, 10 of them disabled: the flags now survive both a full container restart and an unmocked rescan.

```
Refreshed 12 libraries for Russ Plex (rows 12 -> 12, authoritative=True)
enabled: ['Movies', 'TV Shows']
disabled count: 10
```