### PR TITLE
Add an activity tracking toggle

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,21 +50,6 @@ def create_app(config_object=DevelopmentConfig):
 
     init_activity(app)
 
-    # Register activity scheduler tasks if the scheduler is available
-    try:
-        from .extensions import scheduler as activity_scheduler
-
-        if (
-            activity_scheduler
-            and hasattr(activity_scheduler, "scheduler")
-            and activity_scheduler.scheduler
-        ):
-            from app.tasks.activity import register_activity_tasks
-
-            register_activity_tasks(app, activity_scheduler)
-    except Exception as exc:
-        app.logger.warning(f"Failed to register activity tasks: {exc}")
-
     # Step 5: Setup context processors and filters
     if show_startup:
         logger.step("Configuring request processing", "⚙️")

--- a/app/activity/__init__.py
+++ b/app/activity/__init__.py
@@ -8,15 +8,12 @@ sessions across all configured media servers.
 from __future__ import annotations
 
 import os
-import threading
 
 import structlog
 from flask import Flask
 
 from app.models import ActivitySession, ActivitySnapshot
 from app.services.activity import ActivityService
-
-from .monitoring.monitor import WebSocketMonitor
 
 
 def init_app(app: Flask) -> None:
@@ -41,36 +38,31 @@ def init_app(app: Flask) -> None:
         logger.debug("Skipping activity monitoring in reloader parent process")
         return
 
-    app.extensions = getattr(app, "extensions", {})
-    if "activity_monitor" in app.extensions:
-        logger.debug("Activity monitoring already initialized, skipping")
-        return
+    from app.extensions import scheduler
+    from app.tasks.activity import register_activity_tracking_reconcile_task
 
-    logger.info("Initializing activity monitoring")
-    monitor = WebSocketMonitor(app)
-    app.extensions["activity_monitor"] = monitor
+    from .tracking import reconcile_activity_tracking
 
-    def delayed_start():
-        import time
+    activity_scheduler = None
+    if scheduler and hasattr(scheduler, "scheduler") and scheduler.scheduler:
+        activity_scheduler = scheduler
 
-        time.sleep(2)
+    enabled = reconcile_activity_tracking(
+        app,
+        activity_scheduler,
+        start_delay_seconds=2,
+    )
 
+    if activity_scheduler is not None:
         try:
-            from app.tasks.activity import recover_sessions_on_startup_task
-
-            recovered_count = recover_sessions_on_startup_task(app)
-            logger.info(
-                "Session recovery completed on startup: %s orphaned sessions cleaned up",
-                recovered_count,
-            )
+            register_activity_tracking_reconcile_task(app, activity_scheduler)
         except Exception as exc:
-            logger.error("Session recovery failed on startup: %s", exc, exc_info=True)
+            logger.warning(
+                "Activity tracking setting checks are not scheduled",
+                error=str(exc),
+            )
 
-        monitor.start_monitoring()
-
-    threading.Thread(target=delayed_start, daemon=True).start()
-
-    logger.info("Activity monitoring initialized")
+    logger.info("Activity tracking initialized", enabled=enabled)
 
 
 __all__ = ["ActivityService", "ActivitySession", "ActivitySnapshot", "init_app"]

--- a/app/activity/api/blueprint.py
+++ b/app/activity/api/blueprint.py
@@ -38,6 +38,10 @@ except ImportError:
 
 
 from app.activity.domain.models import ActivityQuery
+from app.activity.tracking import (
+    is_activity_tracking_enabled,
+    set_activity_tracking_enabled,
+)
 from app.models import ActivitySession, ActivitySnapshot
 from app.services.activity import ActivityService
 from app.services.historical import HistoricalDataService
@@ -65,14 +69,19 @@ def _activity_settings_template() -> str:
 
 def _default_monitor_status() -> dict[str, object]:
     """Provide a fallback monitor status structure."""
-    return {"monitoring_enabled": False, "connection_status": {}}
+    return {
+        "tracking_enabled": True,
+        "monitoring_enabled": False,
+        "connection_status": {},
+    }
 
 
 def _load_monitor_status() -> dict[str, object]:
     """Return current activity monitor status."""
