### PR TITLE
Fix infinite re-exec loop when PUID/PGID=0

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -53,7 +53,9 @@ if [ "$(id -u)" = "0" ]; then
   fi
 
   # Re-exec as that user
-  exec su-exec "$TARGET_USER":"$TARGET_GRP" "$0" "$@"
+  if [ "$PUID:$PGID" != "0:0" ]; then
+    exec su-exec "$TARGET_USER":"$TARGET_GRP" "$0" "$@"
+  fi
 fi
 
 echo "[entrypoint] 👍 Running as $(id -un):$(id -gn) ($(id -u):$(id -g))"


### PR DESCRIPTION
I recently migrated my containers to Podman and found that Wizarr got stuck in a loop in the entrypoint script.

With a custom user namespace in Podman, UID 0 inside the container is mapped to an unprivileged UID on the host, so setting PUID=0/PGID=0 is a valid way to have files owned by a specific host UID. However, the entrypoint script's root-check assumes it should always re-exec via su-exec when running as UID 0. Since `su-exec 0:0 ...` is still UID 0, the next invocation hits the exact same branch, causing an infinite re-exec loop.

This PR adds a check to skip the re-exec when PUID:PGID is already 0:0, since there's nothing left to do in that case. This lets the script continue through to the end and start the program normally.

Note: this also fixes the same loop for anyone explicitly running the container as root outside of the namespace-mapping case (e.g. --user 0 in rootless Docker), since the underlying bug is the same regardless of why PUID=0 was set.