### PR TITLE
feat(servers): add default Max Active Sessions for Jellyfin servers

### DIFF
--- a/app/blueprints/media_servers/routes.py
+++ b/app/blueprints/media_servers/routes.py
@@ -48,6 +48,11 @@ from app.services.servers import (
 media_servers_bp = Blueprint("media_servers", __name__, url_prefix="/settings/servers")
 
 
+def _parse_max_active_sessions(data: dict) -> int | None:
+    value = data.get("max_active_sessions")
+    return int(value.strip()) if value and str(value).strip().isdigit() else None
+
+
 def _check_connection(data: dict):
     stype = data["server_type"]
     if stype == "plex":
@@ -116,6 +121,7 @@ def create_server():
         # Universal options (work for all server types)
         server.allow_downloads = bool(data.get("allow_downloads"))
         server.allow_live_tv = bool(data.get("allow_live_tv"))
+        server.max_active_sessions = _parse_max_active_sessions(data)
         server.verified = True
         db.session.add(server)
         db.session.commit()
@@ -209,6 +215,7 @@ def edit_server(server_id):
         # Universal options (work for all server types)
         server.allow_downloads = bool(data.get("allow_downloads"))
         server.allow_live_tv = bool(data.get("allow_live_tv"))
+        server.max_active_sessions = _parse_max_active_sessions(data)
         # update libraries
         chosen = request.form.getlist("libraries")
         if chosen:

--- a/app/models.py
+++ b/app/models.py
@@ -444,6 +444,10 @@ class MediaServer(db.Model):
     allow_live_tv = db.Column(db.Boolean, default=False, nullable=False)
     allow_mobile_uploads = db.Column(db.Boolean, default=False, nullable=False)
 
+    # Jellyfin: default MaxActiveSessions applied to new invitations for this
+    # server unless the invitation overrides it (0 = unlimited).
+    max_active_sessions = db.Column(db.Integer, nullable=True)
+
     # Whether the connection credentials were validated successfully
     verified = db.Column(db.Boolean, default=False, nullable=False)
 

--- a/app/templates/modals/create-server.html
+++ b/app/templates/modals/create-server.html
@@ -110,6 +110,24 @@
                   <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Allow Mobile Uploads</span>
                 </label>
               </div>
+              <div id="max-active-sessions-option" class="mt-2" style="display:none;">
+                <label for="max_active_sessions"
+                       class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                  Max Active Sessions
+                  <span class="text-gray-500 ml-1">(simultaneous devices)</span>
+                </label>
+                <input id="max_active_sessions"
+                       name="max_active_sessions"
+                       type="number"
+                       min="0"
+                       max="100"
+                       value="0"
+                       required
+                       class="mt-1 bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary">
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  Default number of devices new invitations allow to stream simultaneously. Set to 0 for unlimited.
+                </p>
+              </div>
             </div>
             <div id="romm-options" style="display:none;">
               <div>
@@ -195,6 +213,12 @@
         const allowMobileUploadsOption = document.getElementById('allow-mobile-uploads-option');
         if (allowMobileUploadsOption) {
             allowMobileUploadsOption.style.display = ['plex', 'emby'].includes(type) ? 'block' : 'none';
+        }
+
+        // "Max Active Sessions" default only applies to Jellyfin
+        const maxActiveSessionsOption = document.getElementById('max-active-sessions-option');
+        if (maxActiveSessionsOption) {
+            maxActiveSessionsOption.style.display = type === 'jellyfin' ? 'block' : 'none';
         }
 
         document.getElementById('romm-options').style.display = type === 'romm' ? 'block' : 'none';

--- a/app/templates/modals/edit-server.html
+++ b/app/templates/modals/edit-server.html
@@ -136,6 +136,26 @@
                   <span class="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Allow Mobile Uploads</span>
                 </label>
               </div>
+              <div id="max-active-sessions-option-edit"
+                   class="mt-2"
+                   style="display:none">
+                <label for="max_active_sessions"
+                       class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">
+                  Max Active Sessions
+                  <span class="text-gray-500 ml-1">(simultaneous devices)</span>
+                </label>
+                <input id="max_active_sessions"
+                       name="max_active_sessions"
+                       type="number"
+                       min="0"
+                       max="100"
+                       value="{{ server.max_active_sessions if server.max_active_sessions is not none else 0 }}"
+                       required
+                       class="mt-1 bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary">
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  Default number of devices new invitations allow to stream simultaneously. Set to 0 for unlimited.
+                </p>
+              </div>
             </div>
             <div class="mt-4">
               <button hx-post="{{ url_for('media_servers.scan_server_libraries', server_id=server.id) }}"
@@ -205,6 +225,12 @@
         const allowMobileUploadsOption = document.getElementById('allow-mobile-uploads-option-edit');
         if (allowMobileUploadsOption) {
             allowMobileUploadsOption.style.display = ['plex', 'emby'].includes(type) ? 'block' : 'none';
+        }
+
+        // "Max Active Sessions" default only applies to Jellyfin
+        const maxActiveSessionsOption = document.getElementById('max-active-sessions-option-edit');
+        if (maxActiveSessionsOption) {
+            maxActiveSessionsOption.style.display = type === 'jellyfin' ? 'block' : 'none';
         }
 
         document.getElementById('romm-options').style.display = type === 'romm' ? 'block' : 'none';

--- a/app/templates/modals/invite.html
+++ b/app/templates/modals/invite.html
@@ -277,6 +277,7 @@
                                    type="number"
                                    min="0"
                                    max="100"
+                                   {% if s.max_active_sessions is not none %}value="{{ s.max_active_sessions }}"{% endif %}
                                    placeholder="0 = unlimited"
                                    class="mt-1 bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-primary dark:focus:border-primary">
                             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">

--- a/migrations/versions/20260901_add_max_active_sessions_to_media_server.py
+++ b/migrations/versions/20260901_add_max_active_sessions_to_media_server.py
@@ -1,0 +1,26 @@
+"""Add max_active_sessions default to MediaServer model
+
+Revision ID: 20260901_mss_default
+Revises: 20260901_expired_unique
+Create Date: 2026-09-01 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260901_mss_default"
+down_revision = "20260901_expired_unique"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("media_server", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("max_active_sessions", sa.Integer(), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("media_server", schema=None) as batch_op:
+        batch_op.drop_column("max_active_sessions")

--- a/tests/test_media_server_max_active_sessions.py
+++ b/tests/test_media_server_max_active_sessions.py
@@ -1,0 +1,85 @@
+"""Test the Jellyfin Max Active Sessions default on MediaServer create/edit."""
+
+import pytest
+
+from app import create_app
+from app.config import BaseConfig
+from app.extensions import db
+from app.models import AdminAccount, MediaServer
+
+
+class TestConfig(BaseConfig):
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    app = create_app(TestConfig)
+    monkeypatch.setattr(
+        "app.blueprints.media_servers.routes.check_jellyfin",
+        lambda url, key: (True, ""),
+    )
+    with app.app_context():
+        db.create_all()
+        admin = AdminAccount(username="testadmin")
+        admin.set_password("testpass")
+        db.session.add(admin)
+        db.session.commit()
+    yield app
+    with app.app_context():
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["_user_id"] = "admin"
+        yield client
+
+
+def test_create_server_stores_max_active_sessions(app, client):
+    client.post(
+        "/settings/servers/create",
+        data={
+            "server_name": "My Jellyfin",
+            "server_type": "jellyfin",
+            "server_url": "http://jellyfin.local",
+            "api_key": "token",
+            "max_active_sessions": "3",
+        },
+    )
+    with app.app_context():
+        server = MediaServer.query.filter_by(name="My Jellyfin").first()
+        assert server.max_active_sessions == 3
+
+
+def test_edit_server_updates_max_active_sessions(app, client):
+    with app.app_context():
+        server = MediaServer(
+            name="My Jellyfin",
+            server_type="jellyfin",
+            url="http://jellyfin.local",
+            api_key="token",
+            max_active_sessions=3,
+            verified=True,
+        )
+        db.session.add(server)
+        db.session.commit()
+        server_id = server.id
+
+    client.post(
+        f"/settings/servers/{server_id}/edit",
+        data={
+            "server_name": "My Jellyfin",
+            "server_type": "jellyfin",
+            "server_url": "http://jellyfin.local",
+            "api_key": "token",
+            "max_active_sessions": "0",
+        },
+    )
+    with app.app_context():
+        server = db.session.get(MediaServer, server_id)
+        assert server.max_active_sessions == 0


### PR DESCRIPTION
## Summary

Jellyfin's `UserPolicy` API supports limiting concurrent/simultaneous
sessions per user (`MaxActiveSessions`), and Wizarr already exposes this
per-invitation (`Invitation.max_active_sessions`) — but there was no way
to set a default at the server level, so every invite had to be configured
by hand.

This adds a **Max Active Sessions (simultaneous devices)** default on the
Jellyfin server config (Add/Edit Server), used to pre-fill new invitations
for that server. The admin can still override the value per invitation
before creating it, same as today.

## Changes

- `MediaServer.max_active_sessions` — new nullable `Integer` column
  (`0` = unlimited, same convention as the existing invitation-level field)
- Migration adding the column (existing servers get `NULL`, i.e. no
  behavior change until an admin opens Edit Server and sets a value)
- Add/Edit Server modals: new field, shown only for `server_type ==
  "jellyfin"`, required with a default of `0`
- Invite modal: the existing per-invitation field now pre-fills from the
  selected server's default; whatever value is submitted is baked into
  the invitation at creation time (unchanged parsing logic in
  `invites.py`)
- Tests covering create/edit persistence of the new field

## Why nullable / no backfill for existing servers

Leaving existing servers as `NULL` (rather than backfilling `0`) preserves
the same "never configured" vs "explicitly unlimited" distinction the
invitation-level field already relies on, and avoids silently changing
behavior (an explicit `MaxActiveSessions=0` write) for servers nobody has
touched since this shipped.

## Test plan

- [x] `pytest` (full suite, excluding Playwright e2e which needs a browser
      binary not present in this environment) — all green
- [x] New migration applies cleanly (`flask db upgrade`)
- [x] Manually verified in browser against a real Jellyfin server: set
      default on Edit Server → persisted → pre-filled on Create
      Invitation → baked into the created invitation record
- [x] Confirmed the field is hidden for non-Jellyfin server types in both
      Add Server and Edit Server modals