-    monitor = getattr(current_app.extensions, "activity_monitor", None)
+    monitor = current_app.extensions.get("activity_monitor")
     return {
-        "monitoring_enabled": monitor is not None,
+        "tracking_enabled": is_activity_tracking_enabled(),
+        "monitoring_enabled": bool(monitor and monitor.monitoring),
         "connection_status": monitor.get_connection_status() if monitor else {},
     }
 
@@ -581,8 +590,18 @@ def activity_settings():
         try:
             action = request.form.get("action")
 
+            if action == "set_tracking":
+                enabled = request.form.get("activity_tracking_enabled") == "true"
+                set_activity_tracking_enabled(enabled)
+                state = _("enabled") if enabled else _("disabled")
+                return _settings_action_response(
+                    success=_(
+                        "Activity tracking is {state}. The change can take up to 15 seconds."
+                    ).format(state=state)
+                )
+
             if action == "restart_monitoring":
-                monitor = getattr(current_app.extensions, "activity_monitor", None)
+                monitor = current_app.extensions.get("activity_monitor")
                 if monitor:
                     monitor.stop_monitoring()
                     monitor.start_monitoring()

--- a/app/activity/monitoring/monitor.py
+++ b/app/activity/monitoring/monitor.py
@@ -6,7 +6,6 @@ using WebSocket APIs where available, with fallback to polling.
 """
 
 import threading
-import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
@@ -94,10 +93,10 @@ class WebSocketMonitor:
             while self.monitoring and not self._stop_event.is_set():
                 try:
                     self._update_collectors()
-                    time.sleep(30)  # Check for new/removed servers every 30 seconds
+                    self._stop_event.wait(30)
                 except Exception as e:
                     self.logger.error(f"Error in monitoring loop: {e}", exc_info=True)
-                    time.sleep(5)
+                    self._stop_event.wait(5)
 
     def _update_collectors(self):
         """Update collectors based on current server configuration."""

--- a/app/activity/templates/activity/settings_tab.html
+++ b/app/activity/templates/activity/settings_tab.html
@@ -39,6 +39,61 @@
 
     <!-- Settings Content -->
     <div class="w-full space-y-6">
+      <!-- Activity Tracking Section -->
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+        <div class="p-6">
+          <div class="space-y-4">
+            <div class="border-b border-gray-200 dark:border-gray-700 pb-3">
+              <div class="flex items-center gap-3">
+                <div class="flex-shrink-0 w-8 h-8 bg-primary/10 rounded-lg flex items-center justify-center">
+                  <svg class="w-4 h-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12h3l3-8 4 16 3-8h5"></path>
+                  </svg>
+                </div>
+                <div>
+                  <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{{ _("Activity Tracking") }}</h2>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">{{ _("Control background playback tracking for all media servers") }}</p>
+                </div>
+              </div>
+            </div>
+
+            <form method="POST"
+                  action="{{ url_for('activity.activity_settings') }}"
+                  hx-post="{{ url_for('activity.activity_settings') }}"
+                  hx-target="#tab-body"
+                  hx-swap="innerHTML"
+                  class="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4">
+              <input type="hidden" name="action" value="set_tracking">
+              <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div class="flex-1">
+                  <label for="activity-tracking-enabled" class="text-sm font-medium text-gray-900 dark:text-white">{{ _("Track playback activity") }}</label>
+                  <p id="activity-tracking-description" class="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                    {{ _("Turn this off to stop background server checks and activity history updates. Existing activity data stays available.") }}
+                  </p>
+                </div>
+                <div class="flex items-center gap-4">
+                  <label class="inline-flex items-center cursor-pointer">
+                    <input id="activity-tracking-enabled"
+                           type="checkbox"
+                           name="activity_tracking_enabled"
+                           value="true"
+                           class="sr-only peer"
+                           aria-describedby="activity-tracking-description"
+                           {% if status.tracking_enabled %}checked{% endif %}>
+                    <span class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/20 dark:peer-focus:ring-primary/30 rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-primary dark:peer-checked:bg-primary"></span>
+                    <span class="sr-only">{{ _("Toggle activity tracking") }}</span>
+                  </label>
+                  <button type="submit"
+                          class="inline-flex items-center justify-center px-4 py-2 bg-primary hover:bg-primary/90 text-white font-medium rounded-lg text-sm focus:ring-4 focus:ring-primary/20 transition-colors">
+                    {{ _("Apply") }}
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
       <!-- Data Management Section -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
         <div class="p-6">

--- a/app/activity/tracking.py
+++ b/app/activity/tracking.py
@@ -1,0 +1,134 @@
+"""Manage the persistent activity tracking setting and monitor lifecycle."""
+
+from __future__ import annotations
+
+import threading
+
+import structlog
+from flask import Flask
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.extensions import db
+from app.models import Settings
+
+ACTIVITY_TRACKING_SETTING = "activity_tracking_enabled"
+ACTIVITY_MONITOR_EXTENSION = "activity_monitor"
+ACTIVITY_START_TIMER_EXTENSION = "activity_monitor_start_timer"
+
+logger = structlog.get_logger(__name__)
+
+
+def is_activity_tracking_enabled() -> bool:
+    """Return the stored tracking state. Tracking is enabled by default."""
+    try:
+        setting = Settings.query.filter_by(key=ACTIVITY_TRACKING_SETTING).first()
+    except (RuntimeError, SQLAlchemyError) as exc:
+        logger.warning("activity_tracking_setting_load_failed", error=str(exc))
+        return True
+
+    if setting is None or setting.value is None:
+        return True
+
+    return str(setting.value).strip().lower() not in {"false", "0", "no", "off"}
+
+
+def set_activity_tracking_enabled(enabled: bool) -> None:
+    """Store the activity tracking state."""
+    setting = Settings.query.filter_by(key=ACTIVITY_TRACKING_SETTING).first()
+    value = "true" if enabled else "false"
+
+    if setting is None:
+        setting = Settings(key=ACTIVITY_TRACKING_SETTING, value=value)
+        db.session.add(setting)
+    else:
+        setting.value = value
+
+    db.session.commit()
+
+
+def start_activity_tracking(app: Flask, delay_seconds: float = 0) -> None:
+    """Create and start the activity monitor when it is not active."""
+    from app.activity.monitoring.monitor import WebSocketMonitor
+
+    monitor = app.extensions.get(ACTIVITY_MONITOR_EXTENSION)
+    timer = app.extensions.get(ACTIVITY_START_TIMER_EXTENSION)
+
+    if monitor is not None and (monitor.monitoring or timer is not None):
+        return
+
+    if monitor is None:
+        monitor = WebSocketMonitor(app)
+        app.extensions[ACTIVITY_MONITOR_EXTENSION] = monitor
+
+    def start_monitor() -> None:
+        app.extensions.pop(ACTIVITY_START_TIMER_EXTENSION, None)
+
+        with app.app_context():
+            if not is_activity_tracking_enabled():
+                app.extensions.pop(ACTIVITY_MONITOR_EXTENSION, None)
+                return
+
+        try:
+            from app.tasks.activity import recover_sessions_on_startup_task
+
+            recovered_count = recover_sessions_on_startup_task(app)
+            logger.info(
+                "activity_session_recovery_completed",
+                recovered_count=recovered_count,
+            )
+        except Exception as exc:
+            logger.error(
+                "activity_session_recovery_failed",
+                error=str(exc),
+                exc_info=True,
+            )
+
+        monitor.start_monitoring()
+
+    if delay_seconds > 0:
+        timer = threading.Timer(delay_seconds, start_monitor)
+        timer.daemon = True
+        app.extensions[ACTIVITY_START_TIMER_EXTENSION] = timer
+        timer.start()
+        return
+
+    start_monitor()
+
+
+def stop_activity_tracking(app: Flask) -> None:
+    """Stop the activity monitor and cancel a pending start."""
+    timer = app.extensions.pop(ACTIVITY_START_TIMER_EXTENSION, None)
+    if timer is not None:
+        timer.cancel()
+
+    monitor = app.extensions.pop(ACTIVITY_MONITOR_EXTENSION, None)
+    if monitor is not None:
+        monitor.stop_monitoring()
+
+
+def reconcile_activity_tracking(
+    app: Flask,
+    scheduler=None,
+    *,
+    start_delay_seconds: float = 0,
+) -> bool:
+    """Apply the stored tracking state to the monitor and scheduler."""
+    from app.tasks.activity import (
+        activity_tasks_registered,
+        register_activity_tasks,
+        unregister_activity_tasks,
+    )
+
+    with app.app_context():
+        enabled = is_activity_tracking_enabled()
+
+    if enabled:
+        start_activity_tracking(app, delay_seconds=start_delay_seconds)
+        if scheduler is not None and not activity_tasks_registered(scheduler):
+            register_activity_tasks(app, scheduler)
+    else:
+        stop_activity_tracking(app)
+        if scheduler is not None:
+            unregister_activity_tasks(scheduler)
+
+    return enabled

--- a/app/tasks/activity.py
+++ b/app/tasks/activity.py
@@ -15,6 +15,14 @@ from structlog import get_logger as _get_logger
 
 from app.services.activity import ActivityService
 
+ACTIVITY_JOB_IDS = (
+    "activity_cleanup",
+    "activity_stale_cleanup",
+    "activity_health_check",
+    "activity_heartbeat",
+)
+ACTIVITY_TRACKING_RECONCILE_JOB_ID = "activity_tracking_reconcile"
+
 
 def cleanup_old_activity_task(app: Flask, retention_days: int = 90):
     """
