### PR TITLE
feat(wizard): gate wizard steps on an external API check

### DIFF
--- a/app/blueprints/wizard/routes.py
+++ b/app/blueprints/wizard/routes.py
@@ -1,4 +1,6 @@
+import math
 from pathlib import Path
+from types import SimpleNamespace
 
 import frontmatter
 import markdown
@@ -23,12 +25,16 @@ from app.models import (
     Invitation,
     MediaServer,
     Settings,
+    User,
     WizardBundle,
     WizardBundleStep,
     WizardStep,
 )
 from app.services.invite_code_manager import InviteCodeManager
 from app.services.ombi_client import run_all_importers
+from app.services.wizard_api_check import gate
+from app.services.wizard_api_check.client import run_check
+from app.services.wizard_api_check.config import normalize, public_view
 
 wizard_bp = Blueprint("wizard", __name__, url_prefix="/wizard")
 BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent / "wizard_steps"
@@ -51,6 +57,12 @@ def restrict_wizard():
     # Skip further checks if the ACL feature is disabled
     if not acl_enabled:
         return None  # Allow everyone
+
+    # The gate poll endpoint does its own access control (session/current_user
+    # checks that always resolve to a card, never a redirect) - an HTMX 302
+    # here would swap the homepage into the status card.
+    if request.endpoint == "wizard.api_check":
+        return None
 
     # Enforce ACL: allow only authenticated users or invited sessions
     if current_user.is_authenticated:
@@ -223,12 +235,14 @@ def _steps(server: str, _cfg: dict, category: str = "post_invite"):
             used by helper functions: `.content` property and `.get()`.
             """
 
-            __slots__ = ("_require", "content")
+            __slots__ = ("_require", "api_check", "content", "step_id")
 
             def __init__(self, row: "WizardStep"):
                 self.content = row.markdown
                 # Mirror frontmatter key `require` from DB boolean
                 self._require = bool(getattr(row, "require_interaction", False))
+                self.step_id = row.id
+                self.api_check = normalize(row.api_check, category=row.category)
 
             def get(self, key, default=None):
                 if key == "require":
@@ -285,6 +299,8 @@ def _render(post, ctx: dict, server_type: str | None = None) -> str:
     Requirement 13.6: Graceful degradation for missing/broken steps.
     """
     from app.services.wizard_widgets import (
+        API_CHECK_PLACEHOLDER_RE,
+        WIDGET_REGISTRY,
         process_card_delimiters,
         process_widget_placeholders,
     )
@@ -308,9 +324,29 @@ def _render(post, ctx: dict, server_type: str | None = None) -> str:
         # This prevents Jinja from trying to parse {{ widget:... }} syntax
         content_with_widgets = content_with_cards
         if server_type:
+            # Kept separate from render_ctx: the gate config/step id must never
+            # reach the markdown template itself (an admin's own {{ }} could
+            # print it), only the widget that already knows how to redact it.
+            step_api_check = getattr(post, "api_check", None) or None
+            widget_ctx = render_ctx | {
+                "wizard_step_id": getattr(post, "step_id", None),
+                "wizard_api_check": public_view(step_api_check),
+                "wizard_gate_passed": gate.has_passed(getattr(post, "step_id", None)),
+            }
             content_with_widgets = process_widget_placeholders(
-                content_with_cards, server_type, context=render_ctx
+                content_with_cards, server_type, context=widget_ctx
             )
+
+            # An admin who enables the gate but forgets the placeholder would
+            # otherwise hard-block users with no UI and no way out.
+            if (
+                step_api_check is not None
+                and step_api_check.is_active
+                and not API_CHECK_PLACEHOLDER_RE.search(content_with_cards)
+            ):
+                content_with_widgets += WIDGET_REGISTRY["api_check"].render(
+                    server_type, _context=widget_ctx
+                )
 
         # THEN: Render Jinja templates in the processed content
         env = current_app.jinja_env.overlay(autoescape=False)
@@ -368,6 +404,10 @@ def _serve_wizard(
     direction = request.values.get("dir", "")
 
     idx = max(0, min(idx, len(steps) - 1))
+    locked = gate.first_locked_index(steps, exempt=current_user.is_authenticated)
+    if locked is not None and idx > locked:
+        idx = locked
+    gate_locked = locked is not None and locked == idx
     post = steps[idx]
 
     # Merge server-specific context (external_url, server_url, etc.) into config
@@ -419,6 +459,7 @@ def _serve_wizard(
         gradient_start=colors["gradient_start"],
         gradient_end=colors["gradient_end"],
         shadow_color=colors["shadow_color"],
+        gate_locked=gate_locked,
     )
 
     # Add custom headers for client-side updates (HTMX requests only)
@@ -431,6 +472,7 @@ def _serve_wizard(
             "true" if require_interaction else "false"
         )
         resp.headers["X-Wizard-Step-Phase"] = display_phase or ""
+        resp.headers["X-Wizard-Gate-Locked"] = "true" if gate_locked else "false"
         return resp
 
     return response
@@ -520,6 +562,150 @@ def _get_server_colors(server_type: str | None) -> dict[str, str]:
         server_type,
         color_schemes["plex"],
     )
+
+
+# ─── api_check gate helpers ────────────────────────────────────
+def _current_post_invite_step_ids() -> set[int] | None:
+    """Post-invite step ids the current session's flow may poll.
+
+    ``None`` means unrestricted, reserved for an authenticated admin with no
+    active invitation (so bundle/step previews still work). Everyone else gets
+    a concrete set, scoped to their bundle or their invitation's servers, so a
+    forged step id from another flow can never trigger an upstream call.
+    """
+    bundle_id = session.get("wizard_bundle_id")
+    if bundle_id:
+        try:
+            assocs = (
+                WizardBundleStep.query.filter_by(bundle_id=bundle_id)
+                .options(joinedload(WizardBundleStep.step))
+                .all()
+            )
+        except Exception as e:
+            current_app.logger.error(
+                f"Error resolving bundle steps for gate membership {bundle_id}: {e}",
+                exc_info=True,
+            )
+            return set()
+        return {
+            a.step_id for a in assocs if a.step and a.step.category == "post_invite"
+        }
+
+    code = session.get("wizard_access")
+    if code:
+        try:
+            invitation = Invitation.query.filter_by(code=code).first()
+        except Exception as e:
+            current_app.logger.error(
+                f"Error resolving invitation for gate membership: {e}", exc_info=True
+            )
+            invitation = None
+
+        server_types: set[str] = set()
+        if invitation:
+            servers = (
+                list(invitation.servers)
+                if invitation.servers
+                else ([invitation.server] if invitation.server else [])
+            )
+            server_types = {s.server_type for s in servers if s}
+
+        if not server_types:
+            return set()
+
+        rows = WizardStep.query.filter(
+            WizardStep.server_type.in_(server_types),
+            WizardStep.category == "post_invite",
+        ).all()
+        return {row.id for row in rows}
+
+    if current_user.is_authenticated:
+        return None
+
+    return set()
+
+
+def _gate_identity(server_type: str | None) -> tuple[str, str, str]:
+    """Resolve (code, username, email) to send to an api_check upstream."""
+    code = session.get("wizard_access") or ""
+    user = None
+    if code:
+        try:
+            candidates = User.query.filter_by(code=code).order_by(User.id).all()
+        except Exception as e:
+            current_app.logger.error(
+                f"Error resolving gate identity for code {code}: {e}", exc_info=True
+            )
+            candidates = []
+        user = next(
+            (u for u in candidates if u.server and u.server.server_type == server_type),
+            candidates[0] if candidates else None,
+        )
+    username = user.username if user else ""
+    email = (user.email or "") if user else ""
+    return code, username, email
+
+
+def _post_invite_gate_steps(cfg: dict) -> list:
+    """Rebuild the post-invite step order the current session can reach.
+
+    Used only by ``complete`` to find the first unsatisfied gate before the
+    wizard finishes - mirrors how post_wizard/combo/bundle_view resolve steps,
+    but returns plain objects carrying just what ``gate.first_locked_index``
+    needs.
+    """
+    bundle_id = session.get("wizard_bundle_id")
+    if bundle_id:
+        try:
+            assocs = (
+                WizardBundleStep.query.filter_by(bundle_id=bundle_id)
+                .options(joinedload(WizardBundleStep.step))
+                .order_by(WizardBundleStep.position)
+                .all()
+            )
+        except Exception as e:
+            current_app.logger.error(
+                f"Error loading bundle steps for gate check {bundle_id}: {e}",
+                exc_info=True,
+            )
+            return []
+        return [
+            SimpleNamespace(
+                step_id=a.step.id,
+                api_check=normalize(a.step.api_check, category=a.step.category),
+            )
+            for a in assocs
+            if a.step and a.step.category == "post_invite"
+        ]
+
+    inv_code = session.get("wizard_access")
+    if not inv_code:
+        return []
+
+    try:
+        invitation = Invitation.query.filter_by(code=inv_code).first()
+    except Exception as e:
+        current_app.logger.error(
+            f"Error loading invitation for gate check {inv_code}: {e}", exc_info=True
+        )
+        return []
+
+    if not invitation:
+        return []
+
+    servers = (
+        list(invitation.servers)
+        if invitation.servers
+        else ([invitation.server] if invitation.server else [])
+    )
+    seen: set[str] = set()
+    steps: list = []
+    for srv in servers:
+        if not srv or srv.server_type in seen:
+            continue
+        seen.add(srv.server_type)
+        steps.extend(_steps(srv.server_type, cfg, category="post_invite"))
+    return steps
 
 
 # ─── routes ─────────────────────────────────────────────────────
@@ -833,12 +1019,33 @@ def post_wizard(idx: int = 0):
 def complete():
     """Completion page shown after user finishes all wizard steps.
 
+    This is the chokepoint: the Next button is hidden on a gated last step,
+    but this URL is directly reachable, so it re-checks the whole post-invite
+    flow itself rather than trusting how the caller got here.
+
     This endpoint provides a dedicated completion experience with:
     - Success message confirming setup is complete
     - Clear call-to-action to proceed to the application
     - Automatic cleanup of all invitation-related session data
     - Cookie with media server URL for login page redirect
     """
+    try:
+        cfg = _settings()
+        gate_steps = _post_invite_gate_steps(cfg)
+        locked = gate.first_locked_index(
+            gate_steps, exempt=current_user.is_authenticated
+        )
+    except Exception as e:
+        # Graceful degradation (Requirement 13.6): a broken lookup must not
+        # trap a user mid-wizard, so an unresolvable gate state opens rather
+        # than blocks.
+        current_app.logger.error(
+            f"Error checking gate status before completion: {e}", exc_info=True
+        )
+        locked = None
+    if locked is not None:
+        return redirect(url_for("wizard.post_wizard", idx=locked))
+
     # Grab media server URL before clearing session data
     invite_code = InviteCodeManager.get_invite_code()
     media_server_url = None
@@ -858,6 +1065,7 @@ def complete():
     session.pop("wizard_access", None)
     session.pop("wizard_server_order", None)
     session.pop("wizard_bundle_id", None)
+    gate.clear()
 
     # Show success message
     flash(_("Setup complete! Welcome to your media server."), "success")
@@ -875,6 +1083,138 @@ def complete():
         )
 
     return resp
+
+
+@wizard_bp.route("/api-check/<int:step_id>")
+def api_check(step_id: int):
+    """Poll endpoint for the wizard API-check gate.
+
+    Unauthenticated by design (the invited user has no login yet), so this is
+    the only outbound-calling endpoint reachable without a session - every
+    branch below exists to refuse an upstream call rather than to grant one.
+    Always renders the status card fragment; a redirect here would let HTMX
+    swap the homepage into the card, and a 4xx would tip a caller off that
+    they guessed wrong instead of just looking inert. HTTP 286 tells HTMX to
+    stop polling; 200 lets it keep going.
+    """
+    check_url = url_for("wizard.api_check", step_id=step_id)
+
+    def card(
+        state,
+        *,
+        status,
+        gate_header,
+        message=None,
+        interval=0,
+        retry_after=0,
+        show_button=False,
+        trigger="",
+    ):
+        resp = make_response(
+            render_template(
+                "wizard/_api_check_card.html",
+                step_id=step_id,
+                state=state,
+                message=message,
+                interval=interval,
+                retry_after=retry_after,
+                check_url=check_url,
+                show_button=show_button,
+                trigger=trigger,
+            ),
+            status,
+        )
+        resp.headers["X-Wizarr-Gate"] = gate_header
+        return resp
+
+    def inert():
+        return card("inactive", status=286, gate_header="inactive")
+
+    if not session.get("wizard_access") and not current_user.is_authenticated:
+        return inert()
+
+    try:
+        step = db.session.get(WizardStep, step_id)
+    except Exception as e:
+        current_app.logger.error(
+            f"Error loading wizard step {step_id} for gate check: {e}", exc_info=True
+        )
+        return inert()
+
+    if step is None:
+        return inert()
+
+    if step.category != "post_invite":
+        return inert()
+
+    cfg = normalize(step.api_check, category=step.category)
+    if not cfg.is_active:
+        return inert()
+
+    allowed_ids = _current_post_invite_step_ids()
+    if allowed_ids is not None and step_id not in allowed_ids:
+        return inert()
+
+    if gate.has_passed(step_id):
+        return card(
+            "passed",
+            status=286,
+            gate_header="passed",
+            message=cfg.success_message,
+            interval=cfg.interval_seconds,
+        )
+
+    if gate.is_capped(step_id, max_poll_seconds=cfg.max_poll_seconds):
+        return card(
+            "capped",
+            status=286,
+            gate_header="capped",
+            message=cfg.pending_message,
+            interval=cfg.interval_seconds,
+            show_button=True,
+        )
+
+    wait = gate.reserve(step_id, interval=cfg.interval_seconds)
+    if wait > 0:
+        retry_after = max(1, math.ceil(wait))
+        resp = card(
+            "cooldown",
+            status=200,
+            gate_header="cooldown",
+            message=cfg.pending_message,
+            interval=cfg.interval_seconds,
+            retry_after=retry_after,
+            show_button=True,
+            trigger=f"load delay:{retry_after}s",
+        )
+        resp.headers["Retry-After"] = str(retry_after)
+        return resp
+
+    gate.note_poll_started(step_id)
+    code, username, email = _gate_identity(step.server_type)
+    outcome = run_check(cfg, code=code, username=username, email=email)
+
+    if outcome.passed:
+        gate.mark_passed(step_id)
+        resp = card(
+            "passed",
+            status=286,
+            gate_header="passed",
+            message=cfg.success_message,
+            interval=cfg.interval_seconds,
+        )
+        resp.headers["HX-Trigger"] = "wizard:gate-passed"
+        return resp
+
+    return card(
+        "pending",
+        status=200,
+        gate_header="pending",
+        message=cfg.pending_message,
+        interval=cfg.interval_seconds,
+        show_button=True,
+        trigger=f"every {cfg.interval_seconds}s",
+    )
 
 
 @wizard_bp.route("/")
@@ -1022,6 +1362,10 @@ def combo(category: str, idx: int = 0):
         return redirect(url_for("wizard.complete"))
 
     idx = max(0, min(idx, len(steps) - 1))
+    locked = gate.first_locked_index(steps, exempt=current_user.is_authenticated)
+    if locked is not None and idx > locked:
+        idx = locked
+    gate_locked = locked is not None and locked == idx
 
     # Check if we're on the last step and moving forward
     direction = request.values.get("dir", "")
@@ -1080,6 +1424,7 @@ def combo(category: str, idx: int = 0):
         gradient_start=colors["gradient_start"],
         gradient_end=colors["gradient_end"],
         shadow_color=colors["shadow_color"],
+        gate_locked=gate_locked,
     )
 
     # Add custom headers for client-side updates (HTMX requests only)
@@ -1097,6 +1442,7 @@ def combo(category: str, idx: int = 0):
         resp.headers["X-Current-Server-Type"] = (
             current_server_type  # NEW: Indicate current server
         )
+        resp.headers["X-Wizard-Gate-Locked"] = "true" if gate_locked else "false"
         return resp
 
     return response
@@ -1203,11 +1549,13 @@ def bundle_view(idx: int):
 
     # adapt to frontmatter-like interface
     class _RowAdapter:
-        __slots__ = ("_require", "content")
+        __slots__ = ("_require", "api_check", "content", "step_id")
 
         def __init__(self, row: WizardStep):
             self.content = row.markdown
             self._require = bool(getattr(row, "require_interaction", False))
+            self.step_id = row.id
+            self.api_check = normalize(row.api_check, category=row.category)
 
         def get(self, key, default=None):
             if key == "require":
@@ -1216,6 +1564,10 @@ def bundle_view(idx: int):
 
     steps = [_RowAdapter(s) for s in steps_raw]
     idx = max(0, min(idx, len(steps) - 1))
+    locked = gate.first_locked_index(steps, exempt=current_user.is_authenticated)
+    if locked is not None and idx > locked:
+        idx = locked
+    gate_locked = locked is not None and locked == idx
 
     # Get the server type and category for the current step from the WizardStep
     current_server_type = steps_raw[idx].server_type if idx < len(steps_raw) else None
@@ -1297,6 +1649,7 @@ def bundle_view(idx: int):
         gradient_start=colors["gradient_start"],
         gradient_end=colors["gradient_end"],
         shadow_color=colors["shadow_color"],
+        gate_locked=gate_locked,
     )
 
     # Add custom headers for client-side updates (HTMX requests only)
@@ -1309,6 +1662,7 @@ def bundle_view(idx: int):
             "true" if require_interaction else "false"
         )
         resp.headers["X-Wizard-Step-Phase"] = phase
+        resp.headers["X-Wizard-Gate-Locked"] = "true" if gate_locked else "false"
         return resp
 
     return response
@@ -1375,11 +1729,13 @@ def bundle_preview(bundle_id: int, idx: int):
 
     # Adapter for frontmatter-like interface
     class _RowAdapter:
-        __slots__ = ("_require", "content")
+        __slots__ = ("_require", "api_check", "content", "step_id")
 
         def __init__(self, row: WizardStep):
             self.content = row.markdown
             self._require = bool(getattr(row, "require_interaction", False))
+            self.step_id = row.id
+            self.api_check = normalize(row.api_check, category=row.category)
 
         def get(self, key, default=None):
             if key == "require":
@@ -1388,6 +1744,13 @@ def bundle_preview(bundle_id: int, idx: int):
 
     steps = [_RowAdapter(s) for s in steps_raw]
     idx = max(0, min(idx, len(steps) - 1))
+    # Admin-preview by construction, but the shared ACL also lets any accepted
+    # invitation reach this URL - keep the same is_authenticated-only exemption
+    # the other wizard routes use rather than trusting the route's intent.
+    locked = gate.first_locked_index(steps, exempt=current_user.is_authenticated)
+    if locked is not None and idx > locked:
+        idx = locked
+    gate_locked = locked is not None and locked == idx
 
     # Get the server type and category for the current step
     current_server_type = steps_raw[idx].server_type if idx < len(steps_raw) else None
@@ -1454,6 +1817,7 @@ def bundle_preview(bundle_id: int, idx: int):
         gradient_end=colors["gradient_end"],
         shadow_color=colors["shadow_color"],
         is_bundle_preview=True,  # Flag to help template generate correct URLs
+        gate_locked=gate_locked,
     )
 
     # Add custom headers for client-side updates (HTMX requests only)
@@ -1464,6 +1828,7 @@ def bundle_preview(bundle_id: int, idx: int):
             "true" if require_interaction else "false"
         )
         resp.headers["X-Wizard-Step-Phase"] = current_phase
+        resp.headers["X-Wizard-Gate-Locked"] = "true" if gate_locked else "false"
         return resp
 
     return response

--- a/app/blueprints/wizard_admin/routes.py
+++ b/app/blueprints/wizard_admin/routes.py
@@ -30,6 +30,7 @@ from app.forms.wizard import (
     WizardStepForm,
 )
 from app.models import MediaServer, WizardBundle, WizardBundleStep, WizardStep
