### PR TITLE
fix: don't log AUTH FAIL for HEAD requests to /login

### DIFF
--- a/app/blueprints/auth/routes.py
+++ b/app/blueprints/auth/routes.py
@@ -29,7 +29,7 @@ def login():
     )
     media_server_url = request.cookies.get("wizarr_media_server_url")
 
-    if request.method == "GET":
+    if request.method in ("GET", "HEAD"):
         return render_template(
             "login.html",
             has_passkeys=has_passkeys,

--- a/tests/test_admin_accounts.py
+++ b/tests/test_admin_accounts.py
@@ -28,3 +28,10 @@ def test_admin_login(client, app):
     # Should redirect to / on success (302 Found)
     assert resp.status_code in {302, 303}
     assert resp.headers["Location"].endswith("/")
+
+
+def test_head_login_does_not_log_auth_fail(client, caplog):
+    """HEAD /login (used by uptime checks) must not be treated as a failed login attempt."""
+    resp = client.head("/login")
+    assert resp.status_code == 200
+    assert "AUTH FAIL" not in caplog.text


### PR DESCRIPTION
Fixes #1373.

HEAD /login falls through to the credential-check branch (Werkzeug keeps `request.method == "HEAD"`, doesn't rewrite to GET), logging a false `AUTH FAIL` for every uptime/status check that pings the login page.

Fix: treat HEAD like GET. Added a regression test (fails without the fix, passes with it). Full suite run locally, no new failures.