@@ -152,6 +160,12 @@ def activity_monitoring_heartbeat_task(app: Flask):
 
     try:
         with app.app_context():
+            from app.activity.tracking import is_activity_tracking_enabled
+
+            if not is_activity_tracking_enabled():
+                logger.debug("Activity monitoring heartbeat skipped")
+                return False
+
             monitor = app.extensions.get("activity_monitor")
 
             if not monitor:
@@ -284,3 +298,42 @@ def register_activity_tasks(app: Flask, scheduler):
 
     except Exception as e:
         logger.error(f"Failed to register activity tasks: {e}", exc_info=True)
+
+
+def activity_tasks_registered(scheduler) -> bool:
+    """Return true when all activity jobs exist."""
+    return all(scheduler.get_job(job_id) is not None for job_id in ACTIVITY_JOB_IDS)
+
+
+def unregister_activity_tasks(scheduler) -> None:
+    """Remove all activity jobs from the scheduler."""
+    logger = _get_logger()
+    removed = False
+
+    for job_id in ACTIVITY_JOB_IDS:
+        if scheduler.get_job(job_id) is not None:
+            scheduler.remove_job(job_id)
+            removed = True
+
+    if removed:
+        logger.info("Activity monitoring tasks removed")
+
+
+def reconcile_activity_tracking_task(app: Flask) -> bool:
+    """Apply a tracking setting change in the scheduler process."""
+    from app.activity.tracking import reconcile_activity_tracking
+    from app.extensions import scheduler
+
+    return reconcile_activity_tracking(app, scheduler)
+
+
+def register_activity_tracking_reconcile_task(app: Flask, scheduler) -> None:
+    """Register the small job that applies tracking setting changes."""
+    scheduler.add_job(
+        id=ACTIVITY_TRACKING_RECONCILE_JOB_ID,
+        func=lambda: reconcile_activity_tracking_task(app),
+        trigger="interval",
+        seconds=15,
+        replace_existing=True,
+        max_instances=1,
+    )

