### PR TITLE
feat: add Plex collection media wizard widget

### DIFF
--- a/app/services/wizard_widgets.py
+++ b/app/services/wizard_widgets.py
@@ -4,6 +4,8 @@ Wizard widget system for embedding dynamic content in wizard steps.
 Widgets are inserted into markdown content using special syntax:
 {{ widget:recently_added_media }}
 {{ widget:recently_added_media limit=6 }}
+{{ widget:collection_media collection="My Collection" }}
+{{ widget:collection_media collection="My Collection" limit=15 }}
 {{ widget:button url="https://example.com" text="Click Here" }}
 
 Cards use delimiter syntax:
@@ -182,6 +184,76 @@ class RecentlyAddedMediaWidget(WizardWidget):
             return []
 
 
+class CollectionMediaWidget(RecentlyAddedMediaWidget):
+    """Show posters from a named Plex collection."""
+
+    def __init__(self):
+        # Reuse Wizarr's built-in carousel so upstream styling changes continue
+        # to apply to this custom widget.
+        super().__init__()
+        self.name = "collection_media"
+
+    def get_data(self, _server_type: str, **_kwargs) -> dict[str, Any]:
+        collection_name = str(_kwargs.get("collection", "")).strip()
+        try:
+            limit = max(0, int(_kwargs.get("limit", 15)))
+        except (TypeError, ValueError):
+            limit = 15
+
+        if not collection_name:
+            return {"items": [], "limit": limit}
+
+        try:
+            from app.models import MediaServer
+
+            server = MediaServer.query.filter_by(server_type=_server_type).first()
+            if server is None:
+                return {"items": [], "limit": limit}
+
+            client = get_media_client(server.server_type, server)
+            plex = getattr(client, "server", None)
+            if plex is None or not hasattr(plex, "library"):
+                return {"items": [], "limit": limit}
+
+            wanted = collection_name.casefold()
+            for section in plex.library.sections():
+                for collection in section.collections():
+                    if str(collection.title).casefold() != wanted:
+                        continue
+
+                    media_items = collection.items()
+                    if limit:
+                        media_items = media_items[:limit]
+
+                    return {
+                        "items": [
+                            self._normalise_item(item, client) for item in media_items
+                        ],
+                        "limit": limit,
+                    }
+        except Exception as exc:
+            logging.warning(
+                "Unable to render Plex collection %r: %s", collection_name, exc
+            )
+
+        return {"items": [], "limit": limit}
+
+    @staticmethod
+    def _normalise_item(item, client) -> dict[str, str]:
+        title = str(getattr(item, "title", ""))
+        thumb_url = ""
+
+        try:
+            # PlexAPI's thumbUrl is already an absolute, authenticated URL.
+            direct_url = getattr(item, "thumbUrl", "") or ""
+            if direct_url:
+                thumb_url = client.generate_image_proxy_url(direct_url)
+        except Exception as exc:
+            logging.debug("Failed to proxy artwork for %r: %s", title, exc)
+
+        return {"title": title, "thumb": thumb_url}
+
+
 class CardWidget(WizardWidget):
     """Widget to create a card - not used with standard widget syntax, rendered via delimiter."""
 
@@ -292,6 +364,7 @@ class ButtonWidget(WizardWidget):
 # Widget registry
 WIDGET_REGISTRY = {
     "recently_added_media": RecentlyAddedMediaWidget(),
+    "collection_media": CollectionMediaWidget(),
     "button": ButtonWidget(),
 }
 
