### PR TITLE
Fix both invite-flow poster strips resetting mid-loop

### DIFF
--- a/app/services/wizard_widgets.py
+++ b/app/services/wizard_widgets.py
@@ -50,63 +50,87 @@ class RecentlyAddedMediaWidget(WizardWidget):
     """Widget to show recently added media from the server."""
 
     def __init__(self):
+        # The strip loops by holding the item list twice and sliding exactly
+        # half its own width, so at the moment it resets the poster under every
+        # pixel is the one that was already there. That only holds when the two
+        # halves are identical in width, which is why the spacing is a right
+        # margin on every item rather than a gap on the track: a flex gap is
+        # drawn between items but not after the last one, so one half came out
+        # a gap narrower than the other and the reset jumped.
         template = """
-        <div class="media-carousel-widget my-6">
+        {%- macro poster(item) -%}
+        <div class="carousel-item">
+            {% if item.thumb %}
+            <img src="{{ item.thumb }}" alt="{{ item.title }}"
+                 decoding="async"
+                 class="w-full h-full object-cover rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300">
+            {% else %}
+            <div class="w-full h-full bg-gradient-to-br from-primary/20 to-primary/40 rounded-lg shadow-lg flex items-center justify-center">
+                <svg class="w-8 h-8 text-primary" fill="currentColor" viewBox="0 0 20 20">
+                    <path d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z"/>
+                </svg>
+            </div>
+            {% endif %}
+        </div>
+        {%- endmacro -%}
+        {# not-prose: the widget is injected into markdown that renders inside
+           .prose, whose img rule adds a ~2em vertical margin. That was harmless
+           while the poster sized itself, but the item needs a fixed height for
+           the two halves to match, and the margin pushed the poster down until
+           the strip clipped its bottom. #}
+        <div class="media-carousel-widget not-prose my-6">
             {% if items %}
-            <div class="carousel-container overflow-hidden relative">
-                <div class="carousel-track flex animate-scroll gap-3" style="width: {{ (items|length * 2) * 150 }}px;">
-                    {% for item in items %}
-                    <div class="carousel-item flex-shrink-0">
-                        {% if item.thumb %}
-                        <img src="{{ item.thumb }}" alt="{{ item.title }}"
-                             loading="lazy"
-                             decoding="async"
-                             class="w-32 h-48 object-cover rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300">
-                        {% else %}
-                        <div class="w-32 h-48 bg-gradient-to-br from-primary/20 to-primary/40 rounded-lg shadow-lg flex items-center justify-center">
-                            <svg class="w-8 h-8 text-primary" fill="currentColor" viewBox="0 0 20 20">
-                                <path d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z"/>
-                            </svg>
-                        </div>
-                        {% endif %}
-                    </div>
-                    {% endfor %}
-                    <!-- Duplicate items for seamless loop -->
-                    {% for item in items %}
-                    <div class="carousel-item flex-shrink-0">
-                        {% if item.thumb %}
-                        <img src="{{ item.thumb }}" alt="{{ item.title }}"
-                             loading="lazy"
-                             decoding="async"
-                             class="w-32 h-48 object-cover rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300">
-                        {% else %}
-                        <div class="w-32 h-48 bg-gradient-to-br from-primary/20 to-primary/40 rounded-lg shadow-lg flex items-center justify-center">
-                            <svg class="w-8 h-8 text-primary" fill="currentColor" viewBox="0 0 20 20">
-                                <path d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z"/>
-                            </svg>
-                        </div>
-                        {% endif %}
-                    </div>
-                    {% endfor %}
+            <div class="carousel-container">
+                <div class="carousel-track"
+                     style="animation-duration: {{ items|length * 3 }}s">
+                    {% for item in items %}{{ poster(item) }}{% endfor %}
+                    {# Second copy is what makes the reset invisible. #}
+                    {% for item in items %}{{ poster(item) }}{% endfor %}
                 </div>
             </div>
 
             <style>
-            @keyframes scroll {
-                0% {
-                    transform: translateX(0);
-                }
-                100% {
-                    transform: translateX(-50%);
-                }
+            .carousel-container {
+                position: relative;
+                overflow: hidden;
+                /* Fade the ends rather than cutting a poster off square. */
+                -webkit-mask-image: linear-gradient(to right, transparent, #000 3rem, #000 calc(100% - 3rem), transparent);
+                mask-image: linear-gradient(to right, transparent, #000 3rem, #000 calc(100% - 3rem), transparent);
             }
 
-            .animate-scroll {
-                animation: scroll 30s linear infinite;
+            .carousel-track {
+                display: flex;
+                width: max-content;
+                animation-name: carousel-scroll;
+                animation-timing-function: linear;
+                animation-iteration-count: infinite;
             }
 
-            .carousel-container:hover .animate-scroll {
+            .carousel-item {
+                flex: 0 0 auto;
+                width: 8rem;            /* 128px */
+                height: 12rem;          /* 2:3, a poster's own aspect ratio */
+                margin-right: 0.75rem;  /* on every item, including the last */
+            }
+
+            .carousel-item > img,
+            .carousel-item > div {
+                margin: 0;
+                display: block;
+            }
+
+            @keyframes carousel-scroll {
+                from { transform: translateX(0); }
+                to   { transform: translateX(-50%); }
+            }
+
+            .carousel-container:hover .carousel-track {
                 animation-play-state: paused;
+            }
+
+            @media (prefers-reduced-motion: reduce) {
+                .carousel-track { animation: none; }
+                .carousel-container { overflow-x: auto; }
             }
             </style>
             {% else %}

--- a/app/templates/user-plex-login.html
+++ b/app/templates/user-plex-login.html
@@ -12,25 +12,10 @@
   <section class="min-h-screen bg-gradient-to-br from-slate-900 via-orange-900 to-slate-900 relative overflow-hidden">
     <!-- Cinema Background Layer -->
     <div class="absolute inset-0 overflow-hidden">
-      <!-- Flowing Movie Poster Grid -->
-      <div class="poster-grid-container">
-        <!-- First row flowing left -->
-        <div class="poster-row poster-row-1" data-direction="left">
-          <!-- Posters will be dynamically added here -->
-        </div>
-        <!-- Second row flowing right -->
-        <div class="poster-row poster-row-2" data-direction="right">
-          <!-- Posters will be dynamically added here -->
-        </div>
-        <!-- Third row flowing left -->
-        <div class="poster-row poster-row-3" data-direction="left">
-          <!-- Posters will be dynamically added here -->
-        </div>
-        <!-- Fourth row flowing right -->
-        <div class="poster-row poster-row-4" data-direction="right">
-          <!-- Posters will be dynamically added here -->
-        </div>
-      </div>
+      <!-- Flowing Movie Poster Grid. Rows are built by the script at the foot
+           of this template: how many rows fit, and how many posters each needs
+           to cover the viewport without a gap, both depend on the window size. -->
+      <div class="poster-grid-container"></div>
     </div>
     <!-- Overlay gradient to ensure readability -->
     <div class="absolute inset-0 bg-gradient-to-br from-slate-900/80 via-orange-900/60 to-slate-900/80"></div>
@@ -149,57 +134,45 @@
           opacity: 0.15;
       }
 
-      /* Poster rows */
+      /* Poster rows. Width comes from the content, and the script gives each
+         row a top, a direction and a duration - see loadCinemaPosters. */
       .poster-row {
           position: absolute;
-          height: 180px;
-          width: 300%;
+          left: 0;
           display: flex;
-          gap: 20px;
           align-items: center;
+          width: max-content;
           pointer-events: none;
+          will-change: transform;
+          animation-name: flow-left;
+          animation-timing-function: linear;
+          animation-iteration-count: infinite;
       }
 
-      .poster-row-1 {
-          top: 10%;
-          animation: flow-left 60s linear infinite;
+      .poster-row[data-direction="right"] {
+          animation-name: flow-right;
       }
 
-      .poster-row-2 {
-          top: 30%;
-          animation: flow-right 50s linear infinite;
-          animation-delay: -10s;
-      }
-
-      .poster-row-3 {
-          top: 50%;
-          animation: flow-left 55s linear infinite;
-          animation-delay: -20s;
-      }
-
-      .poster-row-4 {
-          top: 70%;
-          animation: flow-right 65s linear infinite;
-          animation-delay: -30s;
-      }
-
-      /* Flow animations */
+      /* Each row holds two identical halves and travels exactly half its own
+         width, so the reset is invisible. A trailing margin on every poster
+         (rather than a flex gap, which is omitted after the last child) is what
+         keeps the two halves the same width. */
       @keyframes flow-left {
-          0% {
+          from {
               transform: translateX(0);
           }
 
-          100% {
-              transform: translateX(-66.67%);
+          to {
+              transform: translateX(-50%);
           }
       }
 
       @keyframes flow-right {
-          0% {
-              transform: translateX(-66.67%);
+          from {
+              transform: translateX(-50%);
           }
 
-          100% {
+          to {
               transform: translateX(0);
           }
       }
@@ -208,6 +181,7 @@
       .poster-item {
           width: 120px;
           height: 160px;
+          margin-right: 20px;
           border-radius: 8px;
           flex-shrink: 0;
           background: linear-gradient(135deg, #92400e 0%, #451a03 100%);
@@ -263,130 +237,177 @@
 
       /* Responsive adjustments */
       @media (max-width: 768px) {
-          .poster-row {
-              height: 120px;
-          }
-
           .poster-item {
               width: 80px;
               height: 110px;
+              margin-right: 14px;
           }
 
           .poster-grid-container {
               opacity: 0.1;
           }
       }
+
+      @media (prefers-reduced-motion: reduce) {
+          .poster-row,
+          .animate-blob {
+              animation: none;
+          }
+      }
   </style>
   <script src="{{ url_for('static', filename='js/vendor/bowser.min.js', v=app_version) }}"></script> <!-- needed for plexHeaders -->
   <script>
-      // Load movie posters for flowing grid background with progressive loading
+      // Flowing poster background.
+      //
+      // Rows are sized from the viewport rather than declared in CSS. A row
+      // needs at least a viewport's worth of posters to cover the screen, and
+      // it needs that run twice so it can slide exactly half its own width and
+      // land back where it started. Both numbers depend on the window, so the
+      // browser is the only thing that can work them out.
+      const CINEMA_SPEED_PX_PER_SEC = 18;   // slow drift; this is background
+      const CINEMA_ROW_GAP_PX = 40;         // vertical breathing room
+      const CINEMA_MIN_ROWS = 3;
+      const CINEMA_MAX_ROWS = 7;
+      const CINEMA_REBUILD_DEBOUNCE_MS = 250;
+
+      let cinemaPosters = [];
+      let cinemaRebuildTimer = null;
+      let cinemaLastWidth = 0;
+      let cinemaLastHeight = 0;
+
+      // Read the poster size back out of CSS so the two cannot drift apart
+      // (the mobile breakpoint changes it).
+      function cinemaTileMetrics(grid) {
+          const probe = document.createElement('div');
+          probe.className = 'poster-item';
+          probe.style.visibility = 'hidden';
+          grid.appendChild(probe);
+          const style = window.getComputedStyle(probe);
+          const metrics = {
+              width: parseFloat(style.width) || 120,
+              height: parseFloat(style.height) || 160,
+              margin: parseFloat(style.marginRight) || 20,
+          };
+          grid.removeChild(probe);
+          return metrics;
+      }
+
+      function cinemaShuffled(list) {
+          const out = list.slice();
+          for (let i = out.length - 1; i > 0; i--) {
+              const j = Math.floor(Math.random() * (i + 1));
+              [out[i], out[j]] = [out[j], out[i]];
+          }
+          return out;
+      }
+
+      function cinemaTile(url) {
+          const tile = document.createElement('div');
+          tile.className = 'poster-item';
+          if (url) {
+              // Decode off the main thread, then swap in. A failure just leaves
+              // the placeholder gradient, which is a fine poster shape.
+              const img = new Image();
+              img.decoding = 'async';
+              img.onload = () => {
+                  tile.style.backgroundImage = `url('${url}')`;
+                  tile.classList.add('loaded');
+              };
+              img.src = url;
+          }
+          return tile;
+      }
+
+      function cinemaBuildRow(index, rowCount, metrics, viewport) {
+          const stride = metrics.width + metrics.margin;
+          // +2 so the row still overhangs both edges at the ends of the slide.
+          const perHalf = Math.ceil(viewport.width / stride) + 2;
+
+          const row = document.createElement('div');
+          row.className = 'poster-row';
+          row.dataset.direction = index % 2 === 0 ? 'left' : 'right';
+
+          const rowStride = viewport.height / rowCount;
+          row.style.top = Math.round(index * rowStride + (rowStride - metrics.height) / 2) + 'px';
+
+          // Each row takes its own window into the poster list so the rows do
+          // not mirror one another. Wrapping only happens when the server
+          // returned fewer posters than the screen can hold.
+          const urls = [];
+          for (let i = 0; i < perHalf; i++) {
+              urls.push(cinemaPosters.length ? cinemaPosters[(index * perHalf + i) % cinemaPosters.length] : null);
+          }
+
+          const half = document.createDocumentFragment();
+          urls.forEach(url => half.appendChild(cinemaTile(url)));
+          row.appendChild(half);
+          // Second, identical half: this is what makes translateX(-50%) loop
+          // without a seam.
+          urls.forEach(url => row.appendChild(cinemaTile(url)));
+
+          const halfWidth = perHalf * stride;
+          row.style.animationDuration = (halfWidth / CINEMA_SPEED_PX_PER_SEC).toFixed(2) + 's';
+          // Desynchronise the rows rather than waiting for them to drift apart.
+          row.style.animationDelay = '-' + (index * 7) + 's';
+
+          return row;
+      }
+
+      function cinemaBuild() {
+          const grid = document.querySelector('.poster-grid-container');
+          if (!grid) return;
+
+          const viewport = {
+              width: window.innerWidth || document.documentElement.clientWidth,
+              height: window.innerHeight || document.documentElement.clientHeight,
+          };
+          cinemaLastWidth = viewport.width;
+          cinemaLastHeight = viewport.height;
+
+          grid.textContent = '';
+          const metrics = cinemaTileMetrics(grid);
+
+          let rowCount = Math.round(viewport.height / (metrics.height + CINEMA_ROW_GAP_PX));
+          rowCount = Math.max(CINEMA_MIN_ROWS, Math.min(CINEMA_MAX_ROWS, rowCount));
+
+          const fragment = document.createDocumentFragment();
+          for (let i = 0; i < rowCount; i++) {
+              fragment.appendChild(cinemaBuildRow(i, rowCount, metrics, viewport));
+          }
+          grid.appendChild(fragment);
+      }
+
+      function cinemaScheduleRebuild() {
+          // Ignore the height changes phones fire as the address bar hides;
+          // only a real layout change is worth rebuilding for.
+          const width = window.innerWidth || document.documentElement.clientWidth;
+          const height = window.innerHeight || document.documentElement.clientHeight;
+          if (width === cinemaLastWidth && Math.abs(height - cinemaLastHeight) < 120) return;
+
+          window.clearTimeout(cinemaRebuildTimer);
+          cinemaRebuildTimer = window.setTimeout(cinemaBuild, CINEMA_REBUILD_DEBOUNCE_MS);
+      }
+
       async function loadCinemaPosters() {
+          if (!document.querySelector('.poster-grid-container')) return;
+
+          // Draw placeholder tiles straight away so the background is never
+          // empty, then upgrade them in place once the poster list arrives.
+          cinemaBuild();
+
           try {
               const response = await fetch('/cinema-posters');
-              const posterUrls = await response.json();
-
-              if (posterUrls && posterUrls.length > 0) {
-                  const posterRows = document.querySelectorAll('.poster-row');
-                  let loadQueue = [];
-
-                  // Populate each row with posters - ensure seamless repetition
-                  posterRows.forEach((row, rowIndex) => {
-                      // Reduced from 25 to 20 posters per row for better performance
-                      const postersPerRow = 20;
-
-                      // Create a subset of posters for this row to avoid having all rows identical
-                      const startOffset = Math.floor(rowIndex * posterUrls.length / 4);
-                      const rowPosters = [];
-
-                      // Fill row posters array by cycling through available posters
-                      for (let i = 0; i < postersPerRow; i++) {
-                          const posterIndex = (startOffset + i) % posterUrls.length;
-                          rowPosters.push(posterUrls[posterIndex]);
-                      }
-
-                      // Create poster elements immediately but load images progressively
-                      rowPosters.forEach((posterUrl, index) => {
-                          const posterItem = document.createElement('div');
-                          posterItem.className = 'poster-item';
-                          row.appendChild(posterItem);
-
-                          // Add to load queue with priority (visible items first)
-                          loadQueue.push({
-                              element: posterItem,
-                              url: posterUrl,
-                              priority: rowIndex < 2 ? 1 : 2 // Top 2 rows get priority
-                          });
-                      });
-                  });
-
-                  // Progressive loading with batching
-                  await loadPostersInBatches(loadQueue);
-
-              } else {
-                  createPlaceholderPosters();
+              const posterUrls = response.ok ? await response.json() : [];
+              if (Array.isArray(posterUrls) && posterUrls.length) {
+                  cinemaPosters = cinemaShuffled(posterUrls);
+                  cinemaBuild();
               }
           } catch (error) {
               console.warn('Failed to load cinema posters:', error);
-              createPlaceholderPosters();
           }
-      }
 
-      // Load posters in batches to avoid overwhelming the browser
-      async function loadPostersInBatches(loadQueue) {
-          // Sort by priority (visible items first)
-          loadQueue.sort((a, b) => a.priority - b.priority);
-
-          const batchSize = 8; // Load 8 images at a time
-          const delay = 100; // 100ms delay between batches
-
-          for (let i = 0; i < loadQueue.length; i += batchSize) {
-              const batch = loadQueue.slice(i, i + batchSize);
-
-              // Load batch concurrently
-              const promises = batch.map(item => loadPosterImage(item.element, item.url));
-              await Promise.allSettled(promises);
-
-              // Small delay before next batch
-              if (i + batchSize < loadQueue.length) {
-                  await new Promise(resolve => setTimeout(resolve, delay));
-              }
-          }
-      }
-
-      // Load individual poster with timeout
-      function loadPosterImage(element, url) {
-          return new Promise((resolve) => {
-              const img = new Image();
-              const timeout = setTimeout(() => {
-                  resolve(); // Resolve anyway to continue with other images
-              }, 2000); // 2s timeout per image
-
-              img.onload = () => {
-                  clearTimeout(timeout);
-                  element.style.backgroundImage = `url('${url}')`;
-                  element.classList.add('loaded');
-                  resolve();
-              };
-
-              img.onerror = () => {
-                  clearTimeout(timeout);
-                  resolve(); // Keep default gradient background
-              };
-
-              img.src = url;
-          });
-      }
-
-      // Create placeholder posters fallback
-      function createPlaceholderPosters() {
-          const posterRows = document.querySelectorAll('.poster-row');
-          posterRows.forEach(row => {
-              for (let i = 0; i < 20; i++) { // Reduced from 25 to 20
-                  const posterItem = document.createElement('div');
-                  posterItem.className = 'poster-item';
-                  row.appendChild(posterItem);
-              }
-          });
+          window.addEventListener('resize', cinemaScheduleRebuild);
+          window.addEventListener('orientationchange', cinemaScheduleRebuild);
       }
 
       // Load posters when page loads


### PR DESCRIPTION
Both poster strips on the invite flow reset visibly every cycle, and the one behind the join page runs out of posters partway across the screen. Same root cause in both: a strip that loops by holding its content twice and sliding half its width, where the two halves are not the same width.

## Carousel (`recently_added_media` widget)

The spacing is a flex `gap` on the track. A gap is drawn between items but not after the last one, so the first half is 12px narrower than the second. The track also declares `width: (n*2)*150px` while the items measure 128px plus a 12px gap, overshooting the real content by 10px per item. Either alone puts the 50% mark somewhere other than a tile boundary.

Spacing becomes a right margin carried by every item, and the track takes its width from its content.

Two consequences of the item needing a fixed size for that to hold:

- the widget is marked `not-prose`. It renders inside `.prose`, whose `img` rule adds a ~2em vertical margin, which now pushes the poster down until the strip clips its bottom.
- `loading="lazy"` is dropped. The strip is clipped by `overflow: hidden` and moved by transform, so tiles past the first screenful were never counted as intersecting and scrolled in blank.

Also: duration proportional to item count, so a 6-poster step and a 40-poster step scroll at the same speed; masked ends so a poster fades rather than being cut square; and the item markup moves into a macro, since the duplicated copy had already drifted (its fallback icon carries a malformed path).

## Background (`user-plex-login.html`)

Rows are `width: 300%` and travel `66.67%` of that per loop, but are filled with a hard-coded 20 posters. Those numbers are unrelated, and the posters run out long before the row does. Measured on `main`, 20 posters at 120px plus a 20px gap:

| viewport | row width | travels | posters hold | short by | lowest row ends |
|---|---|---|---|---|---|
| 1920x1080 | 5760px | 3840px | 2780px | 1060px | 936px of 1080 |
| 3440x1440 | 10320px | 6880px | 2780px | 4100px | 1188px of 1440 |

So the animation drags a band of bare background across the screen and then jumps. The two rows starting at `-66.67%` are worse: at 3440 that offset is -6880px against 2780px of content, so they are off-screen entirely for part of the cycle. The four rows are also pinned at 10/30/50/70%, leaving the bottom of the window empty.

Rows are now built from the viewport: enough rows to fill the height, each holding two identical runs of `ceil(viewport / stride) + 2` posters. Half of that is seamless by construction, and the duration is derived from the width so every row drifts at one speed. Rows rebuild on a debounced resize, ignoring the height-only changes phones fire as the address bar hides. Each row takes its own window into the poster list and the list is shuffled, so titles do not line up across rows or recur identically on every visit. `prefers-reduced-motion` is honoured.

## Verification

Measured in Chromium at 1920x1080, 3440x1440 and 390x844, with the carousel at 3, 12 and 40 items. For each: half the track lands exactly on a tile boundary, every background row covers at least the viewport width, the two halves of each row hold the same posters, the lowest row reaches the bottom of the screen, no console errors, and the frame at `currentTime = 0` is pixel-identical to the frame one full duration later. That last check fails on `main` and passes here.

`ruff`, `djlint` and the test suite (584 passed, 1 skipped) are clean.

Not included, happy to raise separately if useful: artwork is fetched at full resolution (a Plex poster is ~750KB, so 80 of them is a ~60MB page that overflows `ImageProxyService`'s own 20MB cache), and `/cinema-posters` sweeps every movie-type section, which on Plex includes Other Videos libraries.