--- a/tests/activity/test_activity_tracking.py
+++ b/tests/activity/test_activity_tracking.py
@@ -1,0 +1,133 @@
+from unittest.mock import Mock, patch
+
+from app.activity.tracking import (
+    ACTIVITY_TRACKING_SETTING,
+    is_activity_tracking_enabled,
+    reconcile_activity_tracking,
+    set_activity_tracking_enabled,
+)
+from app.models import Settings
+from app.tasks.activity import ACTIVITY_JOB_IDS, activity_monitoring_heartbeat_task
+
+
+class FakeScheduler:
+    def __init__(self, job_ids=()):
+        self.jobs = {job_id: object() for job_id in job_ids}
+
+    def add_job(self, **kwargs):
+        job_id = kwargs.pop("id")
+        self.jobs[job_id] = kwargs
+
+    def get_job(self, job_id):
+        return self.jobs.get(job_id)
+
+    def remove_job(self, job_id):
+        self.jobs.pop(job_id)
+
+
+def test_activity_tracking_is_enabled_by_default(app, session):
+    with app.app_context():
+        assert is_activity_tracking_enabled() is True
+
+
+def test_activity_tracking_setting_is_persistent(app, session):
+    with app.app_context():
+        set_activity_tracking_enabled(False)
+
+        setting = Settings.query.filter_by(key=ACTIVITY_TRACKING_SETTING).one()
+        assert setting.value == "false"
+        assert is_activity_tracking_enabled() is False
+
+        set_activity_tracking_enabled(True)
+
+        assert setting.value == "true"
+        assert is_activity_tracking_enabled() is True
+
+
+def test_disabled_tracking_stops_monitor_and_removes_jobs(app, session):
+    scheduler = FakeScheduler(ACTIVITY_JOB_IDS)
+
+    with app.app_context():
+        set_activity_tracking_enabled(False)
+
+    with patch("app.activity.tracking.stop_activity_tracking") as stop_tracking:
+        enabled = reconcile_activity_tracking(app, scheduler)
+
+    assert enabled is False
+    stop_tracking.assert_called_once_with(app)
+    assert all(scheduler.get_job(job_id) is None for job_id in ACTIVITY_JOB_IDS)
+
+
+def test_enabled_tracking_starts_monitor_and_registers_jobs(app, session):
+    scheduler = FakeScheduler()
+
+    with patch("app.activity.tracking.start_activity_tracking") as start_tracking:
+        enabled = reconcile_activity_tracking(app, scheduler)
+
+    assert enabled is True
+    start_tracking.assert_called_once_with(app, delay_seconds=0)
+    assert all(scheduler.get_job(job_id) is not None for job_id in ACTIVITY_JOB_IDS)
+
+
+def test_activity_settings_renders_enabled_toggle(logged_activity_client):
+    response = logged_activity_client.get(
+        "/activity/settings", headers={"HX-Request": "true"}
+    )
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'name="activity_tracking_enabled"' in body
+    assert "checked" in body
+
+
+def test_activity_settings_can_disable_tracking(logged_activity_client):
+    with (
+        patch(
+            "app.activity.api.blueprint.set_activity_tracking_enabled"
+        ) as set_tracking,
+        patch("app.activity.api.blueprint._", side_effect=lambda text: text),
+    ):
+        response = logged_activity_client.post(
+            "/activity/settings",
+            data={"action": "set_tracking"},
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    set_tracking.assert_called_once_with(False)
+    assert "Activity tracking is disabled" in response.get_data(as_text=True)
+
+
+def test_activity_settings_can_enable_tracking(logged_activity_client):
+    with (
+        patch(
+            "app.activity.api.blueprint.set_activity_tracking_enabled"
+        ) as set_tracking,
+        patch("app.activity.api.blueprint._", side_effect=lambda text: text),
+    ):
+        response = logged_activity_client.post(
+            "/activity/settings",
+            data={
+                "action": "set_tracking",
+                "activity_tracking_enabled": "true",
+            },
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    set_tracking.assert_called_once_with(True)
+    assert "Activity tracking is enabled" in response.get_data(as_text=True)
+
+
+def test_disabled_tracking_heartbeat_does_not_restart_monitor(
+    app, session, monkeypatch
+):
+    monitor = Mock()
+    monitor.monitoring = False
+    monkeypatch.setitem(app.extensions, "activity_monitor", monitor)
+
+    with app.app_context():
+        set_activity_tracking_enabled(False)
+
+    assert activity_monitoring_heartbeat_task(app) is False
+    monitor.start_monitoring.assert_not_called()


### PR DESCRIPTION
## Summary

- Add an Activity settings switch that is enabled by default.
- Save the switch state in the existing settings table.
- Apply state changes in the scheduler process within 15 seconds.
- Stop media-server collectors and remove the four activity jobs when tracking is off.
- Keep existing activity data and manual history imports available.

This change supersedes #1367 with an admin setting that supports enable and disable actions.

## Verification

- Ruff check and format pass.
- Template lint passes.
- All 22 activity and application tests pass.
- A Chromium check confirms the default on state and the saved off state.

Closes #1363.