### PR TITLE
feat(admin): confirm invitation deletion with a modal

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -450,6 +450,14 @@ def _rel_string(target: datetime.datetime, now: datetime.datetime) -> str:
     return _("soon")
 
 
+@admin_bp.get("/invite/<int:invite_id>/delete-modal")
+@login_required
+def delete_invite_modal(invite_id: int):
+    """Show the delete invitation confirmation modal."""
+    invitation = db.get_or_404(Invitation, invite_id)
+    return render_template("_partials/delete_invite_modal.html", invitation=invitation)
+
+
 # Users
 @admin_bp.route("/users")
 @login_required

--- a/app/templates/_partials/delete_invite_modal.html
+++ b/app/templates/_partials/delete_invite_modal.html
@@ -1,0 +1,52 @@
+<!-- Delete Invitation Confirmation Modal -->
+<div class="relative modal-container"
+     aria-labelledby="modal-title"
+     role="dialog"
+     aria-modal="true">
+  <div class="fixed inset-0 modal-backdrop transition-opacity"></div>
+  <div class="fixed inset-0 z-10 overflow-y-auto">
+    <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+      <div class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 w-full sm:max-w-md dark:bg-gray-800">
+        <!-- Modal header -->
+        <div class="flex items-center justify-between p-4 md:p-5 border-b rounded-t dark:border-gray-600">
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ _("Delete Invitation") }}</h3>
+          <button type="button"
+                  onclick="closeInviteModal()"
+                  class="text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center dark:hover:bg-gray-600 dark:hover:text-white">
+            <svg class="w-3 h-3"
+                 aria-hidden="true"
+                 xmlns="http://www.w3.org/2000/svg"
+                 fill="none"
+                 viewBox="0 0 14 14">
+              <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6" />
+            </svg>
+          </button>
+        </div>
+        <!-- Modal body -->
+        <div class="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4 dark:bg-gray-800">
+          <p class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+            {{ _("Are you sure you want to delete the invitation") }}
+            <span class="font-medium text-gray-900 dark:text-white">{{ invitation.code }}</span>?
+            {{ _("This action cannot be undone.") }}
+          </p>
+          <!-- Action buttons -->
+          <div class="flex items-center justify-end space-x-3">
+            <button type="button"
+                    onclick="closeInviteModal()"
+                    class="px-4 py-2 text-sm font-medium text-gray-500 bg-gray-100 hover:bg-gray-200 rounded-lg dark:bg-gray-600 dark:text-gray-300 dark:hover:bg-gray-700">
+              {{ _("Cancel") }}
+            </button>
+            <button type="button"
+                    hx-post="/invite/table?delete_id={{ invitation.id }}"
+                    hx-target="#invite_table"
+                    hx-swap="outerHTML swap:0.5s"
+                    hx-on::after-request="closeInviteModal()"
+                    class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg">
+              {{ _("Delete") }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/templates/tables/invite_card.html
+++ b/app/templates/tables/invite_card.html
@@ -180,10 +180,9 @@
                 </button>
                 <!-- Delete invitation button -->
                 <button class="h-8 w-8 p-0 inline-flex items-center justify-center text-white bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 rounded-md transition-colors"
-                        hx-post="/invite/table?delete_id={{ invite.id }}"
-                        hx-trigger="click"
-                        hx-target="#invite_table"
-                        hx-swap="outerHTML swap:0.5s"
+                        hx-get="{{ url_for('admin.delete_invite_modal', invite_id=invite.id) }}"
+                        hx-target="#invite-modal"
+                        hx-swap="innerHTML"
                         onclick="event.stopPropagation()"
                         title="{{ _('Delete invite') }}">
                   <svg class="h-4 w-4"

--- a/tests/test_invite_delete_modal.py
+++ b/tests/test_invite_delete_modal.py
@@ -1,0 +1,72 @@
+"""Tests for the invitation delete confirmation modal route."""
+
+import pytest
+
+from app.extensions import db
+from app.models import AdminAccount, Invitation
+
+
+@pytest.fixture
+def admin_user(app):
+    """Create an admin account for authenticated requests."""
+    with app.app_context():
+        created = False
+        previous_hash = None
+        admin = AdminAccount.query.filter_by(username="testadmin").first()
+        if not admin:
+            admin = AdminAccount(username="testadmin")
+            admin.set_password("TestPass123")
+            db.session.add(admin)
+            db.session.commit()
+            created = True
+        else:
+            previous_hash = admin.password_hash
+            admin.set_password("TestPass123")
+            db.session.commit()
+        yield admin
+        if created:
+            db.session.delete(admin)
+            db.session.commit()
+        elif previous_hash is not None:
+            admin = AdminAccount.query.filter_by(username="testadmin").first()
+            if admin:
+                admin.password_hash = previous_hash
+                db.session.commit()
+
+
+def test_delete_invite_modal_shows_invite_code(client, app, admin_user):
+    """The modal renders the invitation's code so the admin can confirm it."""
+    with app.app_context():
+        invite = Invitation(code="MODALTEST", used=False, unlimited=False)
+        db.session.add(invite)
+        db.session.commit()
+        invite_id = invite.id
+
+    client.post("/login", data={"username": "testadmin", "password": "TestPass123"})
+
+    response = client.get(f"/invite/{invite_id}/delete-modal")
+
+    assert response.status_code == 200
+    assert b"MODALTEST" in response.data
+
+
+def test_delete_invite_modal_requires_login(client, app):
+    """Unauthenticated requests must not see the confirmation modal."""
+    with app.app_context():
+        invite = Invitation(code="NOAUTH", used=False, unlimited=False)
+        db.session.add(invite)
+        db.session.commit()
+        invite_id = invite.id
+
+    response = client.get(f"/invite/{invite_id}/delete-modal")
+
+    assert response.status_code in (302, 401)
+
+
+def test_delete_invite_modal_404_for_missing_invite(client, app, admin_user):
+    """A non-existent invite id returns 404 instead of a broken modal."""
+    client.post("/login", data={"username": "testadmin", "password": "TestPass123"})
+
+    response = client.get("/invite/999999/delete-modal")
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Problem

Deleting an invitation from the Invitations table removes it **instantly** on a single click of the trash icon — no confirmation dialog and no success feedback. A misclick permanently deletes an invite with no way to undo it.

closes #1360 

## Fix

Reuse the app's existing delete-confirmation modal pattern (already used for user deletion in `delete_user_modal.html`) instead of firing the delete request immediately:

- New `GET /invite/<id>/delete-modal` route rendering a confirmation modal (`app/templates/_partials/delete_invite_modal.html`), styled consistently with the existing "Remove User" modal.
- The delete button in `invite_card.html` now opens this modal (`hx-get` into the existing `#invite-modal` container) instead of posting the delete directly.
- Confirming still uses the same `POST /invite/table?delete_id=<id>` endpoint and table refresh as before; the modal auto-closes on success via `hx-on::after-request`.
- Canceling closes the modal with no changes.

## Testing

- Added `tests/test_invite_delete_modal.py`: modal renders the invite code, unauthenticated access is rejected, and a missing invite id returns 404.
- Full existing invite-delete regression suite (`tests/test_invite_delete_by_id.py`) still passes.
- `ruff check`, `ruff format --check`, and `djlint --profile jinja` all pass on the changed files.
- Manually verified in a local dev environment: create invite → delete opens modal → Cancel preserves it → Delete removes it and closes the modal.