+from app.services.wizard_api_check.config import from_form, normalize, to_form
 from app.services.wizard_export_import import WizardExportImportService
 from app.services.wizard_presets import (
     create_step_from_preset,
@@ -156,57 +157,69 @@ def create_step():
         stype = "custom" if simple else (server_type_attr and server_type_attr.data)
 
         # Get category from form (defaults to 'post_invite')
-        category = form.category.data if hasattr(form, "category") else "post_invite"
-
-        max_pos = (
-            db.session.query(func.max(WizardStep.position))
-            .filter_by(server_type=stype, category=category)
-            .scalar()
+        category = (
+            form.category.data or "post_invite"
+            if hasattr(form, "category")
+            else "post_invite"
         )
-        next_pos = (max_pos or 0) + 1
 
-        cleaned_md = _strip_localization(form.markdown.data or "")
+        api_check_blob, api_check_errors = from_form(form, category=category)
 
-        step = WizardStep(
-            server_type=stype,
-            category=category,
-            position=next_pos,
-            title=(getattr(form, "title", None) and form.title.data) or None,
-            markdown=cleaned_md,
-            require_interaction=(
-                getattr(form, "require_interaction", None) is not None
-                and bool(form.require_interaction.data)
-            ),
-        )
-        db.session.add(step)
-        db.session.flush()  # get step.id
-
-        # If created from a bundle context attach immediately
-        if bundle_id:
-            max_bpos = (
-                db.session.query(func.max(WizardBundleStep.position))
-                .filter_by(bundle_id=bundle_id)
+        # A rejected gate field (bad URL, out-of-range interval, ...) refuses
+        # the whole save rather than silently dropping just the gate.
+        if not api_check_errors:
+            max_pos = (
+                db.session.query(func.max(WizardStep.position))
+                .filter_by(server_type=stype, category=category)
                 .scalar()
             )
-            next_bpos = (max_bpos or 0) + 1
-            db.session.add(
-                WizardBundleStep(
-                    bundle_id=bundle_id, step_id=step.id, position=next_bpos
+            next_pos = (max_pos or 0) + 1
+
+            cleaned_md = _strip_localization(form.markdown.data or "")
+
+            step = WizardStep(
+                server_type=stype,
+                category=category,
+                position=next_pos,
+                title=(getattr(form, "title", None) and form.title.data) or None,
+                markdown=cleaned_md,
+                require_interaction=(
+                    getattr(form, "require_interaction", None) is not None
+                    and bool(form.require_interaction.data)
+                ),
+                api_check=api_check_blob,
+            )
+            db.session.add(step)
+            db.session.flush()  # get step.id
+
+            # If created from a bundle context attach immediately
+            if bundle_id:
+                max_bpos = (
+                    db.session.query(func.max(WizardBundleStep.position))
+                    .filter_by(bundle_id=bundle_id)
+                    .scalar()
+                )
+                next_bpos = (max_bpos or 0) + 1
+                db.session.add(
+                    WizardBundleStep(
+                        bundle_id=bundle_id, step_id=step.id, position=next_bpos
+                    )
+                )
+
+            db.session.commit()
+            flash(_("Step created"), "success")
+
+            # HTMX target refresh depending on origin
+            if request.headers.get("HX-Request"):
+                return list_bundles() if bundle_id else list_steps()
+
+            return redirect(
+                url_for(
+                    "wizard_admin.list_bundles"
+                    if bundle_id
+                    else "wizard_admin.list_steps"
                 )
             )
-
-        db.session.commit()
-        flash(_("Step created"), "success")
-
-        # HTMX target refresh depending on origin
-        if request.headers.get("HX-Request"):
-            return list_bundles() if bundle_id else list_steps()
-
-        return redirect(
-            url_for(
-                "wizard_admin.list_bundles" if bundle_id else "wizard_admin.list_steps"
-            )
-        )
 
     # GET – choose modal / full template based on form type
     if simple:
@@ -217,7 +230,9 @@ def create_step():
         page_tmpl = "settings/wizard/form.html"
 
     tmpl = modal_tmpl if request.headers.get("HX-Request") else page_tmpl
-    return render_template(tmpl, form=form, action="create", bundle_id=bundle_id)
+    return render_template(
+        tmpl, form=form, action="create", bundle_id=bundle_id, has_api_key=False
+    )
 
 
 @wizard_admin_bp.route("/create-preset", methods=["GET", "POST"])
@@ -300,38 +315,60 @@ def edit_step(step_id: int):
     form = FormCls(request.form if request.method == "POST" else None, obj=step)
 
     if form.validate_on_submit():
-        if not simple:
-            server_type_attr = getattr(form, "server_type", None)
-            step.server_type = server_type_attr.data if server_type_attr else "custom"
-
-        # Update category if present on form
-        if hasattr(form, "category") and form.category.data:
-            step.category = form.category.data
-
-        step.title = (getattr(form, "title", None) and form.title.data) or None
-        cleaned_md = _strip_localization(form.markdown.data or "")
-        step.markdown = cleaned_md
-
-        # Update interaction requirement if present on this form
-        if getattr(form, "require_interaction", None) is not None:
-            step.require_interaction = bool(form.require_interaction.data)
-
-        db.session.commit()
-        flash(_("Step updated"), "success")
-
-        # HTMX refresh
-        if request.headers.get("HX-Request"):
-            return list_bundles() if simple else list_steps()
-
-        return redirect(
-            url_for(
-                "wizard_admin.list_bundles" if simple else "wizard_admin.list_steps"
-            )
+        # Category may change via this same submit, so resolve the candidate
+        # value up front - from_form's post-invite-only check needs it.
+        category = (
+            form.category.data
+            if hasattr(form, "category") and form.category.data
+            else step.category
         )
 
+        api_check_blob, api_check_errors = from_form(
+            form, category=category, existing=step.api_check
+        )
+
+        # A rejected gate field refuses the whole save, not just the gate -
+        # otherwise an unrelated title edit could silently persist a bad URL.
+        if not api_check_errors:
+            if not simple:
+                server_type_attr = getattr(form, "server_type", None)
+                step.server_type = (
+                    server_type_attr.data if server_type_attr else "custom"
+                )
+
+            step.category = category
+            step.title = (getattr(form, "title", None) and form.title.data) or None
+            cleaned_md = _strip_localization(form.markdown.data or "")
+            step.markdown = cleaned_md
+
+            # Update interaction requirement if present on this form
+            if getattr(form, "require_interaction", None) is not None:
+                step.require_interaction = bool(form.require_interaction.data)
+
+            step.api_check = api_check_blob
+
+            db.session.commit()
+            flash(_("Step updated"), "success")
+
+            # HTMX refresh
+            if request.headers.get("HX-Request"):
+                return list_bundles() if simple else list_steps()
+
+            return redirect(
+                url_for(
+                    "wizard_admin.list_bundles" if simple else "wizard_admin.list_steps"
+                )
+            )
+
     # GET: populate fields
+    cfg = normalize(step.api_check, category=step.category)
+    has_api_key = bool(cfg.api_key_enc)
     if request.method == "GET":
         form.markdown.data = _strip_localization(step.markdown)
+        for field_name, value in to_form(cfg).items():
+            if field_name == "has_api_key":
+                continue
+            getattr(form, field_name).data = value
 
     modal_tmpl = (
         "modals/wizard-simple-step-form.html"
@@ -342,7 +379,9 @@ def edit_step(step_id: int):
         "settings/wizard/simple_form.html" if simple else "settings/wizard/form.html"
     )
     tmpl = modal_tmpl if request.headers.get("HX-Request") else page_tmpl
-    return render_template(tmpl, form=form, action="edit", step=step)
+    return render_template(
+        tmpl, form=form, action="edit", step=step, has_api_key=has_api_key
+    )
 
 
 @wizard_admin_bp.route("/<int:step_id>/delete", methods=["POST"])
@@ -459,8 +498,26 @@ def reorder_steps():
 def preview_markdown():
     from markdown import markdown as md_to_html
 
+    from app.services.wizard_widgets import (
+        process_card_delimiters,
+        process_widget_placeholders,
+    )
+
     raw = request.form.get("markdown", "")
-    return md_to_html(raw, extensions=["fenced_code", "tables", "attr_list"])
+    server_type = request.form.get("server_type") or "plex"
+
+    # wizard_step_id=None is what keeps the api_check widget inert here: it
+    # bails out before touching hx-* attributes, since there is no real step
+    # for a re-check request to poll.
+    widget_ctx = {
+        "wizard_step_id": None,
+        "wizard_api_check": None,
+        "wizard_gate_passed": False,
+    }
+    content = process_card_delimiters(raw)
+    content = process_widget_placeholders(content, server_type, context=widget_ctx)
+
+    return md_to_html(content, extensions=["fenced_code", "tables", "attr_list"])
 
 
 # ─── bundle CRUD ─────────────────────────────────────────────────

--- a/app/forms/wizard.py
+++ b/app/forms/wizard.py
@@ -1,10 +1,194 @@
+from flask_babel import lazy_gettext as _l
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileAllowed, FileField, FileRequired
-from wtforms import BooleanField, HiddenField, SelectField, StringField, TextAreaField
+from wtforms import (
+    BooleanField,
+    HiddenField,
+    IntegerField,
+    PasswordField,
+    SelectField,
+    StringField,
+    TextAreaField,
+)
 from wtforms.validators import DataRequired, Optional
 
 
-class WizardStepForm(FlaskForm):
+class ApiCheckFieldsMixin:
+    """Fields for the wizard API-check gate.
+
+    Deliberately loose validators – ``Optional()`` everywhere, no range or
+    URL checks. ``app.services.wizard_api_check.config.from_form`` is where
+    submitted values are actually judged, so a rejected value is echoed back
+    for the admin to fix rather than clamped here without them noticing.
+    """
+
+    api_check_enabled = BooleanField(
+        str(_l("Enable API Gate")),
+        default=False,
+        description=str(
+            _l(
+                "Block this step until an external API confirms the invited "
+                "user. Only takes effect on post-invite steps, since that is "
+                "the earliest point a username and email exist to check."
+            )
+        ),
+    )
+
+    api_check_method = SelectField(
+        str(_l("Method")),
+        choices=[("GET", "GET"), ("POST", "POST")],
+        default="GET",
+        description=str(_l("HTTP method used to call the endpoint.")),
+    )
+
+    api_check_url = StringField(
+        str(_l("Endpoint URL")),
+        validators=[Optional()],
+        description=str(
+            _l(
+                "The API to call, e.g. https://example.com/check. Must be a "
+                "plain http(s) URL with no embedded credentials."
+            )
+        ),
+    )
+
+    api_check_auth_header = StringField(
+        str(_l("Auth Header")),
+        validators=[Optional()],
+        description=str(_l("Header the API key is sent under, e.g. Authorization.")),
+    )
+
+    api_check_auth_prefix = StringField(
+        str(_l("Auth Prefix")),
+        validators=[Optional()],
+        description=str(
+            _l('Text placed before the key in that header, e.g. "Bearer ".')
+        ),
+    )
+
+    api_check_api_key = PasswordField(
+        str(_l("API Key")),
+        validators=[Optional()],
+        description=str(
+            _l(
+                "Sent in the auth header above. Leave blank to keep the "
+                "currently stored key – it is never shown here once saved."
+            )
+        ),
+    )
+
+    api_check_clear_key = BooleanField(
+        str(_l("Remove stored key")),
+        default=False,
+        description=str(
+            _l(
+                "Delete the saved key instead of keeping it. A signed gate "
+                "left without a key stays inactive rather than blocking users."
+            )
+        ),
+    )
+
+    api_check_code_param = StringField(
+        str(_l("Code Parameter")),
+        validators=[Optional()],
+        description=str(
+            _l("The invite code is sent to the endpoint under this parameter name.")
+        ),
+    )
+
+    api_check_username_param = StringField(
+        str(_l("Username Parameter")),
+        validators=[Optional()],
+        description=str(
+            _l("The invited user's username is sent under this parameter name.")
+        ),
+    )
+
+    api_check_email_param = StringField(
+        str(_l("Email Parameter")),
+        validators=[Optional()],
+        description=str(
+            _l("The invited user's email is sent under this parameter name.")
+        ),
+    )
+
+    api_check_expect_status = StringField(
+        str(_l("Expected Status Codes")),
+        validators=[Optional()],
+        description=str(
+            _l(
+                'Comma-separated HTTP status codes that count as a pass, e.g. "200, 204".'
+            )
+        ),
+    )
+
+    api_check_interval_seconds = IntegerField(
+        str(_l("Poll Interval (seconds)")),
+        validators=[Optional()],
+        description=str(
+            _l("How often the browser re-checks while waiting (5-300 seconds).")
+        ),
+    )
+
+    api_check_timeout_seconds = IntegerField(
+        str(_l("Request Timeout (seconds)")),
+        validators=[Optional()],
+        description=str(
+            _l(
+                "How long to wait for the endpoint to respond before counting "
+                "the attempt as failed (1-15 seconds)."
+            )
+        ),
+    )
+
+    api_check_max_poll_seconds = IntegerField(
+        str(_l("Give Up After (seconds)")),
+        validators=[Optional()],
+        description=str(
+            _l(
+                "Stop auto-polling after this long (30-3600 seconds); the "
+                "user can still tap Re-check by hand."
+            )
+        ),
+    )
+
+    api_check_sign_requests = BooleanField(
+        str(_l("Sign Requests")),
+        default=True,
+        description=str(
+            _l(
+                "Sign each request with an HMAC of the key above, a "
+                "timestamp and a nonce. Your endpoint should reject "
+                "timestamps more than 300 seconds old and track nonces to "
+                "stop replayed requests."
+            )
+        ),
+    )
+
+    api_check_pending_message = TextAreaField(
+        str(_l("Pending Message")),
+        validators=[Optional()],
+        description=str(
+            _l(
+                "Shown while waiting for a passing check. Plain text only – "
+                "template syntax is rejected."
+            )
+        ),
+    )
+
+    api_check_success_message = TextAreaField(
+        str(_l("Success Message")),
+        validators=[Optional()],
+        description=str(
+            _l(
+                "Shown once the check passes. Plain text only – template "
+                "syntax is rejected."
+            )
+        ),
+    )
+
+
+class WizardStepForm(ApiCheckFieldsMixin, FlaskForm):
     server_type = SelectField(
         "Server Type",
         choices=[
@@ -89,7 +273,7 @@ class WizardBundleForm(FlaskForm):
     # optional: Steps selection handled in separate UI; keep form minimal
 
 
-class SimpleWizardStepForm(FlaskForm):
+class SimpleWizardStepForm(ApiCheckFieldsMixin, FlaskForm):
     """Minimal form for bundle-only steps (no server_type, no requires)."""
 
     category = SelectField(

--- a/app/models.py
+++ b/app/models.py
@@ -559,6 +559,10 @@ class WizardStep(db.Model):
     # New: require explicit user interaction before enabling Next
     require_interaction = db.Column(db.Boolean, default=False, nullable=True)
 
+    # Optional external API gate config (see app/services/wizard_api_check).
+    # Honoured on post_invite steps only; the API key inside is encrypted.
+    api_check = db.Column(db.JSON, nullable=True)
+
     created_at = db.Column(
         db.DateTime, default=lambda: datetime.now(UTC), nullable=False
     )
@@ -581,6 +585,8 @@ class WizardStep(db.Model):
     # ── convenience helpers ─────────────────────────────────────────────
     def to_dict(self):
         """Return serialisable representation (for JSON responses)."""
+        from app.services.wizard_api_check.config import public_view
+
         return {
             "id": self.id,
             "server_type": self.server_type,
@@ -590,6 +596,7 @@ class WizardStep(db.Model):
             "markdown": self.markdown,
             "requires": self.requires or [],
             "require_interaction": bool(self.require_interaction or False),
+            "api_check": public_view(self.api_check, category=self.category),
         }
 
 

--- a/app/services/wizard_api_check/__init__.py
+++ b/app/services/wizard_api_check/__init__.py
@@ -1,0 +1,25 @@
+"""External API gate for wizard steps.
+
+An admin can attach an HTTP check to a post-invite wizard step; the user cannot
+continue until that endpoint answers with an expected status code.
+"""
+
+from app.services.wizard_api_check.client import (
+    CheckOutcome,
+    build_canonical_string,
+    run_check,
+)
+from app.services.wizard_api_check.config import (
+    ApiCheckConfig,
+    normalize,
+    public_view,
+)
+
+__all__ = [
+    "ApiCheckConfig",
+    "CheckOutcome",
+    "build_canonical_string",
+    "normalize",
+    "public_view",
+    "run_check",
+]

--- a/app/services/wizard_api_check/client.py
+++ b/app/services/wizard_api_check/client.py
@@ -1,0 +1,173 @@
+"""Outbound HTTP for the wizard API-check gate.
+
+The endpoint is admin-configured but the *result* is shown to an unauthenticated
+invited user, so this layer is deliberately one-way: it reports whether the
+upstream answered with an expected status and nothing else. The response body is
+never read, redirects are never followed, and errors are collapsed to a coarse
+reason so the user cannot learn anything about the admin's network.
+"""
+
+import hashlib
+import hmac
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+import requests
+
+from app.services.wizard_api_check.config import ALLOWED_SCHEMES, ApiCheckConfig
+
+SIGNATURE_VERSION = "v1"
+MAX_CONNECT_TIMEOUT = 5
+
+
+@dataclass(frozen=True)
+class CheckOutcome:
+    """Verdict for one upstream call. Deliberately carries no response content."""
+
+    passed: bool
+    reason: str  # ok | status | timeout | network | config | redirect
+    status_code: int | None = None
+
+
+def build_canonical_string(
+    *,
+    timestamp: str,
+    nonce: str,
+    method: str,
+    path: str,
+    code: str,
+    username: str,
+    email: str,
+) -> str:
+    """Return the string signed by ``X-Wizarr-Signature``.
+
+    The upstream rebuilds this from the request it received and compares HMACs.
+    It must also reject stale timestamps and replayed nonces - Wizarr cannot
+    enforce freshness on the upstream's behalf.
+    """
+    return "\n".join(
+        [
+            SIGNATURE_VERSION,
+            timestamp,
+            nonce,
+            method.upper(),
+            path,
+            code,
+            username,
+            email,
+        ]
+    )
+
+
+def _safe_url(url: str) -> str | None:
+    """Re-validate the stored URL at call time; the column is not trusted."""
+    if not url or any(ch.isspace() for ch in url):
+        return None
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return None
+    if parts.scheme.lower() not in ALLOWED_SCHEMES or not parts.hostname:
+        return None
+    if parts.username or parts.password or "@" in parts.netloc:
+        return None
+    return url
+
+
+def _payload(
+    cfg: ApiCheckConfig, code: str, username: str, email: str
+) -> dict[str, str]:
+    fields = (
+        (cfg.code_param, code),
+        (cfg.username_param, username),
+        (cfg.email_param, email),
+    )
+    return {name: value for name, value in fields if name}
+
+
+def _headers(
+    cfg: ApiCheckConfig, path: str, code: str, username: str, email: str
+) -> dict[str, str]:
+    headers = {"Accept": "application/json"}
+    key = cfg.api_key()
+
+    if cfg.auth_header and key:
+        headers[cfg.auth_header] = f"{cfg.auth_prefix}{key}"
+
+    if cfg.sign_requests and key:
+        timestamp = str(int(time.time()))
+        nonce = secrets.token_hex(16)
+        canonical = build_canonical_string(
+            timestamp=timestamp,
+            nonce=nonce,
+            method=cfg.method,
+            path=path,
+            code=code,
+            username=username,
+            email=email,
+        )
+        digest = hmac.new(key.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+        headers["X-Wizarr-Timestamp"] = timestamp
+        headers["X-Wizarr-Nonce"] = nonce
+        headers["X-Wizarr-Signature"] = f"sha256={digest}"
+
+    return headers
+
+
+def _log_target(url: str) -> str:
+    """A URL safe to log: origin plus path, no query string, no credentials."""
+    parts = urlsplit(url)
+    port = f":{parts.port}" if parts.port else ""
+    target = f"{parts.scheme}://{parts.hostname}{port}{parts.path}"
+    return target.replace("\r", "").replace("\n", "")
+
+
+def run_check(
+    cfg: ApiCheckConfig, *, code: str, username: str = "", email: str = ""
+) -> CheckOutcome:
+    """Call the configured endpoint once and report whether it approved."""
+    url = _safe_url(cfg.url)
+    if url is None:
+        logging.warning("Wizard api_check skipped: unusable URL in step configuration")
+        return CheckOutcome(passed=False, reason="config")
+
+    path = urlsplit(url).path or "/"
+    payload = _payload(cfg, code, username, email)
+    headers = _headers(cfg, path, code, username, email)
+    timeout = (min(cfg.timeout_seconds, MAX_CONNECT_TIMEOUT), cfg.timeout_seconds)
+
+    kwargs = {"json": payload} if cfg.method == "POST" else {"params": payload}
+
+    try:
+        with requests.request(
+            cfg.method,
+            url,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=False,
+            stream=True,
+            **kwargs,
+        ) as response:
+            status = response.status_code
+    except requests.exceptions.Timeout:
+        logging.warning("Wizard api_check timed out: %s", _log_target(url))
+        return CheckOutcome(passed=False, reason="timeout")
+    except requests.exceptions.RequestException as exc:
+        logging.warning(
+            "Wizard api_check failed: %s (%s)", _log_target(url), type(exc).__name__
+        )
+        return CheckOutcome(passed=False, reason="network")
+
+    if status in cfg.expect_status:
+        return CheckOutcome(passed=True, reason="ok", status_code=status)
+    if 300 <= status < 400:
+        # Never chase a redirect: it would replay the auth header at a host the
+        # admin did not configure.
+        logging.warning(
+            "Wizard api_check upstream redirected (%s); not following", status
+        )
+        return CheckOutcome(passed=False, reason="redirect", status_code=status)
+    return CheckOutcome(passed=False, reason="status", status_code=status)

--- a/app/services/wizard_api_check/config.py
+++ b/app/services/wizard_api_check/config.py
@@ -1,0 +1,428 @@
+"""Configuration schema for the wizard API-check gate.
+
+The blob lives on ``wizard_step.api_check`` and is authored by an admin, so it
+is treated as untrusted on read: :func:`normalize` never raises and clamps every
+bound rather than trusting what the column happens to contain.
+"""
+
+import logging
+import re
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any
+from urllib.parse import urlsplit
+
+VERSION = 1
+
+ALLOWED_METHODS = ("GET", "POST")
+ALLOWED_SCHEMES = ("http", "https")
+GATED_CATEGORY = "post_invite"
+
+MAX_URL_LEN = 2048
+MAX_HEADER_LEN = 64
+MAX_PREFIX_LEN = 32
+MAX_KEY_LEN = 4096
+MAX_PARAM_LEN = 64
+MAX_MESSAGE_LEN = 500
+MAX_EXPECT_STATUS = 10
+
+MIN_INTERVAL, MAX_INTERVAL = 5, 300
+MIN_TIMEOUT, MAX_TIMEOUT = 1, 15
+MIN_MAX_POLL, MAX_MAX_POLL = 30, 3600
+
+DEFAULT_INTERVAL = 10
+DEFAULT_TIMEOUT = 5
+DEFAULT_MAX_POLL = 600
+DEFAULT_HEADER = "Authorization"
+DEFAULT_PREFIX = "Bearer "
+DEFAULT_STATUS = (200,)
+
+_HEADER_RE = re.compile(rf"^[A-Za-z0-9-]{{1,{MAX_HEADER_LEN}}}$")
+_PARAM_RE = re.compile(rf"^[A-Za-z0-9_.-]{{1,{MAX_PARAM_LEN}}}$")
+_PREFIX_RE = re.compile(r"^[\x20-\x7e]*$")
+_TEMPLATE_RE = re.compile(r"\{\{|\{%|\{#|\}\}|%\}|#\}")
+_CONTROL_RE = re.compile(r"[\x00-\x09\x0b-\x1f\x7f]")
+
+
+@dataclass(frozen=True)
+class ApiCheckConfig:
+    """A validated, clamped view of the stored ``api_check`` blob.
+
+    ``category`` is not part of the stored blob – it is carried from the owning
+    step so :attr:`is_active` can enforce the post-invite-only rule in one place.
+    """
+
+    version: int = VERSION
+    enabled: bool = False
+    method: str = "GET"
+    url: str = ""
+    auth_header: str = DEFAULT_HEADER
+    auth_prefix: str = DEFAULT_PREFIX
+    api_key_enc: str = ""
+    code_param: str = "code"
+    username_param: str = "username"
+    email_param: str = "email"
+    expect_status: tuple[int, ...] = DEFAULT_STATUS
+    interval_seconds: int = DEFAULT_INTERVAL
+    timeout_seconds: int = DEFAULT_TIMEOUT
+    max_poll_seconds: int = DEFAULT_MAX_POLL
+    sign_requests: bool = True
+    pending_message: str = ""
+    success_message: str = ""
+    category: str = field(default=GATED_CATEGORY, compare=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"ApiCheckConfig(enabled={self.enabled}, method={self.method!r}, "
+            f"url={self.url!r}, category={self.category!r}, key=***)"
+        )
+
+    @property
+    def is_active(self) -> bool:
+        """Whether this gate may block a user.
+
+        Signed gates without a key stay inert so an imported step (which never
+        carries a key) cannot lock anyone out.
+        """
+        return bool(
+            self.enabled
+            and self.url
+            and (not self.sign_requests or self.api_key_enc)
+            and self.category == GATED_CATEGORY
+        )
+
+    def api_key(self) -> str:
+        """Decrypt the stored credential, returning "" if it is unusable."""
+        if not self.api_key_enc:
+            return ""
+        from app.services.ldap.encryption import decrypt_credential
+
+        try:
+            return (
+                decrypt_credential(self.api_key_enc).replace("\r", "").replace("\n", "")
+            )
+        except Exception:
+            logging.warning("Wizard api_check credential could not be decrypted")
+            return ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the storable blob (JSON-native, excludes the step category)."""
+        blob = asdict(self)
+        blob.pop("category", None)
+        blob["expect_status"] = list(self.expect_status)
+        return blob
+
+    def without_key(self) -> "ApiCheckConfig":
+        return replace(self, api_key_enc="")
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    return value if isinstance(value, bool) else default
+
+
+def _as_int(value: Any, default: int, low: int, high: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        candidate = value
+    elif isinstance(value, str):
+        try:
+            candidate = int(value.strip())
+        except ValueError:
+            return default
+    else:
+        return default
+    return max(low, min(candidate, high))
+
+
+def _as_text(value: Any, default: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str):
+        return default
+    if value == "":
+        return ""
+    return value if pattern.match(value) else default
+
+
+def _clean_url(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    url = value.strip()
+    if not url or len(url) > MAX_URL_LEN:
+        return ""
+    if any(ch.isspace() for ch in url):
+        return ""
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return ""
+    if parts.scheme.lower() not in ALLOWED_SCHEMES or not parts.hostname:
+        return ""
+    if parts.username or parts.password or "@" in parts.netloc:
+        return ""
+    return url
+
+
+def _clean_message(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = _CONTROL_RE.sub("", value)[:MAX_MESSAGE_LEN]
+    # Fail closed: the render pass neutralises braces too, but a hand-edited
+    # column should never reach it carrying template syntax.
+    return "" if _TEMPLATE_RE.search(text) else text
+
+
+def _clean_statuses(value: Any) -> tuple[int, ...]:
+    if isinstance(value, bool):
+        return DEFAULT_STATUS
+    candidates = [value] if isinstance(value, int) else value
+    if not isinstance(candidates, list | tuple):
+        return DEFAULT_STATUS
+    codes = sorted(
+        {
+            code
+            for code in candidates
+            if isinstance(code, int)
+            and not isinstance(code, bool)
+            and 100 <= code <= 599
+        }
+    )
+    return tuple(codes[:MAX_EXPECT_STATUS]) or DEFAULT_STATUS
+
+
+def normalize(raw: Any, *, category: str = GATED_CATEGORY) -> ApiCheckConfig:
+    """Return a validated config for *raw*, never raising.
+
+    Anything unrecognised – a missing column, a wrong type, a future version,
+    an out-of-range number – collapses to a safe, disabled default.
+    """
+    empty = ApiCheckConfig(category=category or "")
+    if not isinstance(raw, dict) or raw.get("version") != VERSION:
+        return empty
+
+    method = raw.get("method")
+    method = method.strip().upper() if isinstance(method, str) else ""
+
+    key = raw.get("api_key_enc")
+    key = key if isinstance(key, str) and 0 < len(key) <= MAX_KEY_LEN else ""
+
+    prefix = raw.get("auth_prefix")
+    if (
+        not isinstance(prefix, str)
+        or len(prefix) > MAX_PREFIX_LEN
+        or not _PREFIX_RE.match(prefix)
+    ):
+        prefix = DEFAULT_PREFIX
+
+    return ApiCheckConfig(
+        enabled=_as_bool(raw.get("enabled"), False),
+        method=method if method in ALLOWED_METHODS else "GET",
+        url=_clean_url(raw.get("url")),
+        auth_header=_as_text(raw.get("auth_header"), DEFAULT_HEADER, _HEADER_RE),
+        auth_prefix=prefix,
+        api_key_enc=key,
+        code_param=_as_text(raw.get("code_param"), "code", _PARAM_RE),
+        username_param=_as_text(raw.get("username_param"), "username", _PARAM_RE),
+        email_param=_as_text(raw.get("email_param"), "email", _PARAM_RE),
+        expect_status=_clean_statuses(raw.get("expect_status")),
+        interval_seconds=_as_int(
+            raw.get("interval_seconds"), DEFAULT_INTERVAL, MIN_INTERVAL, MAX_INTERVAL
+        ),
+        timeout_seconds=_as_int(
+            raw.get("timeout_seconds"), DEFAULT_TIMEOUT, MIN_TIMEOUT, MAX_TIMEOUT
+        ),
+        max_poll_seconds=_as_int(
+            raw.get("max_poll_seconds"), DEFAULT_MAX_POLL, MIN_MAX_POLL, MAX_MAX_POLL
+        ),
+        sign_requests=_as_bool(raw.get("sign_requests"), True),
+        pending_message=_clean_message(raw.get("pending_message")),
+        success_message=_clean_message(raw.get("success_message")),
+        category=category or "",
+    )
+
+
+def public_view(raw: Any, *, category: str = GATED_CATEGORY) -> dict[str, Any]:
+    """Return the blob with the credential replaced by a presence flag.
+
+    This is what reaches exports, the widget context and any JSON response –
+    the ciphertext itself must never leave the service layer.
+    """
+    cfg = raw if isinstance(raw, ApiCheckConfig) else normalize(raw, category=category)
+    view = cfg.to_dict()
+    view.pop("api_key_enc", None)
+    view["has_api_key"] = bool(cfg.api_key_enc)
+    view["is_active"] = cfg.is_active
+    return view
+
+
+def _parse_expect_status(value: Any) -> list[int]:
+    """Parse the admin's free-text comma list, e.g. ``"200, 204"``.
+
+    Unparsable tokens are dropped silently; :func:`normalize` is what enforces
+    the valid HTTP status range and supplies the default if nothing survives.
+    """
+    if not isinstance(value, str):
+        return []
+    codes = []
+    for token in value.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        try:
+            codes.append(int(token))
+        except ValueError:
+            continue
+    return codes
+
+
+def from_form(
+    form: Any, *, category: str, existing: dict[str, Any] | None = None
+) -> tuple[dict[str, Any] | None, list[str]]:
+    """Build the storable ``api_check`` blob from a submitted admin form.
+
+    Unlike :func:`normalize`, this is the authoring boundary: an out-of-range
+    number or a rejected URL is refused – with the error attached to the
+    offending field – rather than silently clamped, so a typo cannot produce
+    a gate that quietly behaves differently than what was entered. ``existing``
+    is the step's previously stored blob, consulted only so a blank password
+    field preserves the credential already on file instead of erasing it.
+    """
+    from flask_babel import gettext as _
+
+    existing = existing if isinstance(existing, dict) else {}
+    errors: list[str] = []
+
+    def fail(field: Any, message: str) -> None:
+        field.errors.append(message)
+        errors.append(message)
+
+    enabled = bool(form.api_check_enabled.data)
+    if enabled and category != GATED_CATEGORY:
+        fail(
+            form.api_check_enabled,
+            _("The API gate can only be enabled on post-invite steps."),
+        )
+
+    url = (form.api_check_url.data or "").strip()
+    if url and not _clean_url(url):
+        fail(form.api_check_url, _("Enter a valid http:// or https:// URL."))
+    elif enabled and not url:
+        fail(form.api_check_url, _("A URL is required to enable the API gate."))
+
+    # A signed gate with no key stays inert, so refuse it here rather than let
+    # the admin believe the step is gated when it is not.
+    signing = bool(form.api_check_sign_requests.data)
+    has_key = bool(form.api_check_api_key.data) or (
+        not form.api_check_clear_key.data and bool(existing.get("api_key_enc"))
+    )
+    if enabled and signing and not has_key:
+        fail(
+            form.api_check_api_key,
+            _("An API key is required while request signing is enabled."),
+        )
+
+    interval = form.api_check_interval_seconds.data
+    if interval is not None and not (MIN_INTERVAL <= interval <= MAX_INTERVAL):
+        fail(
+            form.api_check_interval_seconds,
+            _(
+                "Interval must be between %(low)s and %(high)s seconds.",
+                low=MIN_INTERVAL,
+                high=MAX_INTERVAL,
+            ),
+        )
+
+    timeout = form.api_check_timeout_seconds.data
+    if timeout is not None and not (MIN_TIMEOUT <= timeout <= MAX_TIMEOUT):
+        fail(
+            form.api_check_timeout_seconds,
+            _(
+                "Timeout must be between %(low)s and %(high)s seconds.",
+                low=MIN_TIMEOUT,
+                high=MAX_TIMEOUT,
+            ),
+        )
+
+    max_poll = form.api_check_max_poll_seconds.data
+    if max_poll is not None and not (MIN_MAX_POLL <= max_poll <= MAX_MAX_POLL):
+        fail(
+            form.api_check_max_poll_seconds,
+            _(
+                "Give up after must be between %(low)s and %(high)s seconds.",
+                low=MIN_MAX_POLL,
+                high=MAX_MAX_POLL,
+            ),
+        )
+
+    pending_message = form.api_check_pending_message.data or ""
+    if _TEMPLATE_RE.search(pending_message):
+        fail(
+            form.api_check_pending_message,
+            _("Messages cannot contain template syntax ({{, {%, or {#)."),
+        )
+
+    success_message = form.api_check_success_message.data or ""
+    if _TEMPLATE_RE.search(success_message):
+        fail(
+            form.api_check_success_message,
+            _("Messages cannot contain template syntax ({{, {%, or {#)."),
+        )
+
+    if errors:
+        return None, errors
+
+    if form.api_check_clear_key.data:
+        api_key_enc = ""
+    else:
+        from app.services.ldap.encryption import encrypt_credential
+
+        new_key = form.api_check_api_key.data or ""
+        api_key_enc = (
+            encrypt_credential(new_key) if new_key else existing.get("api_key_enc", "")
+        )
+
+    raw = {
+        "version": VERSION,
+        "enabled": enabled,
+        "method": form.api_check_method.data,
+        "url": url,
+        "auth_header": form.api_check_auth_header.data or "",
+        "auth_prefix": form.api_check_auth_prefix.data or "",
+        "api_key_enc": api_key_enc,
+        "code_param": form.api_check_code_param.data or "",
+        "username_param": form.api_check_username_param.data or "",
+        "email_param": form.api_check_email_param.data or "",
+        "expect_status": _parse_expect_status(form.api_check_expect_status.data),
+        "interval_seconds": interval,
+        "timeout_seconds": timeout,
+        "max_poll_seconds": max_poll,
+        "sign_requests": signing,
+        "pending_message": pending_message,
+        "success_message": success_message,
+    }
+
+    return normalize(raw, category=category).to_dict(), []
+
+
+def to_form(cfg: ApiCheckConfig) -> dict[str, Any]:
+    """Values to prefill the edit form. The credential itself never appears.
+
+    ``has_api_key`` is not a form field – it tells the template whether to
+    show a "key on file" indicator next to the (always-blank) password field.
+    """
+    return {
+        "api_check_enabled": cfg.enabled,
+        "api_check_method": cfg.method,
+        "api_check_url": cfg.url,
+        "api_check_auth_header": cfg.auth_header,
+        "api_check_auth_prefix": cfg.auth_prefix,
+        "api_check_code_param": cfg.code_param,
+        "api_check_username_param": cfg.username_param,
+        "api_check_email_param": cfg.email_param,
+        "api_check_expect_status": ", ".join(str(code) for code in cfg.expect_status),
+        "api_check_interval_seconds": cfg.interval_seconds,
+        "api_check_timeout_seconds": cfg.timeout_seconds,
+        "api_check_max_poll_seconds": cfg.max_poll_seconds,
+        "api_check_sign_requests": cfg.sign_requests,
+        "api_check_pending_message": cfg.pending_message,
+        "api_check_success_message": cfg.success_message,
+        "has_api_key": bool(cfg.api_key_enc),
+    }

--- a/app/services/wizard_api_check/gate.py
+++ b/app/services/wizard_api_check/gate.py
@@ -1,0 +1,152 @@
+"""Server-side state for the wizard API-check gate.
+
+Client-side gating is advisory - a user can edit the DOM or type a later step
+URL. This module is the authoritative half: it records which gates an
+invitation has satisfied, enforces the re-check cooldown, and tells the wizard
+routes how far the user is actually allowed to navigate.
+
+State lives in the Flask session, which is server-side (``SESSION_TYPE =
+"cachelib"``), so the browser holds only a signed session id and cannot forge a
+pass. The blob is scoped to a hash of the invitation code and is discarded
+wholesale the moment that scope changes, so one invitation's pass can never be
+replayed against another in the same browser.
+"""
+
+import hashlib
+import threading
+import time
+from typing import Any
+
+from flask import session
+from flask_login import current_user
+
+GATE_SESSION_KEY = "wizard_api_gates"
+
+# Session writes are read-modify-write, so two concurrent polls could both see a
+# stale cooldown. This in-process floor closes that window within a worker; across
+# gunicorn workers the residual is at most one extra call per interval per worker.
+_CALL_LOCK = threading.Lock()
+_IN_PROCESS_CALLS: dict[str, float] = {}
+_IN_PROCESS_TTL = 3600
+
+
+def _scope() -> str:
+    """Identify whose gate state this is, without storing the invite code."""
+    code = session.get("wizard_access")
+    if code:
+        return hashlib.sha256(str(code).encode()).hexdigest()[:32]
+    if current_user.is_authenticated:
+        return f"admin:{getattr(current_user, 'id', '?')}"
+    return "anon"
+
+
+def _state() -> dict[str, Any]:
+    """Return this scope's gate state, discarding anything from another scope."""
+    scope = _scope()
+    blob = session.get(GATE_SESSION_KEY)
+    if not isinstance(blob, dict) or blob.get("scope") != scope:
+        blob = {"scope": scope, "passed": [], "next_at": {}, "started": {}}
+        session[GATE_SESSION_KEY] = blob
+    return blob
+
+
+def _save(blob: dict[str, Any]) -> None:
+    session[GATE_SESSION_KEY] = blob
+    session.modified = True
+
+
+def clear() -> None:
+    """Forget every gate for this session (wizard completion, invite reset)."""
+    session.pop(GATE_SESSION_KEY, None)
+
+
+def has_passed(step_id: int | None) -> bool:
+    if step_id is None:
+        return False
+    return step_id in _state().get("passed", [])
+
+
+def mark_passed(step_id: int | None) -> None:
+    if step_id is None:
+        return
+    blob = _state()
+    if step_id not in blob["passed"]:
+        blob["passed"].append(step_id)
+    blob["next_at"].pop(str(step_id), None)
+    _save(blob)
+
+
+def note_poll_started(step_id: int | None) -> None:
+    """Record when polling for *step_id* began, so the cap can be applied."""
+    if step_id is None:
+        return
+    blob = _state()
+    blob["started"].setdefault(str(step_id), time.time())
+    _save(blob)
+
+
+def is_capped(step_id: int | None, *, max_poll_seconds: int) -> bool:
+    """Whether automatic polling has run long enough to give up on its own."""
+    if step_id is None:
+        return False
+    started = _state().get("started", {}).get(str(step_id))
+    return bool(started) and (time.time() - started) > max_poll_seconds
+
+
+def _prune(now: float) -> None:
+    for key, seen in list(_IN_PROCESS_CALLS.items()):
+        if now - seen > _IN_PROCESS_TTL:
+            del _IN_PROCESS_CALLS[key]
+
+
+def reserve(step_id: int | None, *, interval: int) -> float:
+    """Atomically claim the next upstream call slot for *step_id*.
+
+    Returns ``0.0`` when the caller may make the call, otherwise the seconds
+    still to wait. The slot is claimed *before* the upstream request so that
+    parallel requests cannot each decide they are first.
+    """
+    if step_id is None:
+        return 0.0
+
+    with _CALL_LOCK:
+        now = time.time()
+        _prune(now)
+        key = f"{_scope()}:{step_id}"
+
+        blob = _state()
+        session_next = float(blob.get("next_at", {}).get(str(step_id), 0) or 0)
+        process_next = _IN_PROCESS_CALLS.get(key, 0.0) + interval
+        allowed_at = max(session_next, process_next)
+
+        if now < allowed_at:
+            return allowed_at - now
+
+        _IN_PROCESS_CALLS[key] = now
+        blob["next_at"][str(step_id)] = now + interval
+        blob["started"].setdefault(str(step_id), now)
+        _save(blob)
+        return 0.0
+
+
+def first_locked_index(steps: list, *, exempt: bool) -> int | None:
+    """Index of the earliest step whose gate is still unsatisfied.
+
+    ``None`` means the user may go anywhere in *steps*. Admins are exempt so
+    previewing a wizard never traps them behind their own gate.
+    """
+    if exempt:
+        return None
+
+    passed = set(_state().get("passed", []))
+    for index, item in enumerate(steps):
+        config = getattr(item, "api_check", None)
+        step_id = getattr(item, "step_id", None)
+        if (
+            config is not None
+            and config.is_active
+            and step_id is not None
+            and step_id not in passed
+        ):
+            return index
+    return None

--- a/app/services/wizard_export_import.py
+++ b/app/services/wizard_export_import.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.extensions import db
 from app.models import WizardBundle, WizardBundleStep, WizardStep
+from app.services.wizard_api_check.config import normalize, public_view
 
 
 @dataclass(frozen=True)
@@ -25,10 +26,12 @@ class WizardStepDTO:
     requires: list[str] | None
     require_interaction: bool = False
     category: str = "post_invite"  # NEW: Category field for pre/post-invite distinction
+    api_check: dict[str, Any] | None = None
 
     @classmethod
     def from_model(cls, step: WizardStep) -> WizardStepDTO:
         """Create DTO from WizardStep model."""
+        category = getattr(step, "category", "post_invite")
         return cls(
             server_type=step.server_type,
             position=step.position,
@@ -36,7 +39,10 @@ class WizardStepDTO:
             markdown=step.markdown,
             requires=step.requires or [],
             require_interaction=bool(getattr(step, "require_interaction", False)),
-            category=getattr(step, "category", "post_invite"),  # NEW: Include category
+            category=category,  # NEW: Include category
+            # Redacted view: the encrypted credential must never reach an
+            # export file, even though the rest of the gate config should.
+            api_check=public_view(step.api_check, category=category),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -49,6 +55,7 @@ class WizardStepDTO:
             "requires": self.requires or [],
             "require_interaction": bool(self.require_interaction),
             "category": self.category,  # NEW: Include category in export
+            "api_check": self.api_check,
         }
 
 
@@ -108,6 +115,18 @@ class WizardImportResult:
     skipped_count: int
     updated_count: int
     errors: list[str]
+
+
+def _imported_api_check(step_data: dict[str, Any], category: str) -> dict[str, Any]:
+    """Normalize an imported gate config with the credential stripped.
+
+    An import must never set a credential - combined with ``is_active``
+    requiring one for a signed gate, that leaves an imported signed gate
+    inert until an admin supplies a key by hand, so a shared JSON file can
+    never lock anyone out against a stranger's endpoint.
+    """
+    cfg = normalize(step_data.get("api_check"), category=category)
+    return cfg.without_key().to_dict()
 
 
 class WizardExportImportService:
@@ -195,7 +214,6 @@ class WizardExportImportService:
         """
         errors = []
 
-        # Check export type
         export_type = data.get("export_type", "steps")
         if export_type not in ["steps", "bundle"]:
             errors.append("Invalid export_type, must be 'steps' or 'bundle'")
@@ -320,6 +338,15 @@ class WizardExportImportService:
                     f"Step {index}: 'category' must be 'pre_invite' or 'post_invite'"
                 )
 
+        # NEW: api_check is untrusted input from here on - normalize() is what
+        # actually validates its contents, this just rejects the wrong shape.
+        if (
+            "api_check" in step
+            and step["api_check"] is not None
+            and not isinstance(step["api_check"], dict)
+        ):
+            errors.append(f"Step {index}: 'api_check' must be an object or null")
+
         return errors
 
     def import_data(
@@ -427,8 +454,10 @@ class WizardExportImportService:
                                         step_data.get("require_interaction") or False
                                     )
                                 # NEW: Update category with backward compatibility
-                                existing_step.category = step_data.get(
-                                    "category", "post_invite"
+                                category = step_data.get("category", "post_invite")
+                                existing_step.category = category
+                                existing_step.api_check = _imported_api_check(
+                                    step_data, category
                                 )
                                 updated_count += 1
                                 continue
@@ -438,6 +467,9 @@ class WizardExportImportService:
                             next_position += 1
                         else:
                             position = step_data["position"]
+
+                        # NEW: Include category with backward compatibility default
+                        category = step_data.get("category", "post_invite")
 
                         # Create new step
                         new_step = WizardStep(
@@ -449,8 +481,8 @@ class WizardExportImportService:
                             require_interaction=bool(
                                 step_data.get("require_interaction") or False
                             ),
-                            # NEW: Include category with backward compatibility default
-                            category=step_data.get("category", "post_invite"),
+                            category=category,
+                            api_check=_imported_api_check(step_data, category),
                         )
                         self.session.add(new_step)
                         imported_count += 1
@@ -544,6 +576,9 @@ class WizardExportImportService:
 
             for bundle_position, step_data in enumerate(bundle_data["steps"]):
                 try:
+                    # NEW: Include category with backward compatibility default
+                    category = step_data.get("category", "post_invite")
+
                     # Create the wizard step with server_type "custom"
                     wizard_step = WizardStep(
                         server_type="custom",
@@ -554,8 +589,8 @@ class WizardExportImportService:
                         require_interaction=bool(
                             step_data.get("require_interaction") or False
                         ),
-                        # NEW: Include category with backward compatibility default
-                        category=step_data.get("category", "post_invite"),
+                        category=category,
+                        api_check=_imported_api_check(step_data, category),
                     )
                     self.session.add(wizard_step)
                     self.session.flush()  # Get the step ID

--- a/app/services/wizard_widgets.py
+++ b/app/services/wizard_widgets.py
@@ -18,9 +18,14 @@ import re
 from typing import Any
 
 import markdown
-from flask import render_template_string
+from flask import render_template, render_template_string, url_for
 
 from app.services.media.service import get_media_client
+from app.services.wizard_api_check.config import DEFAULT_INTERVAL
+
+# Exported so other modules (e.g. the wizard step editor) can detect the
+# placeholder without depending on the widget registry.
+API_CHECK_PLACEHOLDER_RE = re.compile(r"\{\{\s*widget:api_check\b")
 
 
 class WizardWidget:
@@ -289,10 +294,71 @@ class ButtonWidget(WizardWidget):
             return f'\n\n<div class="text-sm text-gray-500 italic">Button widget error: {e}</div>\n\n'
 
 
+def _neutralize_jinja(html: str) -> str:
+    """Strip every brace from rendered widget HTML.
+
+    ``_render`` re-parses widget output as a Jinja template with autoescape
+    off, so any ``{{``/``{%`` that survives here would execute against that
+    template's context (e.g. leaking ``config.SECRET_KEY``). ``html.escape``
+    does not touch braces, so this is what actually neutralises admin-authored
+    text - applied after render_template, it also catches braces the config
+    layer's own filter might miss (e.g. lone ``{``/``}``).
+    """
+    return html.replace("{", "&#123;").replace("}", "&#125;")
+
+
+class ApiCheckWidget(WizardWidget):
+    """Widget for the wizard API-check gate's status card."""
+
+    def __init__(self):
+        # Empty template since we'll override render
+        super().__init__("api_check", "")
+
+    def render(self, server_type: str, _context: dict | None = None, **kwargs) -> str:  # noqa: ARG002
+        """Render the gate's status card, ignoring every markdown parameter.
+
+        Params on the placeholder must not be able to redirect the check or
+        change its timing, so only ``_context`` (server-derived) is trusted.
+        """
+        try:
+            context = _context or {}
+            step_id = context.get("wizard_step_id")
+            view = context.get("wizard_api_check")
+            if (
+                step_id is None
+                or not isinstance(view, dict)
+                or not view.get("is_active")
+            ):
+                return ""
+
+            passed = bool(context.get("wizard_gate_passed"))
+            interval = view.get("interval_seconds") or DEFAULT_INTERVAL
+
+            html_content = render_template(
+                "wizard/_api_check_card.html",
+                step_id=step_id,
+                state="passed" if passed else "pending",
+                message=view.get("success_message")
+                if passed
+                else view.get("pending_message"),
+                interval=interval,
+                retry_after=0,
+                check_url=url_for("wizard.api_check", step_id=step_id),
+                show_button=not passed,
+                trigger="" if passed else f"load, every {interval}s",
+            )
+            html_content = _neutralize_jinja(html_content)
+            return f'\n\n<div class="widget-container">\n{html_content}\n</div>\n\n'
+        except Exception:
+            # Fail gracefully in wizard context
+            return f'\n\n<div class="text-sm text-gray-500 italic">Widget "{self.name}" temporarily unavailable</div>\n\n'
+
+
 # Widget registry
 WIDGET_REGISTRY = {
     "recently_added_media": RecentlyAddedMediaWidget(),
     "button": ButtonWidget(),
+    "api_check": ApiCheckWidget(),
 }
 
 

--- a/app/static/js/wizard-steps.js
+++ b/app/static/js/wizard-steps.js
@@ -364,8 +364,11 @@ function attachInteractionGating(root = document) {
   // Single interaction handler for the content area
   function handler(ev) {
     const t = ev.target;
-    if (!t) return;
-    if (t.closest && t.closest('a,button') !== null) enableAllButtons();
+    if (!t || !t.closest) return;
+    // Opt-out rather than opt-in: every existing step relies on any link or
+    // button unlocking Next, so only marked controls are excluded.
+    if (t.closest('[data-wizard-no-unlock]')) return;
+    if (t.closest('a,button') !== null) enableAllButtons();
   }
 
   // Listen for any click within the content that bubbles/captures from links/buttons
@@ -374,7 +377,16 @@ function attachInteractionGating(root = document) {
     content.addEventListener('click', handler, true);
     content._interactionHandler = handler; // Store for cleanup
   }
+
+  window.unlockWizardNavButtons = enableAllButtons;
 }
+
+// Fired by the api-check endpoint (HX-Trigger) the moment a gate passes.
+document.body.addEventListener('wizard:gate-passed', () => {
+  if (typeof window.unlockWizardNavButtons === 'function') {
+    window.unlockWizardNavButtons();
+  }
+});
 
 document.addEventListener('DOMContentLoaded', () => {
   attachSortableLists();

--- a/app/templates/modals/_wizard_api_check_fields.html
+++ b/app/templates/modals/_wizard_api_check_fields.html
@@ -1,0 +1,167 @@
+{# Shared "API Gate" fields for the wizard step admin forms. Included from
+   both step modals and both full-page fallbacks so they cannot drift out of
+   sync. Visibility depends on the including template exposing an Alpine
+   `apiCheckCategory` binding on the category select (see the x-data on its
+   <form> tag) - the gate only ever applies to post-invite steps, since that
+   is the earliest point a username and email exist to check against. #}
+<div x-show="apiCheckCategory === 'post_invite'"
+     class="pt-4 border-t border-gray-200 dark:border-gray-600">
+  <div x-data="{ show: {{ 'true' if form.api_check_enabled.data else 'false' }} }">
+    <button type="button"
+            @click="show = !show"
+            class="inline-flex items-center text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-primary transition-colors">
+      <svg class="w-4 h-4 mr-2 transition-transform"
+           :class="{ 'rotate-90': show }"
+           fill="none"
+           stroke="currentColor"
+           viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+      </svg>
+      {{ _("API Gate") }}
+    </button>
+    <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
+      {{ _("Blocks this step until an external API confirms the invited user. The check identifies them by username and email, which only exist once the invitation has been accepted.") }}
+    </p>
+    <div x-show="show" x-transition class="mt-4 space-y-4">
+      <div class="flex items-start gap-3">
+        {{ form.api_check_enabled(class="h-5 w-5 text-primary rounded focus:ring-primary") }}
+        <div class="flex flex-col">
+          <label for="{{ form.api_check_enabled.id }}"
+                 class="text-sm font-medium text-gray-900 dark:text-white select-none">
+            {{ form.api_check_enabled.label.text }}
+          </label>
+          <span class="text-xs text-gray-500 dark:text-gray-400">{{ form.api_check_enabled.description }}</span>
+          {% for err in form.api_check_enabled.errors %}
+            <p class="text-xs text-red-600 dark:text-red-500 mt-1">{{ err }}</p>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
+        <div>
+          {{ form.api_check_method.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_method(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_method.description }}</p>
+        </div>
+        <div class="sm:col-span-3">
+          {{ form.api_check_url.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_url(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white", placeholder="https://example.com/check") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_url.description }}</p>
+          {% for err in form.api_check_url.errors %}
+            <p class="text-xs text-red-600 dark:text-red-500 mt-1">{{ err }}</p>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          {{ form.api_check_auth_header.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_auth_header(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white", placeholder="Authorization") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_auth_header.description }}</p>
+        </div>
+        <div>
+          {{ form.api_check_auth_prefix.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_auth_prefix(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white", placeholder="Bearer ") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_auth_prefix.description }}</p>
+        </div>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          {{ form.api_check_api_key.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_api_key(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white", autocomplete="new-password") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_api_key.description }}</p>
+          {% if has_api_key %}
+            <p class="text-xs text-green-600 dark:text-green-400 mt-1">{{ _("A key is currently saved for this step.") }}</p>
+          {% endif %}
+          {% for err in form.api_check_api_key.errors %}
+            <p class="text-xs text-red-600 dark:text-red-500 mt-1">{{ err }}</p>
+          {% endfor %}
+        </div>
+        <div class="flex items-start gap-3 sm:pt-7">
+          {{ form.api_check_clear_key(class="h-5 w-5 text-primary rounded focus:ring-primary") }}
+          <div class="flex flex-col">
+            <label for="{{ form.api_check_clear_key.id }}"
+                   class="text-sm font-medium text-gray-900 dark:text-white select-none">
+              {{ form.api_check_clear_key.label.text }}
+            </label>
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ form.api_check_clear_key.description }}</span>
+          </div>
+        </div>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div>
+          {{ form.api_check_code_param.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_code_param(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_code_param.description }}</p>
+        </div>
+        <div>
+          {{ form.api_check_username_param.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_username_param(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_username_param.description }}</p>
+        </div>
+        <div>
+          {{ form.api_check_email_param.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_email_param(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_email_param.description }}</p>
+        </div>
+      </div>
+      <div>
+        {{ form.api_check_expect_status.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+        {{ form.api_check_expect_status(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white", placeholder="200, 204") }}
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_expect_status.description }}</p>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div>
+          {{ form.api_check_interval_seconds.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_interval_seconds(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_interval_seconds.description }}</p>
+          {% for err in form.api_check_interval_seconds.errors %}
+            <p class="text-xs text-red-600 dark:text-red-500 mt-1">{{ err }}</p>
+          {% endfor %}
+        </div>
+        <div>
+          {{ form.api_check_timeout_seconds.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_timeout_seconds(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_timeout_seconds.description }}</p>
+          {% for err in form.api_check_timeout_seconds.errors %}
+            <p class="text-xs text-red-600 dark:text-red-500 mt-1">{{ err }}</p>
+          {% endfor %}
+        </div>
+        <div>
+          {{ form.api_check_max_poll_seconds.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_max_poll_seconds(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_max_poll_seconds.description }}</p>
+          {% for err in form.api_check_max_poll_seconds.errors %}
+            <p class="text-xs text-red-600 dark:text-red-500 mt-1">{{ err }}</p>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="flex items-start gap-3">
+        {{ form.api_check_sign_requests(class="h-5 w-5 text-primary rounded focus:ring-primary") }}
+        <div class="flex flex-col">
+          <label for="{{ form.api_check_sign_requests.id }}"
+                 class="text-sm font-medium text-gray-900 dark:text-white select-none">
+            {{ form.api_check_sign_requests.label.text }}
+          </label>
+          <span class="text-xs text-gray-500 dark:text-gray-400">{{ form.api_check_sign_requests.description }}</span>
+        </div>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          {{ form.api_check_pending_message.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_pending_message(rows="2", class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_pending_message.description }}</p>
+          {% for err in form.api_check_pending_message.errors %}
+            <p class="text-xs text-red-600 dark:text-red-500 mt-1">{{ err }}</p>
+          {% endfor %}
+        </div>
+        <div>
+          {{ form.api_check_success_message.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+          {{ form.api_check_success_message(rows="2", class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ form.api_check_success_message.description }}</p>
+          {% for err in form.api_check_success_message.errors %}
+            <p class="text-xs text-red-600 dark:text-red-500 mt-1">{{ err }}</p>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/templates/modals/_wizard_widget_picker.html
+++ b/app/templates/modals/_wizard_widget_picker.html
@@ -1,0 +1,207 @@
+{# Shared "Add..." widget/element picker for the markdown editor toolbar.
+   Included from both wizard-step-form.html and wizard-simple-step-form.html
+   so the two modals cannot drift out of sync. #}
+<div class="relative" x-data="{ open: false }">
+  <button @click="open = !open"
+          @click.away="open = false"
+          type="button"
+          class="inline-flex items-center gap-2 px-3 py-2 bg-primary hover:bg-primary/90 text-white text-sm font-medium rounded-lg transition-colors duration-200 shadow-sm">
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+    </svg>
+    {{ _("Add...") }}
+    <svg class="w-4 h-4 transition-transform duration-200"
+         :class="{ 'rotate-180': open }"
+         fill="currentColor"
+         viewBox="0 0 24 24">
+      <path d="M7 10l5 5 5-5z" />
+    </svg>
+  </button>
+  <!-- Dropdown Menu -->
+  <div x-show="open"
+       x-transition:enter="transition ease-out duration-100"
+       x-transition:enter-start="transform opacity-0 scale-95"
+       x-transition:enter-end="transform opacity-100 scale-100"
+       x-transition:leave="transition ease-in duration-75"
+       x-transition:leave-start="transform opacity-100 scale-100"
+       x-transition:leave-end="transform opacity-0 scale-95"
+       class="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-10">
+    <div class="p-1">
+      <!-- Widgets Section -->
+      <div class="px-3 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider border-b border-gray-200 dark:border-gray-700 mb-1">
+        {{ _("Widgets") }}
+      </div>
+      <button type="button"
+              onclick="insertWidget('recently_added_media')"
+              @click="open = false"
+              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
+        <div class="flex-shrink-0 w-8 h-8 bg-blue-500/10 rounded-lg flex items-center justify-center">
+          <svg class="w-4 h-4 text-blue-500" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9h-4v4h-2v-4H9V9h4V5h2v4h4v2z" />
+          </svg>
+        </div>
+        <div class="text-left">
+          <div class="font-medium">{{ _("Recently Added Media") }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400">{{ _("Show recent content") }}</div>
+        </div>
+      </button>
+      <button type="button"
+              onclick="insertWidget('button')"
+              @click="open = false"
+              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
+        <div class="flex-shrink-0 w-8 h-8 bg-green-500/10 rounded-lg flex items-center justify-center">
+          <svg class="w-4 h-4 text-green-500"
+               fill="none"
+               stroke="currentColor"
+               viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+          </svg>
+        </div>
+        <div class="text-left">
+          <div class="font-medium">{{ _("Button") }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400">{{ _("Add a clickable link button") }}</div>
+        </div>
+      </button>
+      <button type="button"
+              onclick="insertWidget('api_check')"
+              @click="open = false"
+              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
+        <div class="flex-shrink-0 w-8 h-8 bg-indigo-500/10 rounded-lg flex items-center justify-center">
+          <svg class="w-4 h-4 text-indigo-500"
+               fill="none"
+               stroke="currentColor"
+               viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+          </svg>
+        </div>
+        <div class="text-left">
+          <div class="font-medium">{{ _("API Gate") }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400">{{ _("Show the gate's verification status") }}</div>
+        </div>
+      </button>
+      <!-- Elements Section -->
+      <div class="px-3 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider border-b border-gray-200 dark:border-gray-700 mb-1 mt-2">
+        {{ _("Elements") }}
+      </div>
+      <button type="button"
+              onclick="insertCard()"
+              @click="open = false"
+              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
+        <div class="flex-shrink-0 w-8 h-8 bg-purple-500/10 rounded-lg flex items-center justify-center">
+          <svg class="w-4 h-4 text-purple-500"
+               fill="currentColor"
+               viewBox="0 0 24 24">
+            <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z" />
+          </svg>
+        </div>
+        <div class="text-left">
+          <div class="font-medium">{{ _("Card") }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400">{{ _("Add a styled content card") }}</div>
+        </div>
+      </button>
+    </div>
+  </div>
+</div>
+<script>
+    function insertWidget(widgetType) {
+        // Don't process empty values (from the placeholder option)
+        if (!widgetType) {
+            return;
+        }
+
+        // Widget syntax based on type
+        let widgetSyntax = '';
+        switch (widgetType) {
+            case 'recently_added_media':
+                widgetSyntax = '\n\n{' + '{ widget:recently_added_media }' + '}\n\n';
+                break;
+            case 'button':
+                widgetSyntax = '\n\n{' + '{ widget:button url="https://example.com" text="Click Here" }' + '}\n\n';
+                break;
+            case 'api_check':
+                widgetSyntax = '\n\n{' + '{ widget:api_check }' + '}\n\n';
+                break;
+            default:
+                widgetSyntax = '\n\n{' + '{ widget:' + widgetType + ' }' + '}\n\n';
+        }
+
+        // Find the textarea
+        const modal = document.getElementById('step-modal') || document;
+        const textarea = modal.querySelector('textarea[name="markdown"]');
+
+        if (!textarea) {
+            alert('Could not find textarea');
+            return;
+        }
+
+        // Check if TinyMDE editor exists
+        if (textarea.tinyMDEEditor) {
+            // Use TinyMDE's proper API to insert content
+            textarea.tinyMDEEditor.paste(widgetSyntax);
+        } else if (window.TinyMDE && textarea.dataset.tinymdeAttached) {
+            // Try to find the TinyMDE instance another way
+            // Look for the TinyMDE editor in the DOM structure
+            const editorElement = textarea.nextElementSibling;
+            if (editorElement && editorElement._tinyMDEInstance) {
+                editorElement._tinyMDEInstance.paste(widgetSyntax);
+            } else {
+                // Fallback: direct textarea manipulation (clean)
+                const cursorPos = textarea.selectionStart || textarea.value.length;
+                const textBefore = textarea.value.substring(0, cursorPos);
+                const textAfter = textarea.value.substring(textarea.selectionEnd || cursorPos);
+
+                textarea.value = textBefore + widgetSyntax + textAfter;
+                textarea.dispatchEvent(new Event('input', {
+                    bubbles: true
+                }));
+            }
+        } else {
+            // No TinyMDE, direct textarea manipulation
+            const cursorPos = textarea.selectionStart || textarea.value.length;
+            const textBefore = textarea.value.substring(0, cursorPos);
+            const textAfter = textarea.value.substring(textarea.selectionEnd || cursorPos);
+
+            textarea.value = textBefore + widgetSyntax + textAfter;
+            textarea.focus();
+        }
+    }
+
+    function insertCard() {
+        const cardSyntax = '\n\n|||\n# Card Title\n\nYour card content here. Supports **markdown** formatting.\n\n* Bullet points\n* Work too\n\n|||\n\n';
+
+        // Find the textarea
+        const modal = document.getElementById('step-modal') || document;
+        const textarea = modal.querySelector('textarea[name="markdown"]');
+
+        if (!textarea) {
+            alert('Could not find textarea');
+            return;
+        }
+
+        // Check if TinyMDE editor exists
+        if (textarea.tinyMDEEditor) {
+            textarea.tinyMDEEditor.paste(cardSyntax);
+        } else if (window.TinyMDE && textarea.dataset.tinymdeAttached) {
+            const editorElement = textarea.nextElementSibling;
+            if (editorElement && editorElement._tinyMDEInstance) {
+                editorElement._tinyMDEInstance.paste(cardSyntax);
+            } else {
+                const cursorPos = textarea.selectionStart || textarea.value.length;
+                const textBefore = textarea.value.substring(0, cursorPos);
+                const textAfter = textarea.value.substring(textarea.selectionEnd || cursorPos);
+
+                textarea.value = textBefore + cardSyntax + textAfter;
+                textarea.dispatchEvent(new Event('input', {
+                    bubbles: true
+                }));
+            }
+        } else {
+            const cursorPos = textarea.selectionStart || textarea.value.length;
+            const textBefore = textarea.value.substring(0, cursorPos);
+            const textAfter = textarea.value.substring(textarea.selectionEnd || cursorPos);
+
+            textarea.value = textBefore + cardSyntax + textAfter;
+            textarea.focus();
+        }
+    }
+</script>

--- a/app/templates/modals/wizard-simple-step-form.html
+++ b/app/templates/modals/wizard-simple-step-form.html
@@ -16,11 +16,12 @@
                 method="post"
                 hx-post="{{ request.path }}{{ '?' + request.query_string.decode("utf-8") if request.query_string else '' }}"
                 hx-target="#tab-body"
-                hx-swap="innerHTML">
+                hx-swap="innerHTML"
+                x-data="{ apiCheckCategory: '{{ form.category.data or 'post_invite' }}' }">
             {{ form.hidden_tag() }}
             <div>
               {{ form.category.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
-              {{ form.category(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+              {{ form.category(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white", **{"x-model": "apiCheckCategory"}) }}
               <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ _("Choose when this step should be shown to users") }}</p>
             </div>
             <div>
@@ -28,7 +29,10 @@
               {{ form.title(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
             </div>
             <div>
-              {{ form.markdown.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
+              <div class="flex justify-between items-center mb-1">
+                {{ form.markdown.label(class="text-sm font-medium text-gray-900 dark:text-white") }}
+                {% include "modals/_wizard_widget_picker.html" %}
+              </div>
               {{ form.markdown(rows="10", class="hidden", id="markdown-textarea") }}
             </div>
             <div class="flex items-start gap-3 mt-2">
@@ -41,6 +45,7 @@
                 <span class="text-xs text-gray-500 dark:text-gray-400">{{ form.require_interaction.description }}</span>
               </div>
             </div>
+            {% include "modals/_wizard_api_check_fields.html" %}
             <div class="flex gap-2 justify-end pt-4">
               <button type="button"
                       onclick="document.getElementById('step-modal').innerHTML=''"

--- a/app/templates/modals/wizard-step-form.html
+++ b/app/templates/modals/wizard-step-form.html
@@ -17,7 +17,8 @@
                 method="post"
                 hx-post="{{ request.path }}"
                 hx-target="#tab-body"
-                hx-swap="innerHTML">
+                hx-swap="innerHTML"
+                x-data="{ apiCheckCategory: '{{ form.category.data or 'post_invite' }}' }">
             {{ form.hidden_tag() }}
             <div>
               {{ form.server_type.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
@@ -25,7 +26,7 @@
             </div>
             <div>
               {{ form.category.label(class="block mb-1 text-sm font-medium text-gray-900 dark:text-white") }}
-              {{ form.category(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white") }}
+              {{ form.category(class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white", **{"x-model": "apiCheckCategory"}) }}
               <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ _("Choose when this step should be shown to users") }}</p>
             </div>
             <div>
@@ -35,90 +36,7 @@
             <div>
               <div class="flex justify-between items-center mb-1">
                 {{ form.markdown.label(class="text-sm font-medium text-gray-900 dark:text-white") }}
-                <div class="relative" x-data="{ open: false }">
-                  <button @click="open = !open"
-                          @click.away="open = false"
-                          type="button"
-                          class="inline-flex items-center gap-2 px-3 py-2 bg-primary hover:bg-primary/90 text-white text-sm font-medium rounded-lg transition-colors duration-200 shadow-sm">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
-                    </svg>
-                    {{ _("Add...") }}
-                    <svg class="w-4 h-4 transition-transform duration-200"
-                         :class="{ 'rotate-180': open }"
-                         fill="currentColor"
-                         viewBox="0 0 24 24">
-                      <path d="M7 10l5 5 5-5z" />
-                    </svg>
-                  </button>
-                  <!-- Dropdown Menu -->
-                  <div x-show="open"
-                       x-transition:enter="transition ease-out duration-100"
-                       x-transition:enter-start="transform opacity-0 scale-95"
-                       x-transition:enter-end="transform opacity-100 scale-100"
-                       x-transition:leave="transition ease-in duration-75"
-                       x-transition:leave-start="transform opacity-100 scale-100"
-                       x-transition:leave-end="transform opacity-0 scale-95"
-                       class="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-10">
-                    <div class="p-1">
-                      <!-- Widgets Section -->
-                      <div class="px-3 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider border-b border-gray-200 dark:border-gray-700 mb-1">
-                        {{ _("Widgets") }}
-                      </div>
-                      <button type="button"
-                              onclick="insertWidget('recently_added_media')"
-                              @click="open = false"
-                              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
-                        <div class="flex-shrink-0 w-8 h-8 bg-blue-500/10 rounded-lg flex items-center justify-center">
-                          <svg class="w-4 h-4 text-blue-500" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9h-4v4h-2v-4H9V9h4V5h2v4h4v2z" />
-                          </svg>
-                        </div>
-                        <div class="text-left">
-                          <div class="font-medium">{{ _("Recently Added Media") }}</div>
-                          <div class="text-xs text-gray-500 dark:text-gray-400">{{ _("Show recent content") }}</div>
-                        </div>
-                      </button>
-                      <button type="button"
-                              onclick="insertWidget('button')"
-                              @click="open = false"
-                              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
-                        <div class="flex-shrink-0 w-8 h-8 bg-green-500/10 rounded-lg flex items-center justify-center">
-                          <svg class="w-4 h-4 text-green-500"
-                               fill="none"
-                               stroke="currentColor"
-                               viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                          </svg>
-                        </div>
-                        <div class="text-left">
-                          <div class="font-medium">{{ _("Button") }}</div>
-                          <div class="text-xs text-gray-500 dark:text-gray-400">{{ _("Add a clickable link button") }}</div>
-                        </div>
-                      </button>
-                      <!-- Elements Section -->
-                      <div class="px-3 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider border-b border-gray-200 dark:border-gray-700 mb-1 mt-2">
-                        {{ _("Elements") }}
-                      </div>
-                      <button type="button"
-                              onclick="insertCard()"
-                              @click="open = false"
-                              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
-                        <div class="flex-shrink-0 w-8 h-8 bg-purple-500/10 rounded-lg flex items-center justify-center">
-                          <svg class="w-4 h-4 text-purple-500"
-                               fill="currentColor"
-                               viewBox="0 0 24 24">
-                            <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z" />
-                          </svg>
-                        </div>
-                        <div class="text-left">
-                          <div class="font-medium">{{ _("Card") }}</div>
-                          <div class="text-xs text-gray-500 dark:text-gray-400">{{ _("Add a styled content card") }}</div>
-                        </div>
-                      </button>
-                    </div>
-                  </div>
-                </div>
+                {% include "modals/_wizard_widget_picker.html" %}
               </div>
               {{ form.markdown(rows="10", class="hidden", id="markdown-textarea") }}
             </div>
@@ -132,6 +50,7 @@
                 <span class="text-xs text-gray-500 dark:text-gray-400">{{ form.require_interaction.description }}</span>
               </div>
             </div>
+            {% include "modals/_wizard_api_check_fields.html" %}
             <div class="flex gap-2 justify-end pt-4">
               <button type="button"
                       onclick="document.getElementById('step-modal').innerHTML=''"
@@ -146,103 +65,3 @@
     </div>
   </div>
 </div>
-<script>
-    function insertWidget(widgetType) {
-        // Don't process empty values (from the placeholder option)
-        if (!widgetType) {
-            return;
-        }
-
-        // Widget syntax based on type
-        let widgetSyntax = '';
-        switch (widgetType) {
-            case 'recently_added_media':
-                widgetSyntax = '\n\n{' + '{ widget:recently_added_media }' + '}\n\n';
-                break;
-            case 'button':
-                widgetSyntax = '\n\n{' + '{ widget:button url="https://example.com" text="Click Here" }' + '}\n\n';
-                break;
-            default:
-                widgetSyntax = '\n\n{' + '{ widget:' + widgetType + ' }' + '}\n\n';
-        }
-
-        // Find the textarea
-        const modal = document.getElementById('step-modal') || document;
-        const textarea = modal.querySelector('textarea[name="markdown"]');
-
-        if (!textarea) {
-            alert('Could not find textarea');
-            return;
-        }
-
-        // Check if TinyMDE editor exists
-        if (textarea.tinyMDEEditor) {
-            // Use TinyMDE's proper API to insert content
-            textarea.tinyMDEEditor.paste(widgetSyntax);
-        } else if (window.TinyMDE && textarea.dataset.tinymdeAttached) {
-            // Try to find the TinyMDE instance another way
-            // Look for the TinyMDE editor in the DOM structure
-            const editorElement = textarea.nextElementSibling;
-            if (editorElement && editorElement._tinyMDEInstance) {
-                editorElement._tinyMDEInstance.paste(widgetSyntax);
-            } else {
-                // Fallback: direct textarea manipulation (clean)
-                const cursorPos = textarea.selectionStart || textarea.value.length;
-                const textBefore = textarea.value.substring(0, cursorPos);
-                const textAfter = textarea.value.substring(textarea.selectionEnd || cursorPos);
-
-                textarea.value = textBefore + widgetSyntax + textAfter;
-                textarea.dispatchEvent(new Event('input', {
-                    bubbles: true
-                }));
-            }
-        } else {
-            // No TinyMDE, direct textarea manipulation
-            const cursorPos = textarea.selectionStart || textarea.value.length;
-            const textBefore = textarea.value.substring(0, cursorPos);
-            const textAfter = textarea.value.substring(textarea.selectionEnd || cursorPos);
-
-            textarea.value = textBefore + widgetSyntax + textAfter;
-            textarea.focus();
-        }
-    }
-
-    function insertCard() {
-        const cardSyntax = '\n\n|||\n# Card Title\n\nYour card content here. Supports **markdown** formatting.\n\n* Bullet points\n* Work too\n\n|||\n\n';
-
-        // Find the textarea
-        const modal = document.getElementById('step-modal') || document;
-        const textarea = modal.querySelector('textarea[name="markdown"]');
-
-        if (!textarea) {
-            alert('Could not find textarea');
-            return;
-        }
-
-        // Check if TinyMDE editor exists
-        if (textarea.tinyMDEEditor) {
-            textarea.tinyMDEEditor.paste(cardSyntax);
-        } else if (window.TinyMDE && textarea.dataset.tinymdeAttached) {
-            const editorElement = textarea.nextElementSibling;
-            if (editorElement && editorElement._tinyMDEInstance) {
-                editorElement._tinyMDEInstance.paste(cardSyntax);
-            } else {
-                const cursorPos = textarea.selectionStart || textarea.value.length;
-                const textBefore = textarea.value.substring(0, cursorPos);
-                const textAfter = textarea.value.substring(textarea.selectionEnd || cursorPos);
-
-                textarea.value = textBefore + cardSyntax + textAfter;
-                textarea.dispatchEvent(new Event('input', {
-                    bubbles: true
-                }));
-            }
-        } else {
-            const cursorPos = textarea.selectionStart || textarea.value.length;
-            const textBefore = textarea.value.substring(0, cursorPos);
-            const textAfter = textarea.value.substring(textarea.selectionEnd || cursorPos);
-
-            textarea.value = textBefore + cardSyntax + textAfter;
-            textarea.focus();
-        }
-    }
-</script>

--- a/app/templates/settings/wizard/form.html
+++ b/app/templates/settings/wizard/form.html
@@ -3,7 +3,9 @@
   <h1 class="text-xl font-bold mb-4 text-gray-900 dark:text-white">
     {{ _(action == 'create' and 'Create Wizard Step' or 'Edit Wizard Step') }}
   </h1>
-  <form method="post" class="space-y-4">
+  <form method="post"
+        class="space-y-4"
+        x-data="{ apiCheckCategory: '{{ form.category.data or 'post_invite' }}' }">
     <div>
       {{ form.server_type.label(class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300") }}
       {{ form.server_type(class="w-full border rounded p-2 dark:bg-gray-700 dark:border-gray-600") }}
@@ -26,6 +28,7 @@
         <span class="text-xs text-gray-500 dark:text-gray-400">{{ form.require_interaction.description }}</span>
       </div>
     </div>
+    {% include "modals/_wizard_api_check_fields.html" %}
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 rounded bg-primary text-white">{{ _("Save") }}</button>
       <button type="button"

--- a/app/templates/settings/wizard/simple_form.html
+++ b/app/templates/settings/wizard/simple_form.html
@@ -3,7 +3,9 @@
   <h1 class="text-xl font-bold mb-4 text-gray-900 dark:text-white">
     {{ _(action == 'create' and 'Create Step' or 'Edit Step') }}
   </h1>
-  <form method="post" class="space-y-4">
+  <form method="post"
+        class="space-y-4"
+        x-data="{ apiCheckCategory: '{{ form.category.data or 'post_invite' }}' }">
     <div>
       {{ form.title.label(class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-300") }}
       {{ form.title(class="w-full border rounded p-2 dark:bg-gray-700 dark:border-gray-600") }}
@@ -22,6 +24,7 @@
         <span class="text-xs text-gray-500 dark:text-gray-400">{{ form.require_interaction.description }}</span>
       </div>
     </div>
+    {% include "modals/_wizard_api_check_fields.html" %}
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 rounded bg-primary text-white">{{ _("Save") }}</button>
       <a href="{{ url_for('wizard_admin.list_bundles') }}"

--- a/app/templates/wizard/_api_check_card.html
+++ b/app/templates/wizard/_api_check_card.html
@@ -1,0 +1,110 @@
+{# Wizard API-check status card. Rendered by ApiCheckWidget on first paint and
+   (later) by the /wizard/api-check/<step_id> poll route on every re-check, so
+   all four states live here rather than split across two templates. #}
+<div id="wizard-api-check-{{ step_id }}"
+  class="not-prose card-widget my-6 rounded-xl border p-5 sm:p-6 transition-colors duration-300
+  {% if state == 'passed' %}
+    bg-green-50 dark:bg-green-900/10 border-green-200 dark:border-green-800
+  {% elif state == 'capped' %}
+    bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600
+  {% else %}
+    bg-amber-50 dark:bg-amber-900/10 border-amber-200 dark:border-amber-800
+  {% endif %}"
+  data-wizard-no-unlock
+  role="status"
+  aria-live="polite"
+  {# A settled card carries no hx-* at all: HTMX defaults a trigger-less
+        element to `click`, so leaving them on would re-fire the check whenever
+        the user tapped the card. #}
+  {% if trigger %}
+    hx-get="{{ check_url }}"
+    hx-target="this"
+    hx-swap="outerHTML"
+    hx-sync="this:replace"
+    hx-indicator="#wizard-api-check-{{ step_id }}-spinner"
+    hx-trigger="{{ trigger }}"
+  {% endif %}>
+  <div class="flex items-start justify-between gap-4">
+    <div class="flex items-center gap-2">
+      <span class="h-2 w-2 rounded-full
+                   {% if state == 'passed' %}
+                     bg-green-500
+                   {% elif state == 'capped' %}
+                     bg-gray-400
+                   {% else %}
+                     bg-amber-500
+                   {% endif %}
+                   {% if state in ('pending', 'cooldown') %}animate-pulse{% endif %}"></span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
+                   {% if state == 'passed' %}
+                     bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100
+                   {% elif state == 'capped' %}
+                     bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200
+                   {% else %}
+                     bg-amber-100 text-amber-800 dark:bg-amber-800 dark:text-amber-100
+                   {% endif %}">
+        {% if state == 'passed' %}
+          {{ _("Verified") }}
+        {% elif state == 'cooldown' %}
+          {{ _("Please wait") }}
+        {% elif state == 'capped' %}
+          {{ _("Paused") }}
+        {% else %}
+          {{ _("Checking") }}
+        {% endif %}
+      </span>
+    </div>
+    <span id="wizard-api-check-{{ step_id }}-spinner" class="htmx-indicator">
+      <svg class="h-4 w-4 animate-spin text-gray-400 dark:text-gray-500"
+           xmlns="http://www.w3.org/2000/svg"
+           fill="none"
+           viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
+        </path>
+      </svg>
+    </span>
+  </div>
+  <p class="mt-3 text-sm text-gray-700 dark:text-gray-300">
+    {% if message %}
+      {{ message }}
+    {% elif state == 'passed' %}
+      {{ _("Verified — you can continue.") }}
+    {% elif state == 'cooldown' %}
+      {% if retry_after %}
+        {{ _("Please wait %(seconds)ss before trying again…", seconds=retry_after) }}
+      {% else %}
+        {{ _("Please wait before trying again…") }}
+      {% endif %}
+    {% elif state == 'capped' %}
+      {{ _("We stopped checking automatically. Tap Re-check to try again.") }}
+    {% else %}
+      {{ _("Waiting for verification…") }}
+    {% endif %}
+  </p>
+  {% if trigger and interval %}
+    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+      {{ _("Checking automatically every %(interval)ss.", interval=interval) }}
+    </p>
+  {% endif %}
+  {% if show_button %}
+    <div class="mt-4">
+      <button type="button"
+              hx-get="{{ check_url }}"
+              hx-target="#wizard-api-check-{{ step_id }}"
+              hx-swap="outerHTML"
+              hx-sync="#wizard-api-check-{{ step_id }}:drop"
+              hx-indicator="#wizard-api-check-{{ step_id }}-spinner"
+              class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 transition-colors">
+        <svg class="w-4 h-4 mr-2"
+             fill="none"
+             stroke="currentColor"
+             viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15">
+          </path>
+        </svg>
+        {{ _("Re-check") }}
+      </button>
+    </div>
+  {% endif %}
+</div>

--- a/app/templates/wizard/steps.html
+++ b/app/templates/wizard/steps.html
@@ -178,7 +178,7 @@
        {% if not is_pre_final and idx == max_idx %}style="display:none"{% endif %}
        data-default-aria-label="{{ default_next_label }}"
        aria-label="{{ completion_label_text if is_pre_final else default_next_label }}"
-       {% if require_interaction %}
+       {% if require_interaction or gate_locked %}
          aria-disabled="true" data-disabled="1" title="{{ _('Click the link in this step to be able to continue') }}"
        {% endif %}>
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -244,7 +244,7 @@
        data-final-html="{{ completion_label_text }}"
        data-default-aria-label="{{ default_next_label }}"
        aria-label="{{ completion_label_text if is_pre_final else default_next_label }}"
-       {% if require_interaction %}
+       {% if require_interaction or gate_locked %}
          aria-disabled="true" data-disabled="1" title="{{ _('Click the link in this step to be able to continue') }}"
        {% endif %}>
       {% if is_pre_final %}
@@ -372,6 +372,7 @@
 
             const newIdx = parseInt(xhr.getResponseHeader('X-Wizard-Idx'));
             const requireInteraction = xhr.getResponseHeader('X-Require-Interaction') === 'true';
+            const gateLocked = xhr.getResponseHeader('X-Wizard-Gate-Locked') === 'true';
             const maxIdx = this.getMaxIdx();
             const serverType = this.getServerType();
             const newStepPhase = xhr.getResponseHeader('X-Wizard-Step-Phase');
@@ -413,7 +414,7 @@
             this.updateProgress(newIdx, maxIdx);
 
             // Update navigation buttons
-            this.updateButtons(newIdx, maxIdx, serverType, requireInteraction);
+            this.updateButtons(newIdx, maxIdx, serverType, requireInteraction || gateLocked);
         },
 
         updatePhaseBadges(phase) {
@@ -604,6 +605,12 @@
 
             // Reinitialize interaction gating for the new step
             if (typeof attachInteractionGating === 'function') {
+                // The latch is per-button and never self-clears, so a second
+                // gated step would otherwise render disabled but stay clickable.
+                ['wizard-next-btn', 'wizard-next-btn-desktop'].forEach(id => {
+                    const btn = document.getElementById(id);
+                    if (btn) delete btn.dataset.interactionGatingAttached;
+                });
                 attachInteractionGating(this.wrapper);
             }
         }

--- a/migrations/versions/20260825_add_api_check_to_wizard_step.py
+++ b/migrations/versions/20260825_add_api_check_to_wizard_step.py
@@ -1,0 +1,26 @@
+"""Add api_check field to wizard_step
+
+Revision ID: 20260825_apichk
+Revises: 20260401_repair
+Create Date: 2026-08-25
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260825_apichk"
+down_revision = "20260401_repair"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("wizard_step", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("api_check", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("wizard_step", schema=None) as batch_op:
+        batch_op.drop_column("api_check")

--- a/tests/external/api_check/conftest.py
+++ b/tests/external/api_check/conftest.py
@@ -1,0 +1,163 @@
+"""Fixtures for the wizard API-check tests.
+
+The gate only applies after an invitation is accepted, so most of these build a
+post-invite world: a media server, a post-invite step carrying a gate, an
+accepted invitation, and the ``wizard_access`` session that marks acceptance.
+"""
+
+import pytest
+
+from app.extensions import db
+from app.models import AdminAccount, Invitation, MediaServer, User, WizardStep
+from app.services.ldap.encryption import encrypt_credential
+from tests.external.api_check.mock_api_server import MockApiServer
+
+INVITE_CODE = "GATECODE1"
+USERNAME = "gated-user"
+EMAIL = "gated-user@example.com"
+SERVER_TYPE = "jellyfin"
+API_SECRET = "gate-signing-secret"
+
+
+@pytest.fixture(autouse=True)
+def _reset_in_process_cooldowns():
+    """Clear the gate's in-process cooldown map between tests.
+
+    It is keyed by ``scope:step_id``, and SQLite reuses row ids after the
+    ``session`` fixture empties ``wizard_step`` - so without this, one test's
+    cooldown lands on the next test's freshly numbered step.
+    """
+    from app.services.wizard_api_check import gate
+
+    gate._IN_PROCESS_CALLS.clear()
+    yield
+    gate._IN_PROCESS_CALLS.clear()
+
+
+@pytest.fixture
+def mock_api():
+    with MockApiServer() as server:
+        yield server
+
+
+@pytest.fixture
+def signed_mock_api():
+    with MockApiServer(hmac_secret=API_SECRET) as server:
+        yield server
+
+
+def api_check_blob(url, **overrides):
+    blob = {
+        "version": 1,
+        "enabled": True,
+        "method": "GET",
+        "url": url,
+        "auth_header": "",
+        "api_key_enc": "",
+        "sign_requests": False,
+        "expect_status": [200],
+        "interval_seconds": 5,
+        "timeout_seconds": 5,
+        "max_poll_seconds": 600,
+    }
+    blob.update(overrides)
+    return blob
+
+
+@pytest.fixture
+def wizard_world(app, session):
+    """A media server, an accepted invitation and its user."""
+    with app.app_context():
+        server = MediaServer(
+            name="Gate Test Server",
+            server_type=SERVER_TYPE,
+            url="http://127.0.0.1:8096",
+            api_key="unused",
+        )
+        db.session.add(server)
+        db.session.flush()
+
+        invitation = Invitation(code=INVITE_CODE, used=True, unlimited=False)
+        user = User(
+            token="tok-gate",
+            username=USERNAME,
+            email=EMAIL,
+            code=INVITE_CODE,
+            server_id=server.id,
+        )
+        db.session.add_all([invitation, user])
+        db.session.flush()
+        invitation.users.append(user)
+        invitation.servers.append(server)
+        db.session.commit()
+
+        yield {"server": server, "invitation": invitation, "user": user}
+
+
+@pytest.fixture
+def make_step(app, wizard_world):
+    """Create post-invite wizard steps, optionally carrying a gate."""
+    created = []
+
+    def _make(
+        position,
+        *,
+        api_check=None,
+        markdown="# Step\n\n{{ widget:api_check }}",
+        category="post_invite",
+    ):
+        with app.app_context():
+            step = WizardStep(
+                server_type=SERVER_TYPE,
+                category=category,
+                position=position,
+                title=f"Step {position}",
+                markdown=markdown,
+                api_check=api_check,
+            )
+            db.session.add(step)
+            db.session.commit()
+            created.append(step.id)
+            return step.id
+
+    yield _make
+
+
+@pytest.fixture
+def gated_step(make_step, mock_api):
+    """A single post-invite step gated on the mock API."""
+    return make_step(0, api_check=api_check_blob(mock_api.path("/check")))
+
+
+@pytest.fixture
+def accepted_client(client):
+    """A client whose session says the invitation has been accepted."""
+    with client.session_transaction() as sess:
+        sess["wizard_access"] = INVITE_CODE
+    return client
+
+
+@pytest.fixture
+def admin_client(client, app, wizard_world):
+    """A logged-in admin, who is exempt from gating."""
+    with app.app_context():
+        if not AdminAccount.query.filter_by(username="gateadmin").first():
+            admin = AdminAccount(username="gateadmin")
+            admin.set_password("GatePass123!")
+            db.session.add(admin)
+            db.session.commit()
+    client.post("/login", data={"username": "gateadmin", "password": "GatePass123!"})
+    return client
+
+
+@pytest.fixture
+def signed_blob_factory():
+    def _factory(url, **overrides):
+        return api_check_blob(
+            url,
+            sign_requests=True,
+            api_key_enc=encrypt_credential(API_SECRET),
+            **overrides,
+        )
+
+    return _factory

--- a/tests/external/api_check/mock_api_server.py
+++ b/tests/external/api_check/mock_api_server.py
@@ -1,0 +1,451 @@
+"""A reusable mock of the external API that gates wizard progression.
+
+Wizarr's ``{{ widget:api_check }}`` gate calls an admin-configured endpoint and
+lets the user continue only when it answers with an expected status code. This
+module stands in for that endpoint so tests (and other developers) can drive the
+gate without a real service.
+
+It is a real HTTP server on loopback, not a monkeypatch, so it exercises the
+whole ``requests`` path including timeouts, redirects and connection errors.
+
+Wizarr signs each request as::
+
+    canonical = "v1\\n{timestamp}\\n{nonce}\\n{METHOD}\\n{url_path}\\n{code}\\n{username}\\n{email}"
+    X-Wizarr-Signature: sha256=<hmac_sha256(api_key, canonical).hexdigest()>
+
+alongside ``X-Wizarr-Timestamp`` and ``X-Wizarr-Nonce``. Pass ``hmac_secret`` to
+have the mock verify that and expose the verdict on each recorded request.
+
+Fixed paths, always available:
+
+===========  ==========================================================
+``/check``   the validating endpoint (the one you normally point Wizarr at)
+``/boom``    always 500
+``/slow``    sleeps ``delay`` seconds, then behaves like ``/check``
+``/redirect``302 to ``/check`` – Wizarr must never follow it
+``/teapot``  always 418, for non-default ``expect_status`` tests
+===========  ==========================================================
+
+Example::
+
+    with MockApiServer(expect_code="ABC123", hmac_secret="s3cr3t") as api:
+        api.program(403, 403, 200)          # fail twice, then pass
+        ...                                  # drive the wizard
+        assert api.request_count == 3
+        assert api.last().signature_valid
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import hmac
+import json
+import threading
+import time
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Self
+from urllib.parse import parse_qs, urlsplit
+
+SIGNATURE_VERSION = "v1"
+DEFAULT_SKEW_TOLERANCE = 300
+
+
+def build_canonical_string(
+    *,
+    timestamp: str,
+    nonce: str,
+    method: str,
+    path: str,
+    code: str,
+    username: str,
+    email: str,
+) -> str:
+    """Return the exact string Wizarr signs. Kept here so the mock and the app
+    can be tested against one another rather than against a shared helper."""
+    return "\n".join(
+        [
+            SIGNATURE_VERSION,
+            timestamp,
+            nonce,
+            method.upper(),
+            path,
+            code,
+            username,
+            email,
+        ]
+    )
+
+
+def sign(secret: str, canonical: str) -> str:
+    return hmac.new(secret.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+
+
+@dataclass(frozen=True)
+class RecordedRequest:
+    """One request the mock received, captured for assertions."""
+
+    method: str
+    path: str
+    query: dict[str, list[str]]
+    headers: dict[str, str]
+    body: dict[str, Any] | None
+    signature_valid: bool | None
+    signature_error: str
+    received_at: float
+    code: str | None
+    username: str | None
+    email: str | None
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server: MockApiServer._Server  # type: ignore[name-defined]
+
+    def log_message(self, *_args):  # keep pytest output clean
+        pass
+
+    def do_GET(self):
+        self._handle("GET")
+
+    def do_POST(self):
+        self._handle("POST")
+
+    def _handle(self, method: str):
+        api: MockApiServer = self.server.api
+        parts = urlsplit(self.path)
+        query = parse_qs(parts.query, keep_blank_values=True)
+
+        if api.control_enabled and parts.path.startswith("/_control"):
+            self._handle_control(api, parts.path)
+            return
+
+        body = None
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            raw = self.rfile.read(length)
+            try:
+                body = json.loads(raw.decode())
+            except (ValueError, UnicodeDecodeError):
+                body = None
+
+        status = api._record_and_decide(
+            method, parts.path, query, dict(self.headers), body
+        )
+        payload = json.dumps({"ok": status < 400}).encode()
+
+        try:
+            self.send_response(status)
+            if status == 302:
+                self.send_header("Location", f"{api.url}/check")
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except (BrokenPipeError, ConnectionResetError):
+            # Client gave up first - expected whenever a test exercises a timeout.
+            pass
+
+    def _handle_control(self, api: MockApiServer, path: str):
+        """Manual-testing surface: flip the answer without restarting."""
+        if path == "/_control/pass":
+            api.set_status(200)
+        elif path == "/_control/fail":
+            api.set_status(403)
+        elif path.startswith("/_control/status/"):
+            with contextlib.suppress(ValueError):
+                api.set_status(int(path.rsplit("/", 1)[-1]))
+        elif path == "/_control/reset":
+            api.reset()
+
+        body = api.control_page().encode()
+        try:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+
+class MockApiServer:
+    """Threaded stdlib HTTP server. Use as a context manager."""
+
+    class _Server(ThreadingHTTPServer):
+        daemon_threads = True
+        allow_reuse_address = True
+
+        def __init__(self, addr, handler, api: MockApiServer):
+            self.api = api
+            super().__init__(addr, handler)
+
+        def handle_error(self, request, client_address):
+            pass  # a disconnecting client is normal here, not a test failure
+
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        fail_status: int = 403,
+        expect_code: str | None = None,
+        expect_username: str | None = None,
+        expect_email: str | None = None,
+        code_param: str = "code",
+        username_param: str = "username",
+        email_param: str = "email",
+        hmac_secret: str | None = None,
+        auth_header: str | None = None,
+        auth_value: str | None = None,
+        delay: float = 0.0,
+        clock_skew_tolerance: int = DEFAULT_SKEW_TOLERANCE,
+        control_enabled: bool = False,
+    ) -> None:
+        self._status = status
+        self._fail_status = fail_status
+        self._expect_code = expect_code
+        self._expect_username = expect_username
+        self._expect_email = expect_email
+        self._code_param = code_param
+        self._username_param = username_param
+        self._email_param = email_param
+        self._hmac_secret = hmac_secret
+        self._auth_header = auth_header
+        self._auth_value = auth_value
+        self._delay = delay
+        self._skew = clock_skew_tolerance
+        self.control_enabled = control_enabled
+
+        self._programmed: list[int] = []
+        self._requests: list[RecordedRequest] = []
+        self._lock = threading.Lock()
+        self._server: MockApiServer._Server | None = None
+        self._thread: threading.Thread | None = None
+
+    # ── lifecycle ────────────────────────────────────────────────────
+    def start(self) -> Self:
+        self._server = MockApiServer._Server(("127.0.0.1", 0), _Handler, self)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def __enter__(self) -> Self:
+        return self.start()
+
+    def __exit__(self, *_exc) -> None:
+        self.stop()
+
+    # ── addressing ───────────────────────────────────────────────────
+    @property
+    def port(self) -> int:
+        assert self._server is not None, "MockApiServer is not started"
+        return self._server.server_address[1]
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def path(self, p: str = "/check") -> str:
+        return f"{self.url}{p if p.startswith('/') else '/' + p}"
+
+    # ── programmable behaviour ───────────────────────────────────────
+    def set_status(self, code: int) -> None:
+        with self._lock:
+            self._status = code
+            self._programmed.clear()
+
+    def program(self, *statuses: int) -> None:
+        """Queue statuses for successive hits; the last one repeats forever."""
+        with self._lock:
+            self._programmed = list(statuses)
+
+    def set_delay(self, seconds: float) -> None:
+        with self._lock:
+            self._delay = seconds
+
+    def set_expected(
+        self,
+        *,
+        code: str | None = None,
+        username: str | None = None,
+        email: str | None = None,
+    ) -> None:
+        with self._lock:
+            self._expect_code = code
+            self._expect_username = username
+            self._expect_email = email
+
+    def reset(self) -> None:
+        with self._lock:
+            self._requests.clear()
+            self._programmed.clear()
+
+    # ── assertions ───────────────────────────────────────────────────
+    @property
+    def requests(self) -> list[RecordedRequest]:
+        with self._lock:
+            return list(self._requests)
+
+    @property
+    def request_count(self) -> int:
+        with self._lock:
+            return len(self._requests)
+
+    def last(self) -> RecordedRequest | None:
+        with self._lock:
+            return self._requests[-1] if self._requests else None
+
+    def control_page(self) -> str:
+        """A tiny dashboard for driving the mock by hand during dev testing."""
+        with self._lock:
+            current = self._programmed[0] if self._programmed else self._status
+            rows = "".join(
+                f"<tr><td>{r.received_at:.0f}</td><td>{r.method}</td><td>{r.path}</td>"
+                f"<td>{r.code or ''}</td><td>{r.username or ''}</td><td>{r.email or ''}</td>"
+                f"<td>{'' if r.signature_valid is None else r.signature_valid}</td></tr>"
+                for r in reversed(self._requests[-25:])
+            )
+            count = len(self._requests)
+        state = "PASS" if current == 200 else f"FAIL ({current})"
+        return f"""<!doctype html><meta charset=utf-8>
+<title>Wizarr mock API</title>
+<style>
+ body{{font:14px/1.5 system-ui,sans-serif;margin:2rem;max-width:60rem}}
+ a.btn{{display:inline-block;padding:.5rem 1rem;margin-right:.5rem;border-radius:.5rem;
+        text-decoration:none;color:#fff}}
+ .pass{{background:#16a34a}} .fail{{background:#dc2626}} .reset{{background:#525252}}
+ table{{border-collapse:collapse;width:100%;margin-top:1rem}}
+ td,th{{border-bottom:1px solid #ddd;padding:.35rem .5rem;text-align:left;font-size:13px}}
+ code{{background:#f4f4f5;padding:.1rem .3rem;border-radius:.25rem}}
+</style>
+<h1>Wizarr mock API</h1>
+<p>Currently answering <strong>{state}</strong> on <code>/check</code> &mdash; {count} request(s) received.</p>
+<p>
+  <a class="btn pass" href="/_control/pass">Answer 200 (pass)</a>
+  <a class="btn fail" href="/_control/fail">Answer 403 (fail)</a>
+  <a class="btn reset" href="/_control/reset">Clear log</a>
+</p>
+<p>Fixed paths: <code>/check</code>, <code>/boom</code> (500), <code>/slow</code>,
+   <code>/redirect</code> (302), <code>/teapot</code> (418).</p>
+<table>
+ <tr><th>at</th><th>method</th><th>path</th><th>code</th><th>username</th><th>email</th><th>sig ok</th></tr>
+ {rows or "<tr><td colspan=7>no requests yet</td></tr>"}
+</table>
+<script>setTimeout(() => location.replace('/_control/'), 3000)</script>
+"""
+
+    def wait_for(self, n: int, timeout: float = 10.0) -> bool:
+        """Block until at least *n* requests have arrived."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.request_count >= n:
+                return True
+            time.sleep(0.05)
+        return self.request_count >= n
+
+    # ── request handling ─────────────────────────────────────────────
+    def _extract(self, query, body, name):
+        if not name:
+            return None
+        if body is not None and name in body:
+            return str(body[name])
+        values = query.get(name)
+        return values[0] if values else None
+
+    def _verify_signature(self, method, path, headers, code, username, email):
+        if not self._hmac_secret:
+            return None, ""
+        supplied = headers.get("X-Wizarr-Signature", "")
+        timestamp = headers.get("X-Wizarr-Timestamp", "")
+        nonce = headers.get("X-Wizarr-Nonce", "")
+        if not supplied or not timestamp or not nonce:
+            return False, "missing signature headers"
+        try:
+            skew = abs(time.time() - float(timestamp))
+        except ValueError:
+            return False, "unparseable timestamp"
+        if skew > self._skew:
+            return False, f"timestamp skew {skew:.0f}s"
+        canonical = build_canonical_string(
+            timestamp=timestamp,
+            nonce=nonce,
+            method=method,
+            path=path,
+            code=code or "",
+            username=username or "",
+            email=email or "",
+        )
+        expected = f"sha256={sign(self._hmac_secret, canonical)}"
+        if not hmac.compare_digest(supplied, expected):
+            return False, "signature mismatch"
+        return True, ""
+
+    def _record_and_decide(self, method, path, query, headers, body) -> int:
+        with self._lock:
+            delay = self._delay
+        if path == "/slow" and delay:
+            time.sleep(delay)
+
+        code = self._extract(query, body, self._code_param)
+        username = self._extract(query, body, self._username_param)
+        email = self._extract(query, body, self._email_param)
+        sig_valid, sig_error = self._verify_signature(
+            method, path, headers, code, username, email
+        )
+
+        with self._lock:
+            self._requests.append(
+                RecordedRequest(
+                    method=method,
+                    path=path,
+                    query=query,
+                    headers=headers,
+                    body=body,
+                    signature_valid=sig_valid,
+                    signature_error=sig_error,
+                    received_at=time.time(),
+                    code=code,
+                    username=username,
+                    email=email,
+                )
+            )
+
+            if path == "/boom":
+                return 500
+            if path == "/redirect":
+                return 302
+            if path == "/teapot":
+                return 418
+
+            if sig_valid is False:
+                return 401
+            if self._auth_header and not hmac.compare_digest(
+                headers.get(self._auth_header, ""), self._auth_value or ""
+            ):
+                return 401
+
+            for expected, actual in (
+                (self._expect_code, code),
+                (self._expect_username, username),
+                (self._expect_email, email),
+            ):
+                if expected is not None and actual != expected:
+                    return self._fail_status
+
+            if self._programmed:
+                return (
+                    self._programmed.pop(0)
+                    if len(self._programmed) > 1
+                    else self._programmed[0]
+                )
+            return self._status

--- a/tests/external/api_check/run_mock_api.py
+++ b/tests/external/api_check/run_mock_api.py
@@ -1,0 +1,57 @@
+"""Run the API-check mock as a standalone server for manual testing.
+
+    uv run python -m tests.external.api_check.run_mock_api --port 8899
+
+Point a wizard step's API Gate at ``http://127.0.0.1:8899/check`` and drive the
+answer from ``http://127.0.0.1:8899/_control/`` while you click through the
+wizard. Every request is listed there, including whether its Wizarr signature
+verified.
+"""
+
+import argparse
+import threading
+
+from tests.external.api_check.mock_api_server import MockApiServer, _Handler
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8899)
+    parser.add_argument(
+        "--status", type=int, default=403, help="initial answer for /check"
+    )
+    parser.add_argument(
+        "--secret", default=None, help="verify Wizarr's HMAC with this key"
+    )
+    parser.add_argument(
+        "--expect-code", default=None, help="only accept this invite code"
+    )
+    parser.add_argument("--expect-username", default=None)
+    parser.add_argument("--expect-email", default=None)
+    args = parser.parse_args()
+
+    server = MockApiServer(
+        status=args.status,
+        hmac_secret=args.secret,
+        expect_code=args.expect_code,
+        expect_username=args.expect_username,
+        expect_email=args.expect_email,
+        control_enabled=True,
+    )
+    server._server = MockApiServer._Server(("127.0.0.1", args.port), _Handler, server)
+
+    thread = threading.Thread(target=server._server.serve_forever, daemon=True)
+    thread.start()
+
+    print(f"mock API      : {server.url}/check")
+    print(f"control panel : {server.url}/_control/")
+    print(f"answering     : {args.status}")
+    print("Ctrl-C to stop")
+    try:
+        thread.join()
+    except KeyboardInterrupt:
+        server.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/external/api_check/test_admin_forms.py
+++ b/tests/external/api_check/test_admin_forms.py
@@ -1,0 +1,346 @@
+"""Admin authoring of the API gate.
+
+Covers the two things an admin can get wrong destructively - losing the stored
+credential on an unrelated edit, and attaching a gate to a pre-invite step where
+username and email do not exist yet - plus the guarantee that the key is
+write-only from the browser's point of view.
+"""
+
+from app.extensions import db
+from app.models import WizardStep
+from app.services.ldap.encryption import encrypt_credential
+from app.services.wizard_api_check.config import normalize
+
+SECRET = "sk-live-admin-entered"
+
+
+def form_payload(**overrides):
+    payload = {
+        "server_type": "jellyfin",
+        "category": "post_invite",
+        "title": "Install the app",
+        "markdown": "# Install\n\n{{ widget:api_check }}",
+        "api_check_enabled": "y",
+        "api_check_method": "GET",
+        "api_check_url": "https://api.example.com/check",
+        "api_check_auth_header": "Authorization",
+        "api_check_auth_prefix": "Bearer ",
+        "api_check_api_key": SECRET,
+        "api_check_code_param": "code",
+        "api_check_username_param": "username",
+        "api_check_email_param": "email",
+        "api_check_expect_status": "200",
+        "api_check_interval_seconds": "15",
+        "api_check_timeout_seconds": "5",
+        "api_check_max_poll_seconds": "600",
+        "api_check_sign_requests": "y",
+        "api_check_pending_message": "Install the app, then tap Re-check",
+        "api_check_success_message": "All set",
+    }
+    payload.update(overrides)
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+def only_step(app):
+    with app.app_context():
+        return WizardStep.query.order_by(WizardStep.id.desc()).first()
+
+
+class TestCreate:
+    def test_gate_is_saved(self, admin_client, app):
+        admin_client.post("/settings/wizard/create", data=form_payload())
+
+        with app.app_context():
+            step = only_step(app)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.enabled is True
+        assert cfg.url == "https://api.example.com/check"
+        assert cfg.interval_seconds == 15
+        assert cfg.is_active is True
+
+    def test_api_key_is_encrypted_at_rest(self, admin_client, app):
+        admin_client.post("/settings/wizard/create", data=form_payload())
+
+        with app.app_context():
+            step = only_step(app)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.api_key_enc != SECRET
+        assert SECRET not in str(step.api_check)
+        assert cfg.api_key() == SECRET
+
+    def test_expected_statuses_accept_a_comma_list(self, admin_client, app):
+        admin_client.post(
+            "/settings/wizard/create",
+            data=form_payload(api_check_expect_status="200, 204"),
+        )
+
+        with app.app_context():
+            step = only_step(app)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.expect_status == (200, 204)
+
+    def test_a_step_without_the_gate_stores_nothing_active(self, admin_client, app):
+        admin_client.post(
+            "/settings/wizard/create", data=form_payload(api_check_enabled=None)
+        )
+
+        with app.app_context():
+            step = only_step(app)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.is_active is False
+
+
+class TestValidation:
+    def test_gate_is_refused_on_a_pre_invite_step(self, admin_client, app):
+        admin_client.post(
+            "/settings/wizard/create", data=form_payload(category="pre_invite")
+        )
+
+        with app.app_context():
+            step = only_step(app)
+
+        assert (
+            step is None
+            or normalize(step.api_check, category=step.category).enabled is False
+        )
+
+    def test_a_non_http_url_is_refused(self, admin_client, app):
+        admin_client.post(
+            "/settings/wizard/create",
+            data=form_payload(api_check_url="file:///etc/passwd"),
+        )
+
+        with app.app_context():
+            step = only_step(app)
+
+        assert (
+            step is None or normalize(step.api_check, category=step.category).url == ""
+        )
+
+    def test_an_out_of_range_interval_is_refused(self, admin_client, app):
+        admin_client.post(
+            "/settings/wizard/create", data=form_payload(api_check_interval_seconds="1")
+        )
+
+        with app.app_context():
+            step = only_step(app)
+
+        assert (
+            step is None
+            or normalize(step.api_check, category=step.category).interval_seconds >= 5
+        )
+
+    def test_enabling_without_a_url_is_refused(self, admin_client, app):
+        """Otherwise the admin ticks the box and gets a gate that does nothing."""
+        admin_client.post(
+            "/settings/wizard/create", data=form_payload(api_check_url="")
+        )
+
+        with app.app_context():
+            step = only_step(app)
+
+        assert (
+            step is None
+            or normalize(step.api_check, category=step.category).enabled is False
+        )
+
+    def test_enabling_a_signed_gate_without_a_key_is_refused(self, admin_client, app):
+        admin_client.post(
+            "/settings/wizard/create", data=form_payload(api_check_api_key="")
+        )
+
+        with app.app_context():
+            step = only_step(app)
+
+        assert (
+            step is None
+            or normalize(step.api_check, category=step.category).enabled is False
+        )
+
+    def test_the_admin_sees_why_the_save_was_refused(self, admin_client):
+        """A refusal the admin cannot see reads as the form silently ignoring them."""
+        response = admin_client.post(
+            "/settings/wizard/create",
+            data=form_payload(api_check_api_key=""),
+            headers={"HX-Request": "true"},
+        )
+
+        assert b"API key is required" in response.data
+
+    def test_a_bad_url_is_explained_too(self, admin_client):
+        response = admin_client.post(
+            "/settings/wizard/create",
+            data=form_payload(api_check_url="file:///etc/passwd"),
+            headers={"HX-Request": "true"},
+        )
+
+        assert b"valid http" in response.data
+
+    def test_an_unsigned_gate_needs_no_key(self, admin_client, app):
+        admin_client.post(
+            "/settings/wizard/create",
+            data=form_payload(api_check_api_key="", api_check_sign_requests=None),
+        )
+
+        with app.app_context():
+            step = only_step(app)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.is_active is True
+
+    def test_template_syntax_in_a_message_is_refused(self, admin_client, app):
+        admin_client.post(
+            "/settings/wizard/create",
+            data=form_payload(api_check_pending_message="{{ config.SECRET_KEY }}"),
+        )
+
+        with app.app_context():
+            step = only_step(app)
+
+        assert (
+            step is None
+            or normalize(step.api_check, category=step.category).pending_message == ""
+        )
+
+
+class TestEdit:
+    def existing(self, app, **blob_overrides):
+        blob = {
+            "version": 1,
+            "enabled": True,
+            "method": "GET",
+            "url": "https://api.example.com/check",
+            "api_key_enc": encrypt_credential(SECRET),
+            "sign_requests": True,
+            "interval_seconds": 15,
+        }
+        blob.update(blob_overrides)
+        with app.app_context():
+            step = WizardStep(
+                server_type="jellyfin",
+                category="post_invite",
+                position=0,
+                title="Existing",
+                markdown="# Existing\n\n{{ widget:api_check }}",
+                api_check=blob,
+            )
+            db.session.add(step)
+            db.session.commit()
+            return step.id
+
+    def test_a_blank_key_field_preserves_the_stored_credential(self, admin_client, app):
+        step_id = self.existing(app)
+
+        admin_client.post(
+            f"/settings/wizard/{step_id}/edit",
+            data=form_payload(api_check_api_key="", title="Renamed"),
+        )
+
+        with app.app_context():
+            step = db.session.get(WizardStep, step_id)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.api_key() == SECRET
+        assert step.title == "Renamed"
+
+    def test_the_clear_checkbox_wipes_the_credential(self, admin_client, app):
+        step_id = self.existing(app)
+
+        admin_client.post(
+            f"/settings/wizard/{step_id}/edit",
+            data=form_payload(
+                api_check_api_key="",
+                api_check_clear_key="y",
+                api_check_sign_requests=None,
+            ),
+        )
+
+        with app.app_context():
+            step = db.session.get(WizardStep, step_id)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.api_key_enc == ""
+
+    def test_clearing_the_key_of_a_signed_gate_is_refused(self, admin_client, app):
+        """Wiping the key while signing stays on would leave an inert gate."""
+        step_id = self.existing(app)
+
+        admin_client.post(
+            f"/settings/wizard/{step_id}/edit",
+            data=form_payload(api_check_api_key="", api_check_clear_key="y"),
+        )
+
+        with app.app_context():
+            step = db.session.get(WizardStep, step_id)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.api_key() == SECRET
+
+    def test_a_new_key_replaces_the_old_one(self, admin_client, app):
+        step_id = self.existing(app)
+
+        admin_client.post(
+            f"/settings/wizard/{step_id}/edit",
+            data=form_payload(api_check_api_key="sk-live-rotated"),
+        )
+
+        with app.app_context():
+            step = db.session.get(WizardStep, step_id)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.api_key() == "sk-live-rotated"
+
+    def test_the_edit_form_never_echoes_the_credential(self, admin_client, app):
+        step_id = self.existing(app)
+
+        response = admin_client.get(
+            f"/settings/wizard/{step_id}/edit", headers={"HX-Request": "true"}
+        )
+
+        assert SECRET.encode() not in response.data
+
+    def test_disabling_the_gate_keeps_the_step(self, admin_client, app):
+        step_id = self.existing(app)
+
+        admin_client.post(
+            f"/settings/wizard/{step_id}/edit",
+            data=form_payload(api_check_enabled=None, api_check_api_key=""),
+        )
+
+        with app.app_context():
+            step = db.session.get(WizardStep, step_id)
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert step is not None
+        assert cfg.is_active is False
+
+
+class TestAdminPreview:
+    def test_preview_renders_the_widget_instead_of_raw_syntax(self, admin_client):
+        response = admin_client.post(
+            "/settings/wizard/preview",
+            data={
+                "markdown": '# Title\n\n{{ widget:button url="https://x.test" text="Go" }}'
+            },
+        )
+
+        assert b"widget:button" not in response.data
+        assert b"https://x.test" in response.data
+
+    def test_preview_renders_cards(self, admin_client):
+        response = admin_client.post(
+            "/settings/wizard/preview", data={"markdown": "|||\n# Card\n\nBody\n|||"}
+        )
+
+        assert b"card-widget" in response.data
+
+    def test_preview_of_an_api_check_placeholder_is_inert(self, admin_client):
+        response = admin_client.post(
+            "/settings/wizard/preview", data={"markdown": "{{ widget:api_check }}"}
+        )
+
+        assert b"hx-get" not in response.data

--- a/tests/external/api_check/test_client.py
+++ b/tests/external/api_check/test_client.py
@@ -1,0 +1,296 @@
+"""Outbound behaviour of the wizard API-check client.
+
+These run against the real mock server on loopback rather than a patched
+``requests``, so timeouts, refused connections and redirects are exercised for
+real. The rule the whole feature rests on is that the upstream response body is
+never read and never surfaced - only a pass/fail verdict leaves this layer.
+"""
+
+import socket
+
+import pytest
+
+from app.services.wizard_api_check.client import CheckOutcome, run_check
+from app.services.wizard_api_check.config import ApiCheckConfig, normalize
+from tests.external.api_check.mock_api_server import MockApiServer
+
+
+def config(url: str, **overrides):
+    raw = {
+        "version": 1,
+        "enabled": True,
+        "url": url,
+        "sign_requests": False,
+        "auth_header": "",
+        **overrides,
+    }
+    return normalize(raw, category="post_invite")
+
+
+@pytest.fixture
+def api():
+    with MockApiServer() as server:
+        yield server
+
+
+def closed_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class TestStatusMatching:
+    def test_expected_status_passes(self, api):
+        outcome = run_check(config(api.path("/check")), code="ABC123")
+
+        assert outcome == CheckOutcome(passed=True, reason="ok", status_code=200)
+
+    def test_unexpected_status_fails(self, api):
+        api.set_status(403)
+
+        outcome = run_check(config(api.path("/check")), code="ABC123")
+
+        assert outcome.passed is False
+        assert outcome.reason == "status"
+        assert outcome.status_code == 403
+
+    def test_upstream_500_is_a_plain_failure(self, api):
+        outcome = run_check(config(api.path("/boom")), code="ABC123")
+
+        assert outcome.passed is False
+        assert outcome.reason == "status"
+        assert outcome.status_code == 500
+
+    def test_non_default_expected_status(self, api):
+        outcome = run_check(
+            config(api.path("/teapot"), expect_status=[418]), code="ABC123"
+        )
+
+        assert outcome.passed is True
+        assert outcome.status_code == 418
+
+    def test_multiple_expected_statuses(self, api):
+        api.set_status(204)
+
+        outcome = run_check(
+            config(api.path("/check"), expect_status=[201, 204]), code="ABC123"
+        )
+
+        assert outcome.passed is True
+        assert outcome.status_code == 204
+
+    def test_default_expectation_is_200_only(self, api):
+        api.set_status(201)
+
+        assert run_check(config(api.path("/check")), code="ABC123").passed is False
+
+
+class TestRedirects:
+    def test_redirect_is_not_followed(self, api):
+        outcome = run_check(config(api.path("/redirect")), code="ABC123")
+
+        assert outcome.passed is False
+        assert outcome.reason == "redirect"
+        assert outcome.status_code == 302
+        assert api.request_count == 1, (
+            "a redirect must never be chased to a second host"
+        )
+
+    def test_redirect_still_not_followed_when_explicitly_expected(self, api):
+        outcome = run_check(
+            config(api.path("/redirect"), expect_status=[302]), code="ABC123"
+        )
+
+        assert outcome.passed is True
+        assert api.request_count == 1
+
+
+class TestNetworkFailures:
+    def test_timeout(self, api):
+        api.set_delay(2.0)
+
+        outcome = run_check(config(api.path("/slow"), timeout_seconds=1), code="ABC123")
+
+        assert outcome.passed is False
+        assert outcome.reason == "timeout"
+        assert outcome.status_code is None
+
+    def test_slow_but_within_timeout_still_passes(self, api):
+        api.set_delay(0.5)
+
+        outcome = run_check(config(api.path("/slow"), timeout_seconds=5), code="ABC123")
+
+        assert outcome.passed is True
+
+    def test_dns_failure(self):
+        outcome = run_check(
+            config("http://wizarr-nonexistent.invalid/check"), code="ABC123"
+        )
+
+        assert outcome.passed is False
+        assert outcome.reason == "network"
+        assert outcome.status_code is None
+
+    def test_connection_refused(self):
+        outcome = run_check(
+            config(f"http://127.0.0.1:{closed_port()}/check"), code="ABC123"
+        )
+
+        assert outcome.passed is False
+        assert outcome.reason == "network"
+
+
+class TestPayload:
+    def test_get_sends_identity_as_query_params(self, api):
+        run_check(
+            config(api.path("/check")), code="ABC123", username="james", email="a@b.c"
+        )
+
+        recorded = api.last()
+        assert recorded.method == "GET"
+        assert recorded.query["code"] == ["ABC123"]
+        assert recorded.query["username"] == ["james"]
+        assert recorded.query["email"] == ["a@b.c"]
+        assert recorded.body is None
+
+    def test_post_sends_identity_as_json_body(self, api):
+        run_check(
+            config(api.path("/check"), method="POST"),
+            code="ABC123",
+            username="james",
+            email="a@b.c",
+        )
+
+        recorded = api.last()
+        assert recorded.method == "POST"
+        assert recorded.body == {
+            "code": "ABC123",
+            "username": "james",
+            "email": "a@b.c",
+        }
+        assert recorded.query == {}
+
+    def test_custom_param_names_are_honoured(self, api):
+        run_check(
+            config(
+                api.path("/check"),
+                code_param="invite",
+                username_param="user",
+                email_param="mail",
+            ),
+            code="ABC123",
+            username="james",
+            email="a@b.c",
+        )
+
+        recorded = api.last()
+        assert recorded.query["invite"] == ["ABC123"]
+        assert recorded.query["user"] == ["james"]
+        assert recorded.query["mail"] == ["a@b.c"]
+        assert "code" not in recorded.query
+
+    def test_blank_param_name_omits_the_field(self, api):
+        run_check(
+            config(api.path("/check"), username_param="", email_param=""),
+            code="ABC123",
+            username="james",
+            email="a@b.c",
+        )
+
+        recorded = api.last()
+        assert recorded.query["code"] == ["ABC123"]
+        assert "username" not in recorded.query
+        assert "email" not in recorded.query
+
+    def test_missing_email_is_sent_as_empty_string(self, api):
+        run_check(config(api.path("/check")), code="ABC123", username="james", email="")
+
+        assert api.last().query["email"] == [""]
+
+    def test_identity_values_cannot_escape_into_the_url(self, api):
+        """User-derived values go through requests' encoder, never string concat."""
+        run_check(
+            config(api.path("/check")),
+            code="ABC&admin=1#x",
+            username="../../etc/passwd",
+            email="a b@c",
+        )
+
+        recorded = api.last()
+        assert recorded.path == "/check"
+        assert recorded.query["code"] == ["ABC&admin=1#x"]
+        assert recorded.query["username"] == ["../../etc/passwd"]
+        assert "admin" not in recorded.query
+
+
+class TestAuthHeader:
+    def test_header_and_prefix_are_sent(self, api):
+        from app.services.ldap.encryption import encrypt_credential
+
+        run_check(
+            config(
+                api.path("/check"),
+                auth_header="Authorization",
+                auth_prefix="Bearer ",
+                api_key_enc=encrypt_credential("sk-live-1"),
+            ),
+            code="ABC123",
+        )
+
+        assert api.last().headers["Authorization"] == "Bearer sk-live-1"
+
+    def test_empty_prefix_sends_the_bare_key(self, api):
+        from app.services.ldap.encryption import encrypt_credential
+
+        run_check(
+            config(
+                api.path("/check"),
+                auth_header="X-API-Key",
+                auth_prefix="",
+                api_key_enc=encrypt_credential("sk-live-2"),
+            ),
+            code="ABC123",
+        )
+
+        assert api.last().headers["X-API-Key"] == "sk-live-2"
+
+    def test_blank_header_name_sends_no_auth(self, api):
+        run_check(config(api.path("/check")), code="ABC123")
+
+        assert "Authorization" not in api.last().headers
+
+
+class TestUrlRevalidation:
+    """The stored blob is re-checked at call time, not trusted."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "gopher://evil.test/",
+            "https://user:pass@example.com/x",
+            "",
+            "not a url",
+        ],
+    )
+    def test_bad_url_never_reaches_the_network(self, url):
+        outcome = run_check(
+            ApiCheckConfig(enabled=True, url=url, sign_requests=False, auth_header=""),
+            code="ABC123",
+        )
+
+        assert outcome == CheckOutcome(passed=False, reason="config", status_code=None)
+
+
+class TestBodyIsNeverRead:
+    def test_outcome_carries_no_upstream_content(self, api):
+        outcome = run_check(config(api.path("/check")), code="ABC123")
+
+        assert set(vars(outcome)) == {"passed", "reason", "status_code"}
+        assert "ok" not in str(outcome.status_code)
+
+    def test_a_body_that_cannot_be_parsed_does_not_affect_the_verdict(self, api):
+        """The mock always answers with JSON; the client must not care either way."""
+        api.set_status(200)
+
+        assert run_check(config(api.path("/check")), code="ABC123").passed is True

--- a/tests/external/api_check/test_config_schema.py
+++ b/tests/external/api_check/test_config_schema.py
@@ -1,0 +1,407 @@
+"""Schema tests for the wizard API-check configuration blob.
+
+The config is admin-authored and stored as JSON on ``wizard_step.api_check``.
+``normalize`` is the only read path, so it must never raise no matter what the
+column contains, and it must clamp every bound rather than trusting the blob.
+"""
+
+import pytest
+
+from app.services.wizard_api_check.config import (
+    DEFAULT_INTERVAL,
+    DEFAULT_MAX_POLL,
+    DEFAULT_TIMEOUT,
+    MAX_EXPECT_STATUS,
+    MAX_INTERVAL,
+    MAX_MAX_POLL,
+    MAX_MESSAGE_LEN,
+    MAX_TIMEOUT,
+    MAX_URL_LEN,
+    MIN_INTERVAL,
+    MIN_MAX_POLL,
+    MIN_TIMEOUT,
+    ApiCheckConfig,
+    normalize,
+    public_view,
+)
+
+
+def cfg(**overrides):
+    """Build a normalized config from a valid enabled baseline."""
+    raw = {
+        "version": 1,
+        "enabled": True,
+        "method": "GET",
+        "url": "https://api.example.com/check",
+        "api_key_enc": "ciphertext",
+        "sign_requests": True,
+    }
+    category = overrides.pop("category", "post_invite")
+    raw.update(overrides)
+    return normalize(raw, category=category)
+
+
+class TestNormalizeNeverRaises:
+    @pytest.mark.parametrize(
+        "raw",
+        [None, {}, "garbage", [1, 2], 5, True, 3.4, {"version": 99}, {"version": "x"}],
+    )
+    def test_junk_collapses_to_disabled_default(self, raw):
+        result = normalize(raw)
+
+        assert isinstance(result, ApiCheckConfig)
+        assert result.enabled is False
+        assert result.is_active is False
+
+    def test_wrong_typed_scalars_reset_to_defaults(self):
+        result = normalize(
+            {
+                "version": 1,
+                "enabled": "yes",
+                "method": ["GET"],
+                "url": 12345,
+                "interval_seconds": "soon",
+                "expect_status": "200",
+                "pending_message": 7,
+            }
+        )
+
+        assert result.method == "GET"
+        assert result.url == ""
+        assert result.interval_seconds == DEFAULT_INTERVAL
+        assert result.expect_status == (200,)
+        assert result.pending_message == ""
+
+
+class TestDefaults:
+    def test_empty_blob_defaults(self):
+        result = normalize({})
+
+        assert result.version == 1
+        assert result.enabled is False
+        assert result.method == "GET"
+        assert result.url == ""
+        assert result.auth_header == "Authorization"
+        assert result.auth_prefix == "Bearer "
+        assert result.api_key_enc == ""
+        assert result.code_param == "code"
+        assert result.username_param == "username"
+        assert result.email_param == "email"
+        assert result.expect_status == (200,)
+        assert result.interval_seconds == DEFAULT_INTERVAL
+        assert result.timeout_seconds == DEFAULT_TIMEOUT
+        assert result.max_poll_seconds == DEFAULT_MAX_POLL
+        assert result.sign_requests is True
+        assert result.pending_message == ""
+        assert result.success_message == ""
+
+
+class TestMethod:
+    @pytest.mark.parametrize(
+        ("given", "expected"), [("get", "GET"), ("post", "POST"), ("POST", "POST")]
+    )
+    def test_case_insensitive(self, given, expected):
+        assert cfg(method=given).method == expected
+
+    @pytest.mark.parametrize("given", ["PUT", "DELETE", "TRACE", "", "GET POST"])
+    def test_unsupported_method_falls_back_to_get(self, given):
+        assert cfg(method=given).method == "GET"
+
+
+class TestUrl:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.example.com/check",
+            "http://127.0.0.1:8080/pwa/status",
+            "http://nas.local/api",
+        ],
+    )
+    def test_accepts_http_and_https(self, url):
+        assert cfg(url=url).url == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "gopher://evil.test/",
+            "ftp://example.com/x",
+            "//evil.com/path",
+            "javascript:alert(1)",
+            "data:text/plain,hi",
+            "example.com/no-scheme",
+            "https://",
+            "http:///nohost",
+        ],
+    )
+    def test_rejects_non_http_scheme_or_missing_host(self, url):
+        result = cfg(url=url)
+
+        assert result.url == ""
+        assert result.is_active is False
+
+    @pytest.mark.parametrize(
+        "url",
+        ["https://user:pass@example.com/x", "http://admin@example.com/x"],
+    )
+    def test_rejects_embedded_credentials(self, url):
+        assert cfg(url=url).url == ""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.com/a\r\nX-Evil: 1",
+            "https://example.com/a\nb",
+            "https://exa mple.com/a",
+            "https://example.com/\tx",
+        ],
+    )
+    def test_rejects_whitespace_and_crlf(self, url):
+        assert cfg(url=url).url == ""
+
+    def test_rejects_over_length_url(self):
+        too_long = "https://example.com/" + ("a" * MAX_URL_LEN)
+
+        assert cfg(url=too_long).url == ""
+
+    def test_surrounding_whitespace_is_trimmed(self):
+        assert cfg(url="  https://example.com/x  ").url == "https://example.com/x"
+
+
+class TestHeaderAndPrefix:
+    @pytest.mark.parametrize("header", ["Authorization", "X-API-Key", "x-api-key", "A"])
+    def test_accepts_token_charset(self, header):
+        assert cfg(auth_header=header).auth_header == header
+
+    def test_empty_header_means_send_none(self):
+        assert cfg(auth_header="").auth_header == ""
+
+    @pytest.mark.parametrize(
+        "header",
+        ["X-Evil\r\nInjected: 1", "has space", "colon:name", "a" * 65, "naïve"],
+    )
+    def test_rejects_header_injection_charset(self, header):
+        assert cfg(auth_header=header).auth_header == "Authorization"
+
+    @pytest.mark.parametrize("prefix", ["Bearer ", "", "Token "])
+    def test_accepts_printable_prefix(self, prefix):
+        assert cfg(auth_prefix=prefix).auth_prefix == prefix
+
+    @pytest.mark.parametrize("prefix", ["Bearer\r\n", "a" * 33, "tab\there"])
+    def test_rejects_bad_prefix(self, prefix):
+        assert cfg(auth_prefix=prefix).auth_prefix == "Bearer "
+
+
+class TestParamNames:
+    @pytest.mark.parametrize("field", ["code_param", "username_param", "email_param"])
+    def test_empty_means_omit(self, field):
+        assert getattr(cfg(**{field: ""}), field) == ""
+
+    @pytest.mark.parametrize("field", ["code_param", "username_param", "email_param"])
+    @pytest.mark.parametrize("value", ["invite_code", "user.name", "a-b", "X1"])
+    def test_accepts_safe_charset(self, field, value):
+        assert getattr(cfg(**{field: value}), field) == value
+
+    @pytest.mark.parametrize("field", ["code_param", "username_param", "email_param"])
+    @pytest.mark.parametrize("value", ["has space", "a=b", "a&b[]", "a" * 65, "eq="])
+    def test_rejects_unsafe_charset(self, field, value):
+        defaults = {
+            "code_param": "code",
+            "username_param": "username",
+            "email_param": "email",
+        }
+
+        assert getattr(cfg(**{field: value}), field) == defaults[field]
+
+
+class TestExpectStatus:
+    def test_deduped_and_sorted(self):
+        assert cfg(expect_status=[204, 200, 204, 201]).expect_status == (200, 201, 204)
+
+    def test_drops_out_of_range_and_non_ints(self):
+        assert cfg(expect_status=[200, 99, 600, "abc", None, 204]).expect_status == (
+            200,
+            204,
+        )
+
+    def test_empty_after_filtering_falls_back_to_200(self):
+        assert cfg(expect_status=[99, 600]).expect_status == (200,)
+        assert cfg(expect_status=[]).expect_status == (200,)
+
+    def test_caps_entry_count(self):
+        result = cfg(expect_status=list(range(200, 200 + MAX_EXPECT_STATUS + 5)))
+
+        assert len(result.expect_status) == MAX_EXPECT_STATUS
+
+    def test_accepts_single_int(self):
+        assert cfg(expect_status=204).expect_status == (204,)
+
+
+class TestNumericBounds:
+    @pytest.mark.parametrize(
+        ("field", "low", "high"),
+        [
+            ("interval_seconds", MIN_INTERVAL, MAX_INTERVAL),
+            ("timeout_seconds", MIN_TIMEOUT, MAX_TIMEOUT),
+            ("max_poll_seconds", MIN_MAX_POLL, MAX_MAX_POLL),
+        ],
+    )
+    def test_clamped_to_range(self, field, low, high):
+        assert getattr(cfg(**{field: -5}), field) == low
+        assert getattr(cfg(**{field: 0}), field) == low
+        assert getattr(cfg(**{field: 10**9}), field) == high
+        assert getattr(cfg(**{field: low}), field) == low
+        assert getattr(cfg(**{field: high}), field) == high
+
+    def test_numeric_strings_are_coerced(self):
+        assert cfg(interval_seconds="30").interval_seconds == 30
+
+    def test_bools_are_not_treated_as_numbers(self):
+        assert cfg(interval_seconds=True).interval_seconds == DEFAULT_INTERVAL
+
+
+class TestMessages:
+    def test_trimmed_to_max_length(self):
+        result = cfg(pending_message="x" * (MAX_MESSAGE_LEN + 50))
+
+        assert len(result.pending_message) == MAX_MESSAGE_LEN
+
+    def test_newlines_survive_control_stripping(self):
+        assert cfg(pending_message="a\nb").pending_message == "a\nb"
+
+    def test_control_characters_are_stripped(self):
+        assert cfg(pending_message="a\x00\x07b\x7f").pending_message == "ab"
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "{{ config.SECRET_KEY }}",
+            "{% for x in y %}",
+            "{# comment #}",
+            "hello {{ 7*7 }} world",
+        ],
+    )
+    def test_template_syntax_is_dropped(self, message):
+        assert cfg(pending_message=message).pending_message == ""
+        assert cfg(success_message=message).success_message == ""
+
+    def test_unicode_and_emoji_survive(self):
+        text = "✅ 完了 🎉 café"
+
+        assert cfg(success_message=text).success_message == text
+
+    def test_html_is_preserved_verbatim_for_the_template_to_escape(self):
+        text = "<script>alert(1)</script>"
+
+        assert cfg(pending_message=text).pending_message == text
+
+
+class TestIsActive:
+    def test_fully_configured_signed_gate_is_active(self):
+        assert cfg().is_active is True
+
+    def test_disabled_flag_wins(self):
+        assert cfg(enabled=False).is_active is False
+
+    def test_blank_url_is_inactive(self):
+        assert cfg(url="").is_active is False
+
+    def test_signed_gate_without_key_is_inactive(self):
+        assert cfg(api_key_enc="", sign_requests=True).is_active is False
+
+    def test_unsigned_gate_without_key_is_active(self):
+        assert cfg(api_key_enc="", sign_requests=False).is_active is True
+
+    @pytest.mark.parametrize("category", ["pre_invite", "", "custom", None])
+    def test_only_post_invite_steps_can_gate(self, category):
+        assert cfg(category=category).is_active is False
+
+    def test_post_invite_category_is_active(self):
+        assert cfg(category="post_invite").is_active is True
+
+    def test_enabled_survives_a_pre_invite_category(self):
+        """Category suppresses activation but must not silently erase the config."""
+        result = cfg(category="pre_invite")
+
+        assert result.enabled is True
+        assert result.url == "https://api.example.com/check"
+
+
+class TestSerialisation:
+    def test_to_dict_round_trips(self):
+        original = cfg(
+            method="POST",
+            expect_status=[201, 204],
+            interval_seconds=30,
+            pending_message="hold on",
+        )
+
+        assert normalize(original.to_dict(), category="post_invite") == original
+
+    def test_to_dict_is_json_native(self):
+        blob = cfg(expect_status=[200, 204]).to_dict()
+
+        assert isinstance(blob["expect_status"], list)
+        assert blob["expect_status"] == [200, 204]
+        assert "category" not in blob
+
+    def test_to_dict_keeps_the_ciphertext_for_storage(self):
+        assert cfg(api_key_enc="ciphertext").to_dict()["api_key_enc"] == "ciphertext"
+
+
+class TestPublicView:
+    def test_never_exposes_the_ciphertext(self):
+        view = public_view({"version": 1, "enabled": True, "api_key_enc": "ciphertext"})
+
+        assert "api_key_enc" not in view
+        assert "ciphertext" not in str(view)
+
+    def test_reports_key_presence_as_a_boolean(self):
+        assert (
+            public_view({"version": 1, "api_key_enc": "ciphertext"})["has_api_key"]
+            is True
+        )
+        assert public_view({"version": 1, "api_key_enc": ""})["has_api_key"] is False
+
+    def test_handles_a_missing_blob(self):
+        view = public_view(None)
+
+        assert view["enabled"] is False
+        assert view["has_api_key"] is False
+
+    def test_exposes_the_fields_the_widget_needs(self):
+        view = public_view(
+            {
+                "version": 1,
+                "enabled": True,
+                "url": "https://example.com/x",
+                "interval_seconds": 20,
+                "pending_message": "waiting",
+            }
+        )
+
+        assert view["interval_seconds"] == 20
+        assert view["pending_message"] == "waiting"
+
+
+class TestApiKeyDecryption:
+    def test_round_trips_through_the_shared_credential_helpers(self):
+        from app.services.ldap.encryption import encrypt_credential
+
+        result = cfg(api_key_enc=encrypt_credential("sk-live-secret"))
+
+        assert result.api_key() == "sk-live-secret"
+
+    def test_undecryptable_ciphertext_yields_empty_string(self):
+        assert cfg(api_key_enc="not-a-fernet-token").api_key() == ""
+
+    def test_blank_ciphertext_yields_empty_string(self):
+        assert cfg(api_key_enc="", sign_requests=False).api_key() == ""
+
+
+class TestRepr:
+    def test_repr_redacts_the_ciphertext(self):
+        text = repr(cfg(api_key_enc="super-secret-ciphertext"))
+
+        assert "super-secret-ciphertext" not in text
+        assert "***" in text

--- a/tests/external/api_check/test_e2e_api_check.py
+++ b/tests/external/api_check/test_e2e_api_check.py
@@ -1,0 +1,225 @@
+"""End-to-end browser test for the wizard API-check gate.
+
+Drives a real Chromium against a live server and a real mock upstream, so it
+covers the parts no unit test can: that HTMX actually polls, that the cooldown
+surfaces in the UI, that a passing check flips the card and releases the Next
+button without a page reload, and that polling then stops.
+"""
+
+import contextlib
+import itertools
+import multiprocessing
+
+import pytest
+from playwright.sync_api import Page, expect
+
+# pytest-flask's live_server forks; spawn/forkserver cannot pickle the fixtures.
+with contextlib.suppress(RuntimeError):
+    multiprocessing.set_start_method("fork", force=True)
+
+from app.extensions import db
+from app.models import Invitation, MediaServer, User, WizardStep
+
+_CODE_SEQ = itertools.count(1)
+USERNAME = "e2e-gate-user"
+EMAIL = "e2e-gate@example.com"
+INTERVAL = 5
+SERVER_TYPE = "jellyfin"
+
+CARD = "div[id^='wizard-api-check-'][role='status']"
+NEXT = "#wizard-next-btn"
+
+
+@pytest.fixture
+def gate_world(live_server, mock_api):
+    """A gated post-invite step plus the accepted invitation that reaches it.
+
+    Bound to ``live_server.app`` rather than the ``app`` fixture: another e2e
+    module defines its own session-scoped ``app`` on a different SQLite file,
+    and ``live_server`` binds to whichever wins, so this is the only way to be
+    sure the data lands in the database the browser will actually read.
+    """
+    code = f"E2EGATE{next(_CODE_SEQ):03d}"
+    server_app = live_server.app
+
+    with server_app.app_context():
+        # The app seeds default steps for every server type on boot; clear the
+        # ones for our server so positions are ours alone.
+        WizardStep.query.filter_by(
+            server_type=SERVER_TYPE, category="post_invite"
+        ).delete()
+
+        server = MediaServer.query.filter_by(server_type=SERVER_TYPE).first()
+        if server is None:
+            server = MediaServer(
+                name="E2E Gate Server",
+                server_type=SERVER_TYPE,
+                url="http://127.0.0.1:8096",
+                api_key="unused",
+            )
+            db.session.add(server)
+        db.session.flush()
+
+        invitation = Invitation(code=code, used=True, unlimited=False)
+        user = User(
+            token=f"tok-{code}",
+            username=USERNAME,
+            email=EMAIL,
+            code=code,
+            server_id=server.id,
+        )
+        db.session.add_all([invitation, user])
+        db.session.flush()
+        invitation.users.append(user)
+        invitation.servers.append(server)
+
+        db.session.add_all(
+            [
+                WizardStep(
+                    server_type=SERVER_TYPE,
+                    category="post_invite",
+                    position=0,
+                    title="Install the app",
+                    markdown="# Install the app\n\n{{ widget:api_check }}",
+                    api_check={
+                        "version": 1,
+                        "enabled": True,
+                        "method": "GET",
+                        "url": mock_api.path("/check"),
+                        "auth_header": "",
+                        "api_key_enc": "",
+                        "sign_requests": False,
+                        "expect_status": [200],
+                        "interval_seconds": INTERVAL,
+                        "timeout_seconds": 5,
+                        "max_poll_seconds": 600,
+                        "pending_message": "Install the app, then tap Re-check",
+                        "success_message": "App detected, you are good to go",
+                    },
+                ),
+                WizardStep(
+                    server_type=SERVER_TYPE,
+                    category="post_invite",
+                    position=1,
+                    title="All done",
+                    markdown="# All done",
+                ),
+            ]
+        )
+        db.session.commit()
+
+    yield {"code": code, "app": server_app}
+
+    with server_app.app_context():
+        WizardStep.query.filter_by(
+            server_type=SERVER_TYPE, category="post_invite"
+        ).delete()
+        # Delete through the ORM: a bulk delete leaves invitation_user rows
+        # behind, and SQLite reuses ids, so the next run collides on them.
+        stale = Invitation.query.filter_by(code=code).first()
+        if stale is not None:
+            stale.users.clear()
+            stale.servers.clear()
+            db.session.delete(stale)
+        for orphan in User.query.filter_by(code=code).all():
+            db.session.delete(orphan)
+        db.session.commit()
+
+
+def _session_cookie_value(client) -> str:
+    """The signed session id werkzeug issued, whatever domain it filed it under."""
+    cookie = client.get_cookie("session")
+    if cookie is not None:
+        return cookie.value
+    for (_domain, _path, name), stored in client._cookies.items():
+        if name == "session":
+            return stored.value
+    raise AssertionError("no session cookie was issued")
+
+
+@pytest.fixture
+def gated_page(page: Page, live_server, gate_world):
+    """A browser already holding an accepted-invitation session.
+
+    Sessions are server-side (cachelib on disk) and live_server forks this
+    process, so handing the browser the session id is enough to land it in the
+    post-invite flow without replaying the whole invitation journey.
+    """
+    client = gate_world["app"].test_client()
+    with client.session_transaction() as sess:
+        sess["wizard_access"] = gate_world["code"]
+
+    page.context.add_cookies(
+        [
+            {
+                "name": "session",
+                "value": _session_cookie_value(client),
+                "url": live_server.url(),
+            }
+        ]
+    )
+    return page
+
+
+def test_gate_blocks_then_releases(gated_page: Page, live_server, mock_api):
+    mock_api.set_status(403)
+
+    gated_page.goto(f"{live_server.url()}/wizard/post-wizard/0")
+
+    # The card renders and the load trigger fires an immediate check.
+    expect(gated_page.locator(CARD)).to_be_visible()
+    expect(gated_page.locator(CARD)).to_contain_text(
+        "Install the app, then tap Re-check"
+    )
+    assert mock_api.wait_for(1), "the card should check once on load"
+
+    # Next is locked while the gate is unsatisfied.
+    expect(gated_page.locator(NEXT)).to_have_attribute("aria-disabled", "true")
+
+    # A manual re-check inside the interval is refused server-side.
+    gated_page.locator(f"{CARD} button").click()
+    expect(gated_page.locator(CARD)).to_contain_text("Please wait")
+    assert mock_api.request_count == 1, "the cooldown must suppress the extra call"
+
+    # Once the upstream approves, the next automatic poll flips the card.
+    mock_api.set_status(200)
+    expect(gated_page.locator(CARD)).to_contain_text(
+        "App detected, you are good to go", timeout=(INTERVAL + 10) * 1000
+    )
+
+    # ...and releases the Next button without a page reload.
+    expect(gated_page.locator(NEXT)).not_to_have_attribute("aria-disabled", "true")
+
+    # Polling stops once it has passed.
+    settled = mock_api.request_count
+    gated_page.wait_for_timeout((INTERVAL + 2) * 1000)
+    assert mock_api.request_count == settled, "a passed gate must stop polling"
+
+
+def test_navigation_is_blocked_while_the_gate_is_locked(
+    gated_page: Page, live_server, mock_api
+):
+    mock_api.set_status(403)
+
+    gated_page.goto(f"{live_server.url()}/wizard/post-wizard/1")
+
+    expect(gated_page.locator("h1")).to_contain_text("Install the app")
+
+
+def test_recheck_does_not_satisfy_require_interaction(
+    gated_page: Page, live_server, mock_api, gate_world
+):
+    """The card's own button is marked so it cannot unlock Next by itself."""
+    mock_api.set_status(403)
+    with gate_world["app"].app_context():
+        step = WizardStep.query.filter_by(server_type=SERVER_TYPE, position=0).first()
+        step.require_interaction = True
+        db.session.commit()
+
+    gated_page.goto(f"{live_server.url()}/wizard/post-wizard/0")
+    expect(gated_page.locator(CARD)).to_be_visible()
+
+    gated_page.locator(f"{CARD} button").click()
+    gated_page.wait_for_timeout(500)
+
+    expect(gated_page.locator(NEXT)).to_have_attribute("aria-disabled", "true")

--- a/tests/external/api_check/test_endpoint.py
+++ b/tests/external/api_check/test_endpoint.py
@@ -1,0 +1,263 @@
+"""The /wizard/api-check/<step_id> poll endpoint.
+
+This is the only unauthenticated, outbound-calling endpoint in the app, so most
+of these tests are about what it refuses to do: call the upstream for someone
+who is not in the flow, call it twice inside the cooldown, redirect an HTMX
+fragment, or leak anything about the upstream's answer.
+"""
+
+from tests.external.api_check.conftest import INVITE_CODE, api_check_blob
+
+
+def url(step_id):
+    return f"/wizard/api-check/{step_id}"
+
+
+def htmx(client, step_id):
+    return client.get(url(step_id), headers={"HX-Request": "true"})
+
+
+class TestAccessControl:
+    def test_requires_an_accepted_invitation(self, client, gated_step, mock_api):
+        response = htmx(client, gated_step)
+
+        assert response.status_code == 286
+        assert mock_api.request_count == 0, "no session must never reach the upstream"
+
+    def test_never_redirects_an_htmx_fragment(self, client, gated_step):
+        """A 302 would swap the homepage into the card."""
+        response = htmx(client, gated_step)
+
+        assert response.status_code not in {301, 302, 303, 307, 308}
+        assert "Location" not in response.headers
+
+    def test_a_pre_invite_session_is_not_enough(self, client, gated_step, mock_api):
+        with client.session_transaction() as sess:
+            sess["wizarr_invite_code"] = INVITE_CODE
+            sess["invitation_in_progress"] = True
+
+        response = htmx(client, gated_step)
+
+        assert response.status_code == 286
+        assert mock_api.request_count == 0
+
+    def test_accepted_invitation_is_allowed(
+        self, accepted_client, gated_step, mock_api
+    ):
+        response = htmx(accepted_client, gated_step)
+
+        assert response.status_code in {200, 286}
+        assert mock_api.request_count == 1
+
+
+class TestStepResolution:
+    def test_unknown_step_id_makes_no_upstream_call(
+        self, accepted_client, gated_step, mock_api
+    ):
+        response = htmx(accepted_client, 999999)
+
+        assert response.status_code == 286
+        assert mock_api.request_count == 0
+
+    def test_ungated_step_makes_no_upstream_call(
+        self, accepted_client, make_step, mock_api
+    ):
+        plain = make_step(1, api_check=None)
+
+        response = htmx(accepted_client, plain)
+
+        assert response.status_code == 286
+        assert mock_api.request_count == 0
+
+    def test_pre_invite_step_cannot_be_checked(
+        self, accepted_client, make_step, mock_api
+    ):
+        step_id = make_step(
+            0, api_check=api_check_blob(mock_api.path("/check")), category="pre_invite"
+        )
+
+        response = htmx(accepted_client, step_id)
+
+        assert response.status_code == 286
+        assert mock_api.request_count == 0
+
+    def test_a_step_outside_the_current_flow_is_refused(
+        self, accepted_client, make_step, mock_api, app
+    ):
+        """A forged id from another server's wizard must not trigger a call."""
+        from app.extensions import db
+        from app.models import WizardStep
+
+        with app.app_context():
+            foreign = WizardStep(
+                server_type="plex",
+                category="post_invite",
+                position=0,
+                title="Foreign",
+                markdown="# x",
+                api_check=api_check_blob(mock_api.path("/check")),
+            )
+            db.session.add(foreign)
+            db.session.commit()
+            foreign_id = foreign.id
+
+        response = htmx(accepted_client, foreign_id)
+
+        assert response.status_code == 286
+        assert mock_api.request_count == 0
+
+
+class TestVerdicts:
+    def test_passing_check_reports_passed(self, accepted_client, gated_step, mock_api):
+        response = htmx(accepted_client, gated_step)
+
+        assert response.headers["X-Wizarr-Gate"] == "passed"
+        assert response.status_code == 286
+
+    def test_passing_check_triggers_the_unlock_event(self, accepted_client, gated_step):
+        response = htmx(accepted_client, gated_step)
+
+        assert "wizard:gate-passed" in response.headers.get("HX-Trigger", "")
+
+    def test_failing_check_reports_pending_and_keeps_polling(
+        self, accepted_client, gated_step, mock_api
+    ):
+        mock_api.set_status(403)
+
+        response = htmx(accepted_client, gated_step)
+
+        assert response.status_code == 200
+        assert response.headers["X-Wizarr-Gate"] == "pending"
+        assert b"hx-trigger" in response.data.lower()
+
+    def test_a_pass_is_remembered_without_calling_upstream_again(
+        self, accepted_client, gated_step, mock_api
+    ):
+        htmx(accepted_client, gated_step)
+        assert mock_api.request_count == 1
+
+        response = htmx(accepted_client, gated_step)
+
+        assert response.headers["X-Wizarr-Gate"] == "passed"
+        assert mock_api.request_count == 1, "an already-passed gate must not re-call"
+
+    def test_identity_is_sent_to_the_upstream(
+        self, accepted_client, gated_step, mock_api
+    ):
+        from tests.external.api_check.conftest import EMAIL, USERNAME
+
+        htmx(accepted_client, gated_step)
+
+        recorded = mock_api.last()
+        assert recorded.code == INVITE_CODE
+        assert recorded.username == USERNAME
+        assert recorded.email == EMAIL
+
+
+class TestCooldown:
+    def test_second_check_inside_the_interval_is_refused(
+        self, accepted_client, gated_step, mock_api
+    ):
+        mock_api.set_status(403)
+
+        htmx(accepted_client, gated_step)
+        response = htmx(accepted_client, gated_step)
+
+        assert response.headers["X-Wizarr-Gate"] == "cooldown"
+        assert mock_api.request_count == 1, "the cooldown must be enforced server-side"
+
+    def test_cooldown_advertises_retry_after(
+        self, accepted_client, gated_step, mock_api
+    ):
+        mock_api.set_status(403)
+        htmx(accepted_client, gated_step)
+
+        response = htmx(accepted_client, gated_step)
+
+        assert int(response.headers["Retry-After"]) > 0
+
+    def test_cooldown_still_swaps_a_card(self, accepted_client, gated_step, mock_api):
+        mock_api.set_status(403)
+        htmx(accepted_client, gated_step)
+
+        response = htmx(accepted_client, gated_step)
+
+        assert response.status_code == 200
+        assert b"wizard-api-check" in response.data
+
+    def test_rapid_fire_rechecks_hit_the_upstream_once(
+        self, accepted_client, gated_step, mock_api
+    ):
+        mock_api.set_status(403)
+
+        for _ in range(6):
+            htmx(accepted_client, gated_step)
+
+        assert mock_api.request_count == 1
+
+
+class TestNoInformationLeak:
+    def test_upstream_body_is_never_echoed(self, accepted_client, gated_step, mock_api):
+        mock_api.set_status(403)
+
+        response = htmx(accepted_client, gated_step)
+
+        assert b'"ok"' not in response.data
+
+    def test_upstream_url_is_never_exposed(self, accepted_client, make_step, mock_api):
+        step_id = make_step(
+            0, api_check=api_check_blob(mock_api.path("/private-internal-path"))
+        )
+        mock_api.set_status(403)
+
+        response = htmx(accepted_client, step_id)
+
+        assert b"private-internal-path" not in response.data
+        assert str(mock_api.port).encode() not in response.data
+
+    def test_failure_reasons_are_indistinguishable_to_the_user(
+        self, accepted_client, make_step, app
+    ):
+        """DNS failure and a 500 must look the same from the browser."""
+        import socket
+
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            dead_port = sock.getsockname()[1]
+
+        refused = make_step(
+            0, api_check=api_check_blob(f"http://127.0.0.1:{dead_port}/c")
+        )
+        dns = make_step(1, api_check=api_check_blob("http://wizarr-nope.invalid/c"))
+
+        first = htmx(accepted_client, refused)
+        second = htmx(accepted_client, dns)
+
+        assert (
+            first.headers["X-Wizarr-Gate"]
+            == second.headers["X-Wizarr-Gate"]
+            == "pending"
+        )
+
+    def test_api_key_never_appears_in_the_response(
+        self, accepted_client, make_step, signed_mock_api, signed_blob_factory
+    ):
+        from tests.external.api_check.conftest import API_SECRET
+
+        step_id = make_step(
+            0, api_check=signed_blob_factory(signed_mock_api.path("/check"))
+        )
+
+        response = htmx(accepted_client, step_id)
+
+        assert API_SECRET.encode() not in response.data
+
+
+class TestAdminAccess:
+    def test_admins_may_poll_without_an_invitation(
+        self, admin_client, gated_step, mock_api
+    ):
+        response = htmx(admin_client, gated_step)
+
+        assert response.status_code in {200, 286}
+        assert mock_api.request_count == 1

--- a/tests/external/api_check/test_export_import.py
+++ b/tests/external/api_check/test_export_import.py
@@ -1,0 +1,211 @@
+"""Export/import round-tripping of the api_check config.
+
+The one rule that matters here: the encrypted credential must never leave the
+database. An exported step carries the whole gate configuration except the key,
+and importing it produces a gate that is inert until an admin supplies one -
+so a shared JSON file cannot lock anybody out against a stranger's endpoint.
+"""
+
+from app.extensions import db
+from app.models import WizardStep
+from app.services.ldap.encryption import encrypt_credential
+from app.services.wizard_api_check.config import normalize
+from app.services.wizard_export_import import WizardExportImportService
+from tests.external.api_check.conftest import api_check_blob
+
+CIPHERTEXT_MARKER = "sk-live-super-secret"
+
+
+def gated_blob():
+    return api_check_blob(
+        "https://api.example.com/check",
+        sign_requests=True,
+        api_key_enc=encrypt_credential(CIPHERTEXT_MARKER),
+        interval_seconds=25,
+        expect_status=[200, 204],
+        pending_message="Install the app",
+    )
+
+
+def make_gated_step(app, server_type="jellyfin"):
+    with app.app_context():
+        step = WizardStep(
+            server_type=server_type,
+            category="post_invite",
+            position=0,
+            title="Gated",
+            markdown="# Gated\n\n{{ widget:api_check }}",
+            api_check=gated_blob(),
+        )
+        db.session.add(step)
+        db.session.commit()
+        return step.id
+
+
+class TestExport:
+    def test_export_carries_the_configuration(self, app, session):
+        make_gated_step(app)
+
+        with app.app_context():
+            export = WizardExportImportService().export_steps_by_server_type("jellyfin")
+            blob = export.to_dict()["steps"][0]["api_check"]
+
+        assert blob["enabled"] is True
+        assert blob["url"] == "https://api.example.com/check"
+        assert blob["interval_seconds"] == 25
+        assert blob["expect_status"] == [200, 204]
+        assert blob["pending_message"] == "Install the app"
+
+    def test_export_never_contains_the_credential(self, app, session):
+        import json
+
+        make_gated_step(app)
+
+        with app.app_context():
+            export = WizardExportImportService().export_steps_by_server_type("jellyfin")
+            serialised = json.dumps(export.to_dict())
+
+        assert "api_key_enc" not in serialised
+        assert CIPHERTEXT_MARKER not in serialised
+
+    def test_export_reports_key_presence_without_the_key(self, app, session):
+        make_gated_step(app)
+
+        with app.app_context():
+            export = WizardExportImportService().export_steps_by_server_type("jellyfin")
+            blob = export.to_dict()["steps"][0]["api_check"]
+
+        assert blob["has_api_key"] is True
+
+    def test_ungated_steps_export_an_inert_config(self, app, session):
+        with app.app_context():
+            db.session.add(
+                WizardStep(
+                    server_type="jellyfin",
+                    category="post_invite",
+                    position=0,
+                    title="Plain",
+                    markdown="# Plain",
+                )
+            )
+            db.session.commit()
+
+            export = WizardExportImportService().export_steps_by_server_type("jellyfin")
+            blob = export.to_dict()["steps"][0]["api_check"]
+
+        assert blob["enabled"] is False
+
+
+class TestImport:
+    def test_import_restores_the_configuration(self, app, session):
+        make_gated_step(app)
+
+        with app.app_context():
+            service = WizardExportImportService()
+            payload = service.export_steps_by_server_type("jellyfin").to_dict()
+            WizardStep.query.delete()
+            db.session.commit()
+
+            result = service.import_data(payload, replace_existing=True)
+            assert result.success, result.errors
+
+            step = WizardStep.query.filter_by(server_type="jellyfin").first()
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.enabled is True
+        assert cfg.url == "https://api.example.com/check"
+        assert cfg.interval_seconds == 25
+
+    def test_an_imported_signed_gate_is_inert_without_a_key(self, app, session):
+        make_gated_step(app)
+
+        with app.app_context():
+            service = WizardExportImportService()
+            payload = service.export_steps_by_server_type("jellyfin").to_dict()
+            WizardStep.query.delete()
+            db.session.commit()
+            service.import_data(payload, replace_existing=True)
+
+            step = WizardStep.query.filter_by(server_type="jellyfin").first()
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.api_key_enc == ""
+        assert cfg.is_active is False, "an imported gate must not block until keyed"
+
+    def test_a_hostile_payload_cannot_smuggle_a_credential(self, app, session):
+        with app.app_context():
+            payload = {
+                "export_type": "steps",
+                "server_type": "jellyfin",
+                "steps": [
+                    {
+                        "server_type": "jellyfin",
+                        "category": "post_invite",
+                        "position": 0,
+                        "title": "Hostile",
+                        "markdown": "# x",
+                        "api_check": {
+                            "version": 1,
+                            "enabled": True,
+                            "url": "https://attacker.test/collect",
+                            "api_key_enc": "injected-ciphertext",
+                            "sign_requests": True,
+                        },
+                    }
+                ],
+            }
+            WizardExportImportService().import_data(payload, replace_existing=True)
+
+            step = WizardStep.query.filter_by(server_type="jellyfin").first()
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert cfg.api_key_enc == ""
+        assert cfg.is_active is False
+
+    def test_import_tolerates_a_missing_api_check_key(self, app, session):
+        with app.app_context():
+            payload = {
+                "export_type": "steps",
+                "server_type": "jellyfin",
+                "steps": [
+                    {
+                        "server_type": "jellyfin",
+                        "category": "post_invite",
+                        "position": 0,
+                        "title": "Legacy export",
+                        "markdown": "# x",
+                    }
+                ],
+            }
+
+            result = WizardExportImportService().import_data(
+                payload, replace_existing=True
+            )
+            step = WizardStep.query.filter_by(server_type="jellyfin").first()
+            cfg = normalize(step.api_check, category=step.category)
+
+        assert result.success, result.errors
+        assert cfg.enabled is False
+
+    def test_import_rejects_a_malformed_api_check(self, app, session):
+        with app.app_context():
+            payload = {
+                "export_type": "steps",
+                "server_type": "jellyfin",
+                "steps": [
+                    {
+                        "server_type": "jellyfin",
+                        "category": "post_invite",
+                        "position": 0,
+                        "title": "Broken",
+                        "markdown": "# x",
+                        "api_check": "not-a-dict",
+                    }
+                ],
+            }
+
+            result = WizardExportImportService().import_data(
+                payload, replace_existing=True
+            )
+
+        assert result.success is False

--- a/tests/external/api_check/test_gate.py
+++ b/tests/external/api_check/test_gate.py
@@ -1,0 +1,243 @@
+"""Session-backed gate state: passes, cooldowns, poll caps and index clamping.
+
+The gate is what makes the check authoritative rather than decorative, so these
+tests care most about the ways a determined user might try to get past it:
+replaying another invitation's session, hammering the re-check button, or
+jumping straight to a later step index.
+"""
+
+import time
+import types
+
+import pytest
+
+from app.services.wizard_api_check import gate
+from app.services.wizard_api_check.config import normalize
+
+
+def step(step_id, *, active=True, category="post_invite"):
+    """A minimal stand-in for the wizard's step adapter."""
+    raw = {
+        "version": 1,
+        "enabled": active,
+        "url": "https://api.example.com/check" if active else "",
+        "sign_requests": False,
+    }
+    return types.SimpleNamespace(
+        step_id=step_id, api_check=normalize(raw, category=category)
+    )
+
+
+def legacy_step():
+    """A markdown-file step: no id, no config."""
+    return types.SimpleNamespace(content="# hello")
+
+
+@pytest.fixture
+def ctx(app):
+    """A request context with an accepted invitation in the session."""
+    with app.test_request_context("/wizard/post-wizard/0") as context:
+        from flask import session
+
+        session["wizard_access"] = "INVITE-A"
+        gate._IN_PROCESS_CALLS.clear()
+        yield context
+
+
+class TestPassTracking:
+    def test_unseen_step_has_not_passed(self, ctx):
+        assert gate.has_passed(3) is False
+
+    def test_marking_a_pass_is_remembered(self, ctx):
+        gate.mark_passed(3)
+
+        assert gate.has_passed(3) is True
+
+    def test_passes_are_per_step(self, ctx):
+        gate.mark_passed(3)
+
+        assert gate.has_passed(4) is False
+
+    def test_marking_twice_is_idempotent(self, ctx):
+        from flask import session
+
+        gate.mark_passed(3)
+        gate.mark_passed(3)
+
+        assert session[gate.GATE_SESSION_KEY]["passed"] == [3]
+
+    def test_none_step_id_is_ignored(self, ctx):
+        gate.mark_passed(None)
+
+        assert gate.has_passed(None) is False
+
+
+class TestScopeIsolation:
+    def test_switching_invitation_discards_earlier_passes(self, ctx):
+        from flask import session
+
+        gate.mark_passed(3)
+        session["wizard_access"] = "INVITE-B"
+
+        assert gate.has_passed(3) is False
+
+    def test_returning_to_the_original_invitation_does_not_resurrect_passes(self, ctx):
+        from flask import session
+
+        gate.mark_passed(3)
+        session["wizard_access"] = "INVITE-B"
+        gate.has_passed(3)
+        session["wizard_access"] = "INVITE-A"
+
+        assert gate.has_passed(3) is False
+
+    def test_scope_is_not_the_raw_invite_code(self, ctx):
+        from flask import session
+
+        gate.mark_passed(3)
+
+        assert "INVITE-A" not in str(session[gate.GATE_SESSION_KEY])
+
+    def test_clear_removes_all_state(self, ctx):
+        from flask import session
+
+        gate.mark_passed(3)
+        gate.clear()
+
+        assert gate.GATE_SESSION_KEY not in session
+        assert gate.has_passed(3) is False
+
+
+class TestCooldown:
+    def test_first_call_is_allowed(self, ctx):
+        assert gate.reserve(3, interval=10) == 0.0
+
+    def test_second_call_within_the_interval_is_refused(self, ctx):
+        gate.reserve(3, interval=10)
+
+        remaining = gate.reserve(3, interval=10)
+
+        assert 0 < remaining <= 10
+
+    def test_cooldown_is_per_step(self, ctx):
+        gate.reserve(3, interval=10)
+
+        assert gate.reserve(4, interval=10) == 0.0
+
+    def test_reservation_is_taken_before_the_upstream_call(self, ctx):
+        """Two racing requests must not both reach the upstream."""
+        allowed = [gate.reserve(3, interval=30) for _ in range(5)]
+
+        assert allowed.count(0.0) == 1
+
+    def test_cooldown_expires(self, ctx):
+        gate.reserve(3, interval=10)
+        gate._IN_PROCESS_CALLS.clear()
+        from flask import session
+
+        session[gate.GATE_SESSION_KEY]["next_at"]["3"] = time.time() - 1
+
+        assert gate.reserve(3, interval=10) == 0.0
+
+    def test_in_process_floor_survives_a_wiped_session_entry(self, ctx):
+        """A client cannot shorten the cooldown by dropping the session value."""
+        from flask import session
+
+        gate.reserve(3, interval=30)
+        session[gate.GATE_SESSION_KEY]["next_at"].clear()
+
+        assert gate.reserve(3, interval=30) > 0
+
+
+class TestPollCap:
+    def test_not_capped_before_the_first_poll(self, ctx):
+        assert gate.is_capped(3, max_poll_seconds=600) is False
+
+    def test_not_capped_within_the_window(self, ctx):
+        gate.note_poll_started(3)
+
+        assert gate.is_capped(3, max_poll_seconds=600) is False
+
+    def test_capped_after_the_window(self, ctx):
+        from flask import session
+
+        gate.note_poll_started(3)
+        session[gate.GATE_SESSION_KEY]["started"]["3"] = time.time() - 601
+
+        assert gate.is_capped(3, max_poll_seconds=600) is True
+
+    def test_first_poll_timestamp_is_not_reset_by_later_polls(self, ctx):
+        from flask import session
+
+        gate.note_poll_started(3)
+        original = session[gate.GATE_SESSION_KEY]["started"]["3"]
+        gate.note_poll_started(3)
+
+        assert session[gate.GATE_SESSION_KEY]["started"]["3"] == original
+
+
+class TestFirstLockedIndex:
+    def test_no_steps_are_never_locked(self, ctx):
+        assert gate.first_locked_index([], exempt=False) is None
+
+    def test_ungated_steps_are_never_locked(self, ctx):
+        steps = [step(1, active=False), step(2, active=False)]
+
+        assert gate.first_locked_index(steps, exempt=False) is None
+
+    def test_returns_the_first_unpassed_gate(self, ctx):
+        steps = [step(1, active=False), step(2), step(3)]
+
+        assert gate.first_locked_index(steps, exempt=False) == 1
+
+    def test_passing_the_first_gate_advances_to_the_next(self, ctx):
+        steps = [step(1), step(2)]
+        gate.mark_passed(1)
+
+        assert gate.first_locked_index(steps, exempt=False) == 1
+
+    def test_all_gates_passed_unlocks_everything(self, ctx):
+        steps = [step(1), step(2)]
+        gate.mark_passed(1)
+        gate.mark_passed(2)
+
+        assert gate.first_locked_index(steps, exempt=False) is None
+
+    def test_admins_are_exempt(self, ctx):
+        steps = [step(1)]
+
+        assert gate.first_locked_index(steps, exempt=True) is None
+
+    def test_pre_invite_steps_cannot_gate(self, ctx):
+        steps = [step(1, category="pre_invite")]
+
+        assert gate.first_locked_index(steps, exempt=False) is None
+
+    def test_legacy_markdown_steps_are_skipped(self, ctx):
+        steps = [legacy_step(), step(2)]
+
+        assert gate.first_locked_index(steps, exempt=False) == 1
+
+    def test_a_step_without_an_id_cannot_gate(self, ctx):
+        orphan = types.SimpleNamespace(step_id=None, api_check=step(1).api_check)
+
+        assert gate.first_locked_index([orphan], exempt=False) is None
+
+
+class TestAnonymousAndAdminScopes:
+    def test_no_invitation_still_works_without_crashing(self, app):
+        with app.test_request_context("/wizard/post-wizard/0"):
+            gate._IN_PROCESS_CALLS.clear()
+            gate.mark_passed(3)
+
+            assert gate.has_passed(3) is True
+
+    def test_an_anonymous_pass_does_not_leak_into_an_invitation(self, app):
+        with app.test_request_context("/wizard/post-wizard/0"):
+            from flask import session
+
+            gate._IN_PROCESS_CALLS.clear()
+            gate.mark_passed(3)
+            session["wizard_access"] = "INVITE-A"
+
+            assert gate.has_passed(3) is False

--- a/tests/external/api_check/test_gating_routes.py
+++ b/tests/external/api_check/test_gating_routes.py
@@ -1,0 +1,272 @@
+"""Server-side enforcement of the gate across the wizard routes.
+
+Blocking the Next button is cosmetic; these tests cover the part that actually
+makes the gate mandatory - that typing a later index, or jumping straight to the
+completion page, does not get a user past an unsatisfied check.
+"""
+
+from tests.external.api_check.conftest import api_check_blob
+
+
+def check_url(step_id):
+    return f"/wizard/api-check/{step_id}"
+
+
+class TestIndexClamping:
+    def test_a_locked_gate_pins_the_user_to_its_step(
+        self, accepted_client, make_step, mock_api
+    ):
+        make_step(0, api_check=api_check_blob(mock_api.path("/check")))
+        make_step(1, api_check=None, markdown="# Second step")
+        mock_api.set_status(403)
+
+        response = accepted_client.get(
+            "/wizard/post-wizard/1", headers={"HX-Request": "true"}
+        )
+
+        assert response.headers["X-Wizard-Idx"] == "0"
+
+    def test_the_locked_step_reports_itself_as_gated(
+        self, accepted_client, gated_step, make_step, mock_api
+    ):
+        make_step(1, api_check=None, markdown="# Second step")
+        mock_api.set_status(403)
+
+        response = accepted_client.get(
+            "/wizard/post-wizard/0", headers={"HX-Request": "true"}
+        )
+
+        assert response.headers["X-Wizard-Gate-Locked"] == "true"
+
+    def test_passing_the_gate_releases_the_next_step(
+        self, accepted_client, gated_step, make_step, mock_api
+    ):
+        make_step(1, api_check=None, markdown="# Second step")
+        accepted_client.get(check_url(gated_step), headers={"HX-Request": "true"})
+
+        response = accepted_client.get(
+            "/wizard/post-wizard/1", headers={"HX-Request": "true"}
+        )
+
+        assert response.headers["X-Wizard-Idx"] == "1"
+        assert response.headers["X-Wizard-Gate-Locked"] == "false"
+
+    def test_a_second_gate_clamps_again(self, accepted_client, make_step, mock_api):
+        first = make_step(0, api_check=api_check_blob(mock_api.path("/check")))
+        make_step(1, api_check=api_check_blob(mock_api.path("/check")))
+        make_step(2, api_check=None, markdown="# Third step")
+
+        accepted_client.get(check_url(first), headers={"HX-Request": "true"})
+        mock_api.set_status(403)
+
+        response = accepted_client.get(
+            "/wizard/post-wizard/2", headers={"HX-Request": "true"}
+        )
+
+        assert response.headers["X-Wizard-Idx"] == "1"
+
+    def test_ungated_wizards_are_unaffected(self, accepted_client, make_step):
+        make_step(0, api_check=None, markdown="# One")
+        make_step(1, api_check=None, markdown="# Two")
+
+        response = accepted_client.get(
+            "/wizard/post-wizard/1", headers={"HX-Request": "true"}
+        )
+
+        assert response.headers["X-Wizard-Idx"] == "1"
+        assert response.headers["X-Wizard-Gate-Locked"] == "false"
+
+    def test_an_inactive_gate_does_not_clamp(
+        self, accepted_client, make_step, mock_api
+    ):
+        make_step(
+            0,
+            api_check=api_check_blob(
+                mock_api.path("/check"), sign_requests=True, api_key_enc=""
+            ),
+        )
+        make_step(1, api_check=None, markdown="# Second")
+
+        response = accepted_client.get(
+            "/wizard/post-wizard/1", headers={"HX-Request": "true"}
+        )
+
+        assert response.headers["X-Wizard-Idx"] == "1"
+
+
+class TestCompletionIsGated:
+    def test_completion_bounces_back_to_the_locked_step(
+        self, accepted_client, gated_step, mock_api
+    ):
+        mock_api.set_status(403)
+
+        response = accepted_client.get("/wizard/complete")
+
+        assert response.status_code in {302, 303}
+        assert "/wizard/post-wizard/0" in response.headers["Location"]
+
+    def test_completion_succeeds_once_the_gate_passes(
+        self, accepted_client, gated_step, mock_api
+    ):
+        accepted_client.get(check_url(gated_step), headers={"HX-Request": "true"})
+
+        response = accepted_client.get("/wizard/complete")
+
+        assert "/wizard/post-wizard/" not in response.headers["Location"]
+
+    def test_completion_is_open_when_nothing_is_gated(self, accepted_client, make_step):
+        make_step(0, api_check=None, markdown="# One")
+
+        response = accepted_client.get("/wizard/complete")
+
+        assert "/wizard/post-wizard/" not in response.headers["Location"]
+
+    def test_completion_clears_the_gate_state(self, accepted_client, gated_step):
+        from app.services.wizard_api_check.gate import GATE_SESSION_KEY
+
+        accepted_client.get(check_url(gated_step), headers={"HX-Request": "true"})
+        accepted_client.get("/wizard/complete")
+
+        with accepted_client.session_transaction() as sess:
+            assert GATE_SESSION_KEY not in sess
+
+
+class TestAdminExemption:
+    def test_admins_are_not_clamped(
+        self, admin_client, gated_step, make_step, mock_api
+    ):
+        make_step(1, api_check=None, markdown="# Second step")
+        mock_api.set_status(403)
+
+        response = admin_client.get(
+            f"/wizard/{'jellyfin'}/1", headers={"HX-Request": "true"}
+        )
+
+        assert response.headers["X-Wizard-Idx"] == "1"
+
+    def test_the_preview_route_still_gates_a_non_admin(
+        self, accepted_client, gated_step, make_step, mock_api
+    ):
+        """`phase == preview` must not be usable as a way around the gate."""
+        make_step(1, api_check=None, markdown="# Second step")
+        mock_api.set_status(403)
+
+        response = accepted_client.get(
+            "/wizard/jellyfin/1", headers={"HX-Request": "true"}
+        )
+
+        assert response.headers["X-Wizard-Idx"] == "0"
+
+
+class TestCardRendering:
+    def test_the_card_is_rendered_into_the_step(
+        self, accepted_client, gated_step, mock_api
+    ):
+        mock_api.set_status(403)
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert f'id="wizard-api-check-{gated_step}"'.encode() in response.data
+
+    def test_the_card_is_appended_when_the_admin_forgot_the_placeholder(
+        self, accepted_client, make_step, mock_api
+    ):
+        step_id = make_step(
+            0,
+            api_check=api_check_blob(mock_api.path("/check")),
+            markdown="# No placeholder here",
+        )
+        mock_api.set_status(403)
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert f'id="wizard-api-check-{step_id}"'.encode() in response.data
+
+    def test_the_card_is_not_duplicated_when_the_placeholder_is_present(
+        self, accepted_client, gated_step, mock_api
+    ):
+        mock_api.set_status(403)
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert response.data.count(f'id="wizard-api-check-{gated_step}"'.encode()) == 1
+
+    def test_no_card_for_an_ungated_step(self, accepted_client, make_step):
+        make_step(0, api_check=None, markdown="# Plain\n\n{{ widget:api_check }}")
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert b"wizard-api-check" not in response.data
+
+
+class TestConfigIsNotExposedToStepMarkdown:
+    def test_markdown_cannot_print_the_gate_config(
+        self, accepted_client, make_step, mock_api
+    ):
+        """The widget context must stay out of the markdown render context."""
+        make_step(
+            0,
+            api_check=api_check_blob(mock_api.path("/secret-endpoint")),
+            markdown="Leak: {{ wizard_api_check }} {{ wizard_step_id }}",
+        )
+        mock_api.set_status(403)
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert b"secret-endpoint" not in response.data
+        assert b"interval_seconds" not in response.data
+
+
+class TestNextButtonIsLocked:
+    def test_next_is_disabled_while_the_gate_is_locked(
+        self, accepted_client, gated_step, make_step, mock_api
+    ):
+        make_step(1, api_check=None, markdown="# Second step")
+        mock_api.set_status(403)
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert b'aria-disabled="true"' in response.data
+        assert b'data-disabled="1"' in response.data
+
+    def test_next_is_enabled_once_the_gate_passes(
+        self, accepted_client, gated_step, make_step
+    ):
+        make_step(1, api_check=None, markdown="# Second step")
+        accepted_client.get(check_url(gated_step), headers={"HX-Request": "true"})
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert b'data-disabled="1"' not in response.data
+
+    def test_an_ungated_step_leaves_next_alone(self, accepted_client, make_step):
+        make_step(0, api_check=None, markdown="# One")
+        make_step(1, api_check=None, markdown="# Two")
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert b'data-disabled="1"' not in response.data
+
+    def test_require_interaction_still_locks_independently(
+        self, accepted_client, app, wizard_world
+    ):
+        from app.extensions import db
+        from app.models import WizardStep
+
+        with app.app_context():
+            for position in (0, 1):
+                db.session.add(
+                    WizardStep(
+                        server_type="jellyfin",
+                        category="post_invite",
+                        position=position,
+                        title=f"Step {position}",
+                        markdown="# Step\n\n[Open](https://example.com)",
+                        require_interaction=position == 0,
+                    )
+                )
+            db.session.commit()
+
+        response = accepted_client.get("/wizard/post-wizard/0")
+
+        assert b'data-disabled="1"' in response.data

--- a/tests/external/api_check/test_signing.py
+++ b/tests/external/api_check/test_signing.py
@@ -1,0 +1,190 @@
+"""HMAC signing of API-check requests.
+
+Wizarr signs each call so the upstream can tell a genuine request from a forged
+one. The mock server implements the verification independently, so these tests
+are a real cross-check of the two sides rather than a restatement of one.
+"""
+
+import time
+
+import pytest
+
+from app.services.ldap.encryption import encrypt_credential
+from app.services.wizard_api_check.client import build_canonical_string as app_canonical
+from app.services.wizard_api_check.client import run_check
+from app.services.wizard_api_check.config import normalize
+from tests.external.api_check.mock_api_server import MockApiServer, sign
+from tests.external.api_check.mock_api_server import (
+    build_canonical_string as mock_canonical,
+)
+
+SECRET = "shared-signing-secret"
+
+
+def config(url: str, **overrides):
+    raw = {
+        "version": 1,
+        "enabled": True,
+        "url": url,
+        "sign_requests": True,
+        "auth_header": "",
+        "api_key_enc": encrypt_credential(SECRET),
+        **overrides,
+    }
+    return normalize(raw, category="post_invite")
+
+
+@pytest.fixture
+def signed_api():
+    with MockApiServer(hmac_secret=SECRET) as server:
+        yield server
+
+
+class TestCanonicalStringAgreement:
+    def test_app_and_upstream_build_the_same_string(self):
+        kwargs = {
+            "timestamp": "1774300000",
+            "nonce": "0123456789abcdef0123456789abcdef",
+            "method": "GET",
+            "path": "/check",
+            "code": "ABC123",
+            "username": "james",
+            "email": "a@b.c",
+        }
+
+        assert app_canonical(**kwargs) == mock_canonical(**kwargs)
+
+    def test_canonical_string_layout_is_pinned(self):
+        """The docs and the mock server docstring quote this exact layout."""
+        canonical = app_canonical(
+            timestamp="1774300000",
+            nonce="deadbeef",
+            method="post",
+            path="/pwa/status",
+            code="ABC123",
+            username="james",
+            email="a@b.c",
+        )
+
+        assert (
+            canonical
+            == "v1\n1774300000\ndeadbeef\nPOST\n/pwa/status\nABC123\njames\na@b.c"
+        )
+
+
+class TestSignedRequestsAreAccepted:
+    def test_upstream_verifies_the_signature(self, signed_api):
+        outcome = run_check(
+            config(signed_api.path("/check")),
+            code="ABC123",
+            username="james",
+            email="a@b.c",
+        )
+
+        assert outcome.passed is True
+        assert signed_api.last().signature_valid is True
+
+    def test_post_requests_are_signed_too(self, signed_api):
+        outcome = run_check(
+            config(signed_api.path("/check"), method="POST"),
+            code="ABC123",
+            username="james",
+            email="a@b.c",
+        )
+
+        assert outcome.passed is True
+        assert signed_api.last().signature_valid is True
+
+    def test_signing_works_without_identity_values(self, signed_api):
+        outcome = run_check(config(signed_api.path("/check")), code="ABC123")
+
+        assert outcome.passed is True
+        assert signed_api.last().signature_valid is True
+
+
+class TestForgeryIsRejected:
+    def test_a_different_secret_fails_verification(self):
+        with MockApiServer(hmac_secret="a-different-secret") as api:
+            outcome = run_check(config(api.path("/check")), code="ABC123")
+
+            assert outcome.passed is False
+            assert outcome.status_code == 401
+            assert api.last().signature_valid is False
+            assert api.last().signature_error == "signature mismatch"
+
+    def test_unsigned_request_is_rejected_by_a_signing_upstream(self, signed_api):
+        outcome = run_check(
+            config(signed_api.path("/check"), sign_requests=False), code="ABC123"
+        )
+
+        assert outcome.passed is False
+        assert signed_api.last().signature_error == "missing signature headers"
+
+    def test_signature_covers_the_identity_values(self, signed_api):
+        """Swapping the code after signing must invalidate the signature."""
+        run_check(config(signed_api.path("/check")), code="ABC123", username="james")
+        recorded = signed_api.last()
+
+        tampered = mock_canonical(
+            timestamp=recorded.headers["X-Wizarr-Timestamp"],
+            nonce=recorded.headers["X-Wizarr-Nonce"],
+            method="GET",
+            path="/check",
+            code="SOMEONE-ELSE",
+            username="james",
+            email="",
+        )
+
+        assert (
+            recorded.headers["X-Wizarr-Signature"] != f"sha256={sign(SECRET, tampered)}"
+        )
+
+    def test_stale_timestamps_are_refused_by_the_upstream(self):
+        """Wizarr cannot enforce freshness upstream, so the upstream must."""
+        with MockApiServer(hmac_secret=SECRET, clock_skew_tolerance=0) as api:
+            outcome = run_check(config(api.path("/check")), code="ABC123")
+
+            assert outcome.passed is False
+            assert api.last().signature_valid is False
+            assert "skew" in api.last().signature_error
+
+
+class TestSignatureHeaders:
+    def test_headers_are_present_and_well_formed(self, signed_api):
+        run_check(config(signed_api.path("/check")), code="ABC123")
+        headers = signed_api.last().headers
+
+        assert headers["X-Wizarr-Signature"].startswith("sha256=")
+        assert len(headers["X-Wizarr-Signature"]) == len("sha256=") + 64
+        assert len(headers["X-Wizarr-Nonce"]) == 32
+        assert abs(time.time() - int(headers["X-Wizarr-Timestamp"])) < 60
+
+    def test_nonce_is_fresh_on_every_call(self, signed_api):
+        run_check(config(signed_api.path("/check")), code="ABC123")
+        first = signed_api.last().headers["X-Wizarr-Nonce"]
+        run_check(config(signed_api.path("/check")), code="ABC123")
+        second = signed_api.last().headers["X-Wizarr-Nonce"]
+
+        assert first != second
+
+    def test_no_signature_headers_when_signing_is_off(self, signed_api):
+        run_check(config(signed_api.path("/check"), sign_requests=False), code="ABC123")
+        headers = signed_api.last().headers
+
+        assert "X-Wizarr-Signature" not in headers
+        assert "X-Wizarr-Timestamp" not in headers
+        assert "X-Wizarr-Nonce" not in headers
+
+    def test_no_signature_headers_when_the_key_is_unusable(self, signed_api):
+        run_check(
+            config(signed_api.path("/check"), api_key_enc="not-a-fernet-token"),
+            code="ABC123",
+        )
+
+        assert "X-Wizarr-Signature" not in signed_api.last().headers
+
+    def test_the_secret_itself_is_never_sent_when_only_signing(self, signed_api):
+        run_check(config(signed_api.path("/check")), code="ABC123")
+        headers = signed_api.last().headers
+
+        assert SECRET not in " ".join(f"{k}: {v}" for k, v in headers.items())

--- a/tests/external/api_check/test_widget_render.py
+++ b/tests/external/api_check/test_widget_render.py
@@ -1,0 +1,227 @@
+"""Rendering of the {{ widget:api_check }} status card.
+
+The card is what the user actually sees and what drives the polling, so these
+tests pin both the visible states and the HTMX contract. They also cover the
+two ways admin-authored text could turn into an exploit: HTML injection, and
+Jinja injection via the second template pass that ``_render`` performs.
+"""
+
+import re
+
+import pytest
+
+from app.services.wizard_api_check.config import normalize, public_view
+from app.services.wizard_widgets import (
+    API_CHECK_PLACEHOLDER_RE,
+    WIDGET_REGISTRY,
+    process_widget_placeholders,
+)
+
+GATED_STEP_ID = 42
+
+
+def config(**overrides):
+    raw = {
+        "version": 1,
+        "enabled": True,
+        "url": "https://api.example.com/check",
+        "sign_requests": False,
+        "interval_seconds": 15,
+        **overrides,
+    }
+    return normalize(raw, category=overrides.pop("category", "post_invite"))
+
+
+def context(*, step_id=GATED_STEP_ID, passed=False, **overrides):
+    return {
+        "wizard_step_id": step_id,
+        "wizard_api_check": public_view(config(**overrides)),
+        "wizard_gate_passed": passed,
+    }
+
+
+def render(ctx=None, markdown="{{ widget:api_check }}"):
+    with_ctx = context() if ctx is None else ctx
+    return process_widget_placeholders(markdown, "jellyfin", context=with_ctx)
+
+
+@pytest.fixture(autouse=True)
+def _app_context(app):
+    """The card renders through a Jinja template, so it needs an app context."""
+    with app.app_context():
+        yield
+
+
+class TestRegistration:
+    def test_widget_is_registered(self):
+        assert "api_check" in WIDGET_REGISTRY
+
+    def test_placeholder_pattern_matches_the_documented_syntax(self):
+        assert API_CHECK_PLACEHOLDER_RE.search("{{ widget:api_check }}")
+        assert API_CHECK_PLACEHOLDER_RE.search("text\n{{widget:api_check}}\ntext")
+        assert not API_CHECK_PLACEHOLDER_RE.search("{{ widget:button }}")
+
+
+class TestPendingState:
+    def test_renders_a_card_bound_to_the_step(self):
+        html = render()
+
+        assert f'id="wizard-api-check-{GATED_STEP_ID}"' in html
+        assert f"/wizard/api-check/{GATED_STEP_ID}" in html
+
+    def test_polls_on_load_and_on_the_configured_interval(self):
+        html = render()
+        trigger = re.search(r'hx-trigger="([^"]*)"', html).group(1)
+
+        assert "load" in trigger
+        assert "every 15s" in trigger
+
+    def test_swaps_itself_so_the_poll_timer_cannot_stack(self):
+        html = render()
+
+        assert 'hx-target="this"' in html
+        assert 'hx-swap="outerHTML"' in html
+        assert 'hx-swap="innerHTML"' not in html
+
+    def test_offers_a_manual_recheck_button(self):
+        html = render()
+
+        assert "Re-check" in html
+
+    def test_uses_a_scoped_indicator_not_the_global_overlay(self):
+        html = render()
+        indicator = re.search(r'hx-indicator="([^"]*)"', html).group(1)
+
+        assert indicator != ".htmx-indicator"
+        assert str(GATED_STEP_ID) in indicator
+
+    def test_opts_out_of_the_require_interaction_unlock(self):
+        """Clicking Re-check must not satisfy a separate require_interaction gate."""
+        assert "data-wizard-no-unlock" in render()
+
+
+class TestPassedState:
+    def test_shows_success_and_stops_polling(self):
+        html = render(context(passed=True))
+
+        assert "hx-trigger" not in html
+
+    def test_a_settled_card_carries_no_request_attributes(self):
+        """HTMX defaults a trigger-less div to `click`, which would re-fire."""
+        html = render(context(passed=True))
+
+        assert "hx-get" not in html
+        assert "hx-swap" not in html
+
+    def test_success_message_is_shown(self):
+        html = render(
+            context(passed=True, success_message="App detected, you are good to go")
+        )
+
+        assert "App detected, you are good to go" in html
+
+    def test_pending_message_is_shown_while_waiting(self):
+        html = render(context(pending_message="Install the app, then tap Re-check"))
+
+        assert "Install the app, then tap Re-check" in html
+
+    def test_falls_back_to_default_copy_when_no_message_is_set(self):
+        assert render(context()).strip() != ""
+        assert render(context(passed=True)).strip() != ""
+
+
+class TestInactiveGate:
+    def test_disabled_gate_renders_nothing(self):
+        html = render(context(enabled=False))
+
+        assert "wizard-api-check" not in html
+
+    def test_pre_invite_step_renders_nothing(self):
+        html = render(context(category="pre_invite"))
+
+        assert "wizard-api-check" not in html
+
+    def test_signed_gate_without_a_key_renders_nothing(self):
+        html = render(context(sign_requests=True, api_key_enc=""))
+
+        assert "wizard-api-check" not in html
+
+    def test_missing_step_id_renders_nothing(self):
+        html = render(context(step_id=None))
+
+        assert "wizard-api-check" not in html
+
+    def test_absent_widget_context_renders_nothing(self):
+        html = process_widget_placeholders(
+            "{{ widget:api_check }}", "jellyfin", context={}
+        )
+
+        assert "wizard-api-check" not in html
+
+
+class TestSecretsNeverReachThePage:
+    def test_url_is_not_exposed(self):
+        html = render(context(url="https://secret-internal.example.com/private-path"))
+
+        assert "secret-internal.example.com" not in html
+        assert "private-path" not in html
+
+    def test_ciphertext_is_not_exposed(self):
+        html = render(context(api_key_enc="ciphertext-value", sign_requests=False))
+
+        assert "ciphertext-value" not in html
+
+    def test_markdown_parameters_are_ignored(self):
+        """An admin cannot redirect the check by editing the placeholder."""
+        html = process_widget_placeholders(
+            '{{ widget:api_check url="http://evil.test" interval=1 }}',
+            "jellyfin",
+            context=context(),
+        )
+
+        assert "evil.test" not in html
+        assert "every 15s" in html
+
+
+class TestInjectionHardening:
+    def test_html_in_admin_messages_is_escaped(self):
+        html = render(context(pending_message="<script>alert(1)</script>"))
+
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_jinja_syntax_cannot_survive_into_the_second_template_pass(self):
+        """`_render` re-parses widget output as a template with autoescape off."""
+        html = render(context(pending_message="{{ config.SECRET_KEY }}"))
+
+        assert "{{" not in html
+        assert "{%" not in html
+
+    def test_no_raw_braces_are_emitted_at_all(self):
+        html = render(context(pending_message="a { b } c", success_message="{% raw %}"))
+
+        assert "{" not in html
+        assert "}" not in html
+
+    def test_unicode_and_emoji_survive(self):
+        html = render(context(pending_message="✅ 完了 🎉"))
+
+        assert "✅ 完了 🎉" in html
+
+
+class TestPlacementInMarkdown:
+    def test_card_renders_where_the_placeholder_sits(self):
+        html = render(markdown="# Title\n\n{{ widget:api_check }}\n\nAfter")
+
+        assert html.index("# Title") < html.index("wizard-api-check")
+        assert html.index("wizard-api-check") < html.index("After")
+
+    def test_other_widgets_still_work_alongside_it(self):
+        html = process_widget_placeholders(
+            '{{ widget:button url="https://example.com" text="Go" }}\n\n{{ widget:api_check }}',
+            "jellyfin",
+            context=context(),
+        )
+
+        assert 'href="https://example.com"' in html
+        assert "wizard-api-check" in html


### PR DESCRIPTION
## What this adds

An optional **API gate** on post-invite wizard steps. An admin points a step at an HTTP endpoint, and the invited user cannot continue until it answers with an expected status code.

The motivating case: a step asks the user to install a PWA and enable web-push, and an external API returns `200` once it observes both — making that step genuinely mandatory rather than a suggestion.

- The check runs **server-side**, so an API key can be used.
- It polls every X seconds (configurable) and stops permanently once it passes.
- A manual **Re-check** button shares the same server-enforced cooldown.
- Auto-polling gives up after a configurable cap, leaving the manual button.

Admins configure it in the existing step form; `{{ widget:api_check }}` places the status card. If the placeholder is missing, the card is appended automatically — a gate should never block with no visible UI.

## Why post-invite only

The check identifies the user by **invite code, username and email**, and the latter two do not exist until the invitation is accepted. That rule lives in a single predicate (`ApiCheckConfig.is_active`), so a gate attached to a pre-invite step is inert everywhere: the form refuses to save it, the card does not render, and navigation is not clamped.

## Enforcement

Disabling the Next button is cosmetic — a user can type the next step's URL. So:

- A pass is recorded in the **server-side** session (`SESSION_TYPE = "cachelib"`; the cookie holds only a signed id), scoped to a hash of the invite code and discarded wholesale if that scope changes.
- All four wizard render paths clamp `idx` back to the first unsatisfied gate.
- `/wizard/complete` refuses while a gate is outstanding — otherwise it is directly reachable.
- Admins are exempt, so previewing a wizard cannot trap them behind a gate only a real user can satisfy.

## Security posture

`GET /wizard/api-check/<step_id>` is the only unauthenticated outbound-calling route in the app, so it is deliberately one-way:

- The step must belong to the **current flow** — a forged id triggers no upstream call.
- The upstream response **body is never read**, redirects are never followed, and every failure collapses to one generic message, so it cannot be used to probe the admin's network.
- Requests are signed with `X-Wizarr-Timestamp`, `X-Wizarr-Nonce` and `X-Wizarr-Signature: sha256=…` over `v1\n{ts}\n{nonce}\n{METHOD}\n{path}\n{code}\n{username}\n{email}`.
- The cooldown slot is claimed **before** the upstream call, with an in-process floor behind the session value, so parallel requests cannot each decide they are first.
- The API key is Fernet-encrypted at rest (reusing `encrypt_credential`), excluded from exports, never rendered, and redacted in `__repr__`. Import never sets a credential, so a shared JSON file cannot lock anyone out against a stranger's endpoint.

## Pre-existing defects fixed along the way

These are load-bearing for the feature, and each is a bug in its own right:

1. **SSTI in the widget pipeline.** `_render` ran widgets *before* a Jinja pass with `autoescape=False`, and `html.escape()` does not escape braces — so admin-authored text containing `{{ … }}` reached the template context. `ButtonWidget` had the same exposure. Widget output now has its braces neutralised.
2. **`require_interaction` unlocked on any `<a>`/`<button>` click** inside the step, which the Re-check button would have satisfied instantly. Controls can now opt out via `data-wizard-no-unlock` (opt-out, so every existing step keeps working).
3. **The gating latch was never cleared**, so the *second* `require_interaction` step in a session rendered disabled but stayed clickable.

## Schema

One nullable `api_check` JSON column on `wizard_step` (migration `20260825_apichk`, downgrade verified). Export/import carry the config minus the credential.

## Testing

**302 tests** in `tests/external/api_check/`, including **3 real-Chromium Playwright tests** covering the full journey: card polls on load, Next locked, cooldown enforced and surfaced, auto-poll flips to verified, Next unlocks without a reload, polling stops, direct-URL navigation clamped, and Re-check not satisfying `require_interaction`.

Also included, as requested for other contributors: `tests/external/api_check/mock_api_server.py` — a reusable stdlib mock (**no new dependency**) that validates the invite code, username and email, verifies the HMAC, and records every request; plus `run_mock_api.py`, a runner with a small control panel so it can be driven by hand:

```
uv run python -m tests.external.api_check.run_mock_api --port 8899
```

`ruff check`, `ruff format` and `djlint` are clean. The full suite is unchanged from `main` apart from one **pre-existing, unrelated** failure (`test_validate_expired_invitation` builds a naive `datetime.now()` that is reinterpreted as UTC, so it only fails away from UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
