### PR TITLE
fix(connections): make Overseerr/Jellyseerr info-only connection creatable

### DIFF
--- a/app/templates/modals/connection-form.html
+++ b/app/templates/modals/connection-form.html
@@ -44,8 +44,8 @@
         </div>
         <!-- Connection Name -->
         <div>
-          {{ form.name.label(class="block mb-2 text-sm font-medium " + ("text-gray-500 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "text-gray-900 dark:text-white") ) }}
-          {{ form.name(class="text-sm rounded-lg block w-full p-2.5 " + ("bg-gray-100 border-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") , disabled=(form.connection_type.data == 'overseerr')) }}
+          {{ form.name.label(class="block mb-2 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.name(class="text-sm rounded-lg block w-full p-2.5 bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") }}
           {% if form.name.errors %}
             <div class="mt-1 text-sm text-red-600 dark:text-red-400">
               {% for error in form.name.errors %}<p>{{ error }}</p>{% endfor %}
@@ -54,8 +54,8 @@
         </div>
         <!-- Media Server -->
         <div>
-          {{ form.media_server_id.label(class="block mb-2 text-sm font-medium " + ("text-gray-500 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "text-gray-900 dark:text-white") ) }}
-          {{ form.media_server_id(class="text-sm rounded-lg block w-full p-2.5 " + ("bg-gray-100 border-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") , disabled=(form.connection_type.data == 'overseerr')) }}
+          {{ form.media_server_id.label(class="block mb-2 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.media_server_id(class="text-sm rounded-lg block w-full p-2.5 bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-600 dark:border-gray-500 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") }}
           {% if form.media_server_id.errors %}
             <div class="mt-1 text-sm text-red-600 dark:text-red-400">
               {% for error in form.media_server_id.errors %}<p>{{ error }}</p>{% endfor %}

--- a/app/templates/settings/connections/form.html
+++ b/app/templates/settings/connections/form.html
@@ -89,8 +89,8 @@
             </div>
             <!-- Connection Name -->
             <div>
-              {{ form.name.label(class="block mb-2 text-sm font-medium " + ("text-gray-500" if form.connection_type.data == 'overseerr' else "text-gray-900 dark:text-white") ) }}
-              {{ form.name(class="text-sm rounded-lg block w-full p-2.5 " + ("bg-gray-100 border-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") , disabled=(form.connection_type.data == 'overseerr')) }}
+              {{ form.name.label(class="block mb-2 text-sm font-medium text-gray-900 dark:text-white") }}
+              {{ form.name(class="text-sm rounded-lg block w-full p-2.5 bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") }}
               {% if form.name.errors %}
                 <div class="mt-1 text-sm text-red-600 dark:text-red-400">
                   {% for error in form.name.errors %}<p>{{ error }}</p>{% endfor %}
@@ -100,8 +100,8 @@
             </div>
             <!-- Media Server -->
             <div>
-              {{ form.media_server_id.label(class="block mb-2 text-sm font-medium " + ("text-gray-500" if form.connection_type.data == 'overseerr' else "text-gray-900 dark:text-white") ) }}
-              {{ form.media_server_id(class="text-sm rounded-lg block w-full p-2.5 " + ("bg-gray-100 border-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400" if form.connection_type.data == 'overseerr' else "bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") , disabled=(form.connection_type.data == 'overseerr')) }}
+              {{ form.media_server_id.label(class="block mb-2 text-sm font-medium text-gray-900 dark:text-white") }}
+              {{ form.media_server_id(class="text-sm rounded-lg block w-full p-2.5 bg-gray-50 border border-gray-300 text-gray-900 focus:ring-primary focus:border-primary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary") }}
               {% if form.media_server_id.errors %}
                 <div class="mt-1 text-sm text-red-600 dark:text-red-400">
                   {% for error in form.media_server_id.errors %}<p>{{ error }}</p>{% endfor %}

--- a/tests/test_connections_overseerr_form.py
+++ b/tests/test_connections_overseerr_form.py
@@ -1,0 +1,88 @@
+"""Regression tests for wizarrrr/wizarr#1343.
+
+The Overseerr/Jellyseerr (Info Only) connection type rendered the required
+``name`` and ``media_server_id`` fields as ``disabled``. Disabled inputs are not
+submitted by browsers, so ``ConnectionForm`` never validated and the connection
+could not be created through the UI.
+"""
+
+import re
+
+import pytest
+
+from app.extensions import db
+from app.models import AdminAccount, Connection, MediaServer
+
+
+@pytest.fixture
+def admin_client(client, app):
+    """A test client logged in as an admin account."""
+    with app.app_context():
+        if AdminAccount.query.filter_by(username="conn-admin").first() is None:
+            acc = AdminAccount(username="conn-admin")
+            acc.set_password("Password1")
+            db.session.add(acc)
+            db.session.commit()
+    resp = client.post(
+        "/login", data={"username": "conn-admin", "password": "Password1"}
+    )
+    assert resp.status_code in {302, 303}
+    return client
+
+
+@pytest.fixture
+def media_server(app):
+    with app.app_context():
+        server = MediaServer(
+            name="Jellyfin",
+            server_type="jellyfin",
+            url="http://jellyfin:8096",
+            api_key="test-key",
+        )
+        db.session.add(server)
+        db.session.commit()
+        return server.id
+
+
+def _field_tag(html: str, tag: str, name: str) -> str:
+    match = re.search(rf"<{tag}\b[^>]*\bname=\"{name}\"[^>]*>", html)
+    assert match is not None, f"<{tag} name={name!r}> not rendered"
+    return match.group(0)
+
+
+@pytest.mark.parametrize("htmx", [False, True], ids=["page", "modal"])
+def test_overseerr_form_required_fields_are_not_disabled(
+    admin_client, media_server, htmx
+):
+    """Both connection form templates must keep name/media_server_id submittable."""
+    headers = {"HX-Request": "true"} if htmx else {}
+    resp = admin_client.get(
+        "/settings/connections/create?connection_type=overseerr", headers=headers
+    )
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "disabled" not in _field_tag(html, "input", "name")
+    assert "disabled" not in _field_tag(html, "select", "media_server_id")
+
+
+def test_create_overseerr_connection_persists(admin_client, media_server, app):
+    """Submitting the info-only form with its required fields creates the row."""
+    resp = admin_client.post(
+        "/settings/connections/create",
+        data={
+            "connection_type": "overseerr",
+            "name": "Jellyseerr",
+            "media_server_id": str(media_server),
+            "url": "https://jellyseerr.example.com",
+            "api_key": "",
+        },
+    )
+    assert resp.status_code in {200, 302, 303}
+
+    with app.app_context():
+        conn = Connection.query.filter_by(name="Jellyseerr").first()
+        assert conn is not None
+        assert conn.connection_type == "overseerr"
+        assert conn.media_server_id == media_server
+        assert conn.url == "https://jellyseerr.example.com"


### PR DESCRIPTION
## Summary

Creating an **Overseerr/Jellyseerr (Info Only)** connection from the UI never persisted anything (#1343).

Both connection form templates rendered the required `Connection Name` and `Media Server` fields with `disabled=...` when the connection type was `overseerr`. Browsers don't submit disabled inputs, so `ConnectionForm`'s `DataRequired` validators failed and `create_connection()` re-rendered the form with HTTP 200 and no visible error.

## Fix

- Render `name` and `media_server_id` normally for every connection type in `modals/connection-form.html` and `settings/connections/form.html`. The info-only type keeps its existing behaviour otherwise: URL and API key stay optional, the Test Connection button stays hidden, and the info panel still explains that no API connection is needed.

## Tests

- `tests/test_connections_overseerr_form.py`:
  - the rendered `<input name="name">` and `<select name="media_server_id">` carry no `disabled` attribute, for both the full page and the HTMX modal (fails before this change, passes after);
  - `POST /settings/connections/create` with `connection_type=overseerr` persists a `Connection` row.
- Full suite (`pytest tests --ignore=tests/e2e`): 588 tests, 0 failures, 1 pre-existing skip (`test_migrations.py:229`).

Fixes #1343