@@ -343,6 +416,8 @@ def process_widget_placeholders(
     Supports syntax like:
     {{ widget:recently_added_media }}
     {{ widget:recently_added_media limit=6 }}
+    {{ widget:collection_media collection="My Collection" }}
+    {{ widget:collection_media collection="My Collection" limit=15 }}
     {{ widget:button url="https://example.com" text="Click Here" }}
     """
     context = context or {}

--- a/app/templates/modals/wizard-step-form.html
+++ b/app/templates/modals/wizard-step-form.html
@@ -80,6 +80,23 @@
                         </div>
                       </button>
                       <button type="button"
+                              onclick="insertWidget('collection_media')"
+                              @click="open = false"
+                              class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
+                        <div class="flex-shrink-0 w-8 h-8 bg-cyan-500/10 rounded-lg flex items-center justify-center">
+                          <svg class="w-4 h-4 text-cyan-500"
+                               fill="none"
+                               stroke="currentColor"
+                               viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                          </svg>
+                        </div>
+                        <div class="text-left">
+                          <div class="font-medium">{{ _("Collection Media") }}</div>
+                          <div class="text-xs text-gray-500 dark:text-gray-400">{{ _("Show media from a Plex collection") }}</div>
+                        </div>
+                      </button>
+                      <button type="button"
                               onclick="insertWidget('button')"
                               @click="open = false"
                               class="w-full flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
@@ -158,6 +175,9 @@
         switch (widgetType) {
             case 'recently_added_media':
                 widgetSyntax = '\n\n{' + '{ widget:recently_added_media }' + '}\n\n';
+                break;
+            case 'collection_media':
+                widgetSyntax = '\n\n{' + '{ widget:collection_media collection="Collection Name" limit=15 }' + '}\n\n';
                 break;
             case 'button':
                 widgetSyntax = '\n\n{' + '{ widget:button url="https://example.com" text="Click Here" }' + '}\n\n';

--- a/docs/using-wizarr/customise-steps.md
+++ b/docs/using-wizarr/customise-steps.md
@@ -132,6 +132,21 @@ Welcome to our **media server**! Here's what you need to know:
 - **Images**: Use standard Markdown syntax with optional classes
 - **Tailwind classes**: Add `{.class-name}` for custom styling
 
+### Plex Collection Carousel
+
+For Plex wizard steps, use the `collection_media` widget to show posters from a
+named collection:
+
+```markdown
+{{ widget:collection_media collection="Summer Blockbusters" limit=15 }}
+```
+
+The collection name is matched case-insensitively across the Plex server's
+libraries. The optional `limit` parameter caps the number of posters and
+defaults to 15. Set it to `0` to show the entire collection. The
+**Add... → Collection Media** menu item in the wizard-step editor inserts this
+syntax for you.
+
 ### Requiring User Interaction
 
 You can force users to engage with step content before allowing them to proceed to the next step. This is useful for ensuring users actually download apps, read important information, or acknowledge terms.

--- a/messages.pot
+++ b/messages.pot
@@ -2289,10 +2289,18 @@ msgid "Show recent content"
 msgstr ""
 
 #: app/templates/modals/wizard-step-form.html:95
-msgid "Button"
+msgid "Collection Media"
 msgstr ""
 
 #: app/templates/modals/wizard-step-form.html:96
+msgid "Show media from a Plex collection"
+msgstr ""
+
+#: app/templates/modals/wizard-step-form.html:112
+msgid "Button"
+msgstr ""
+
+#: app/templates/modals/wizard-step-form.html:113
 msgid "Add a clickable link button"
 msgstr ""
 

--- a/tests/test_wizard_widgets.py
+++ b/tests/test_wizard_widgets.py
@@ -1,4 +1,12 @@
-from app.services.wizard_widgets import ButtonWidget, process_widget_placeholders
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.services.wizard_widgets import (
+    ButtonWidget,
+    CollectionMediaWidget,
+    process_widget_placeholders,
+)
 
 
 def test_button_widget_resolves_context_variable_url():
@@ -33,3 +41,51 @@ def test_process_widget_placeholders_passes_context_to_button_widget():
 
     assert 'href="https://jellyfin.example.com"' in html
     assert "Open Jellyfin" in html
+
+
+def test_collection_widget_is_registered_and_renders_plex_posters():
+    first_item = SimpleNamespace(
+        title="Arrival", thumbUrl="http://plex/photo/1?token=x"
+    )
+    second_item = SimpleNamespace(title="Dune", thumbUrl="http://plex/photo/2?token=x")
+    collection = SimpleNamespace(
+        title="Sci-Fi", items=lambda: [first_item, second_item]
+    )
+    section = SimpleNamespace(collections=lambda: [collection])
+    client = SimpleNamespace(
+        server=SimpleNamespace(library=SimpleNamespace(sections=lambda: [section])),
+        generate_image_proxy_url=lambda url: f"/image-proxy?source={url}",
+    )
+    server = SimpleNamespace(server_type="plex")
+    query = MagicMock()
+    query.filter_by.return_value.first.return_value = server
+
+    with (
+        patch("app.models.MediaServer.query", query),
+        patch("app.services.wizard_widgets.get_media_client", return_value=client),
+    ):
+        html = process_widget_placeholders(
+            '{{ widget:collection_media collection="sci-fi" limit=1 }}', "plex"
+        )
+
+    assert "Unknown widget" not in html
+    assert "Arrival" in html
+    assert "Dune" not in html
+    assert "/image-proxy?source=http://plex/photo/1?token=x" in html
+
+
+def test_collection_widget_rejects_missing_collection_name():
+    assert CollectionMediaWidget().get_data("plex") == {"items": [], "limit": 15}
+
+
+def test_wizard_step_editor_offers_collection_widget():
+    template = (
+        Path(__file__).parents[1]
+        / "app"
+        / "templates"
+        / "modals"
+        / "wizard-step-form.html"
+    ).read_text(encoding="utf-8")
+
+    assert "insertWidget('collection_media')" in template
+    assert 'widget:collection_media collection="Collection Name" limit=15' in template


### PR DESCRIPTION
## Summary

- add a collection_media wizard widget for named Plex collections
- reuse Wizarr's existing carousel and secure image-proxy handling
- add a **Collection Media** action to the wizard-step editor
- default the carousel to 15 items while supporting an explicit limit
- document the widget and add regression coverage

## Testing

- pytest tests/test_wizard_widgets.py -q — 6 passed
- uff check app/services/wizard_widgets.py tests/test_wizard_widgets.py
- uff format --check app/services/wizard_widgets.py tests/test_wizard_widgets.py
- djlint app/templates/modals/wizard-step-form.html --check

Closes #1252